### PR TITLE
chore: bump version to 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"


### PR DESCRIPTION
Version bump for security patch release.