### PR TITLE
fix: upgrade Alpine 3.20→3.21, patch 18 CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # syntax=docker/dockerfile:1.4
 # Binary is pre-built by CI (cargo build --release) and passed via context
-FROM alpine:3.20@sha256:a4f4213abb84c497377b8544c81b3564f313746700372ec4fe84653e4fb03805
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
-RUN apk add --no-cache ca-certificates \
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates \
     && addgroup -S nora && adduser -S -G nora nora \
     && mkdir -p /data && chown nora:nora /data
 


### PR DESCRIPTION
## Summary
- Upgrade base image from Alpine 3.20 (EOL) to 3.21
- Add `apk upgrade --no-cache` to catch future security patches
- Fixes all 18 vulnerabilities reported by ArtifactHub/Trivy

### CVEs fixed
| CVE | Package | Severity |
|-----|---------|----------|
| CVE-2026-28390 | libcrypto3/libssl3 | HIGH |
| CVE-2026-40200 | musl/musl-utils | HIGH |
| CVE-2026-22184 | zlib | HIGH |
| CVE-2026-28388 | libcrypto3/libssl3 | MEDIUM |
| CVE-2026-28389 | libcrypto3/libssl3 | MEDIUM |
| CVE-2026-31790 | libcrypto3/libssl3 | MEDIUM |
| CVE-2026-31789 | libcrypto3/libssl3 | MEDIUM |
| CVE-2026-6042 | musl/musl-utils | MEDIUM |
| CVE-2026-27171 | zlib | MEDIUM |
| CVE-2026-28387 | libcrypto3/libssl3 | LOW |