### PR TITLE
feat: v0.6.1 — Helm chart support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 [![Release](https://img.shields.io/github/v/release/getnora-io/nora)](https://github.com/getnora-io/nora/releases)
 [![Image Size](https://img.shields.io/badge/image-32%20MB-blue)](https://github.com/getnora-io/nora/pkgs/container/nora)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nora)](https://artifacthub.io/packages/helm/nora/nora)
 
 **32 MB** binary | **< 100 MB** RAM | **3s** startup | **7** registries
 
@@ -54,6 +55,15 @@ docker run -d -p 4000:4000 -v nora-data:/data ghcr.io/getnora-io/nora:latest
 curl -fsSL https://github.com/getnora-io/nora/releases/latest/download/nora-linux-amd64 -o nora
 chmod +x nora && ./nora
 ```
+
+### Kubernetes (Helm)
+
+```bash
+helm repo add nora https://getnora-io.github.io/helm-charts
+helm install nora nora/nora
+```
+
+See [chart documentation](https://github.com/getnora-io/helm-charts/tree/main/charts/nora) for configuration options.
 
 ### From Source
 


### PR DESCRIPTION
## Summary
- Add Kubernetes/Helm installation to Quick Start section
- Add ArtifactHub badge
- Bump version to 0.6.1

Official Helm chart: https://github.com/getnora-io/helm-charts

```bash
helm repo add nora https://getnora-io.github.io/helm-charts
helm install nora nora/nora
```

Closes #126