### PR TITLE
fix: config validation, publish_lock, OpenAPI completeness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.75"
 license = "MIT"
 authors = ["DevITWay <devitway@gmail.com>"]
 repository = "https://github.com/getnora-io/nora"
-homepage = "https://getnora.io"
+homepage = "https://getnora.dev"
 
 [workspace.dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 | Docker Registry v2 | `/v2/` | Docker Hub, GHCR, any OCI, Helm OCI | ✓ |
 | Maven | `/maven2/` | Maven Central, custom | proxy-only |
 | npm | `/npm/` | npmjs.org, custom | ✓ |
-| Cargo | `/cargo/` | — | ✓ |
+| Cargo | `/cargo/` | crates.io | ✓ |
 | PyPI | `/simple/` | pypi.org, custom | ✓ |
 | Go Modules | `/go/` | proxy.golang.org, custom | ✓ |
 | Raw files | `/raw/` | — | ✓ |
@@ -232,6 +232,7 @@ nora mirror                 # Sync packages for offline use
 | `/cargo/` | Cargo |
 | `/simple/` | PyPI |
 | `/go/` | Go Modules |
+| `/raw/` | Raw files |
 
 ## TLS / HTTPS
 
@@ -260,9 +261,9 @@ See [TLS / HTTPS guide](https://getnora.dev/configuration/tls/) for Nginx, Traef
 - ~~**Mirror CLI** — offline sync for air-gapped environments~~ ✅ v0.4.0
 - ~~**Online Garbage Collection** — non-blocking cleanup without registry downtime~~ ✅ v0.6.0
 - ~~**Retention Policies** — declarative rules: keep last N tags, delete older than X days~~ ✅ v0.6.0
+- ~~**Helm Chart** — official chart for Kubernetes deployment~~ ✅ v0.6.1
 - **OIDC / Workload Identity** — zero-secret auth for GitHub Actions, GitLab CI
 - **Image Signing** — cosign verification and policy enforcement
-- **Helm Chart** — official chart for Kubernetes deployment
 
 See [CHANGELOG.md](CHANGELOG.md) for release history.
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # NORA
 
-A lightweight, open-source artifact registry. Docker, Maven, npm, PyPI, Cargo, Go, Helm OCI, Raw — 7 registries in a single 32 MB binary. Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
+A lightweight, open-source artifact registry. Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw — 7 registries in a single 32 MB binary. Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
 
-> The artifact registry that grows with you. SQLite-simple to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
+> The artifact registry that grows with you. Zero-config to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
 
 ## TL;DR
 
@@ -143,8 +143,8 @@ nora                          # Start server on :4000
 nora serve                    # Start server (explicit)
 nora backup -o backup.tar.gz  # Backup all artifacts
 nora restore -i backup.tar.gz # Restore from backup
-nora gc                       # Garbage collect orphaned blobs
-nora gc --dry-run             # Preview what would be deleted
+nora gc                       # Garbage collect orphaned blobs (dry-run by default)
+nora gc --apply               # Actually delete orphaned blobs
 nora migrate --from local --to s3        # Migrate storage
 nora migrate --from local --to s3 --dry-run
 nora mirror docker --registry http://localhost:4000 --image alpine:3.19
@@ -158,6 +158,7 @@ nora mirror maven --registry http://localhost:4000 --artifact org.slf4j:slf4j-ap
 
 | Variable | Default | Description |
 |----------|---------|-------------|
+| `NORA_CONFIG_PATH` | — | Path to config.toml (fatal if set but missing) |
 | `NORA_HOST` | `127.0.0.1` | Bind address |
 | `NORA_PORT` | `4000` | Port |
 | `NORA_STORAGE_MODE` | `local` | `local` or `s3` |
@@ -318,9 +319,9 @@ A: Cosign verification and policy enforcement are on the roadmap. Currently, NOR
 ## Technical details
 
 - Language: Rust
-- Platforms: Linux (x86_64). Docker images: Alpine, Astra Linux SE, RED OS
+- Platforms: Linux (amd64, arm64). Docker images: Alpine, Astra Linux SE, RED OS
 - Binary name: nora (crate name: nora-registry)
-- Tests: 577 (unit + integration + proptest + Playwright e2e)
+- Tests: 592 (unit + integration + proptest + Playwright e2e)
 - Coverage: 61.5%
 - No garbage collector pauses (Rust, not Java/Go)
 - Async I/O with Tokio, Axum web framework

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -386,8 +386,8 @@ impl Default for AuthConfig {
 /// [rate_limit]
 /// auth_rps = 1
 /// auth_burst = 5
-/// upload_rps = 500
-/// upload_burst = 1000
+/// upload_rps = 200
+/// upload_burst = 500
 /// general_rps = 100
 /// general_burst = 200
 /// ```
@@ -508,6 +508,11 @@ pub struct RetentionRule {
 }
 
 /// Retention policies configuration.
+///
+/// # Environment Variables
+/// - `NORA_RETENTION_ENABLED` — enable/disable background retention (default: false)
+/// - `NORA_RETENTION_INTERVAL` — interval in seconds between runs (default: 86400)
+/// - `NORA_RETENTION_DRY_RUN` — if true, only report what would be deleted (default: false)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RetentionConfig {
     /// Enable background retention scheduler
@@ -516,6 +521,9 @@ pub struct RetentionConfig {
     /// Interval in seconds between retention runs (default: 86400 = 24h)
     #[serde(default = "default_retention_interval")]
     pub interval: u64,
+    /// If true, only log what would be deleted without actually deleting (default: false)
+    #[serde(default)]
+    pub dry_run: bool,
     #[serde(default)]
     pub rules: Vec<RetentionRule>,
 }
@@ -529,6 +537,7 @@ impl Default for RetentionConfig {
         Self {
             enabled: false,
             interval: 86400,
+            dry_run: false,
             rules: Vec::new(),
         }
     }
@@ -636,17 +645,60 @@ impl Config {
                 .push("server.body_limit_mb is 0, no request bodies will be accepted".to_string());
         }
 
+        // 6. "Enabled but empty" — subsystems that silently do nothing
+        if self.gc.enabled && self.gc.dry_run {
+            warnings.push(
+                "gc.enabled=true with gc.dry_run=true — GC will run but never delete anything. Set gc.dry_run=false to actually free space".to_string(),
+            );
+        }
+        if self.retention.enabled && self.retention.rules.is_empty() {
+            warnings.push(
+                "retention.enabled=true but no retention rules configured — retention scheduler will run but do nothing. Add [retention.rules] or set retention.enabled=false".to_string(),
+            );
+        }
+
         (warnings, errors)
     }
 
-    /// Load configuration with priority: ENV > config.toml > defaults
+    /// Load configuration with priority: ENV > config file > defaults
+    ///
+    /// Config file resolution order:
+    /// 1. `NORA_CONFIG_PATH` env var (fatal if set but file not found)
+    /// 2. `config.toml` in current working directory (optional)
+    /// 3. Built-in defaults
     pub fn load() -> Self {
         // 1. Start with defaults
-        // 2. Override with config.toml if exists
-        let mut config: Config = fs::read_to_string("config.toml")
-            .ok()
-            .and_then(|content| toml::from_str(&content).ok())
-            .unwrap_or_default();
+        // 2. Override with config file if exists
+        let mut config: Config = if let Ok(config_path) = env::var("NORA_CONFIG_PATH") {
+            let content = fs::read_to_string(&config_path).unwrap_or_else(|e| {
+                panic!(
+                    "NORA_CONFIG_PATH={} but file cannot be read: {}",
+                    config_path, e
+                );
+            });
+            let cfg = toml::from_str(&content).unwrap_or_else(|e| {
+                panic!(
+                    "NORA_CONFIG_PATH={} contains invalid TOML: {}",
+                    config_path, e
+                );
+            });
+            tracing::info!(path = %config_path, "Loaded config from NORA_CONFIG_PATH");
+            cfg
+        } else {
+            match fs::read_to_string("config.toml") {
+                Ok(content) => match toml::from_str(&content) {
+                    Ok(cfg) => {
+                        tracing::info!("Loaded config from config.toml");
+                        cfg
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "config.toml exists but contains invalid TOML, using defaults");
+                        Config::default()
+                    }
+                },
+                Err(_) => Config::default(),
+            }
+        };
 
         // 3. Override with ENV vars (highest priority)
         config.apply_env_overrides();
@@ -916,6 +968,9 @@ impl Config {
             if let Ok(v) = val.parse() {
                 self.retention.interval = v;
             }
+        }
+        if let Ok(val) = env::var("NORA_RETENTION_DRY_RUN") {
+            self.retention.dry_run = val.to_lowercase() == "true" || val == "1";
         }
 
         // Secrets config
@@ -1488,6 +1543,53 @@ mod tests {
         assert_eq!(errors.len(), 1);
         assert_eq!(warnings.len(), 2); // body_limit + auth_rps
     }
+    #[test]
+    fn test_validate_gc_enabled_dry_run() {
+        let mut config = Config::default();
+        config.gc.enabled = true;
+        config.gc.dry_run = true;
+        let (warnings, errors) = config.validate();
+        assert!(errors.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("gc.dry_run"));
+    }
+
+    #[test]
+    fn test_validate_gc_enabled_no_dry_run_ok() {
+        let mut config = Config::default();
+        config.gc.enabled = true;
+        config.gc.dry_run = false;
+        let (warnings, errors) = config.validate();
+        assert!(errors.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_validate_retention_enabled_empty_rules() {
+        let mut config = Config::default();
+        config.retention.enabled = true;
+        config.retention.rules = Vec::new();
+        let (warnings, errors) = config.validate();
+        assert!(errors.is_empty());
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains("retention"));
+    }
+
+    #[test]
+    fn test_validate_retention_enabled_with_rules_ok() {
+        let mut config = Config::default();
+        config.retention.enabled = true;
+        config.retention.rules = vec![RetentionRule {
+            registry: "docker".to_string(),
+            keep_last: Some(5),
+            older_than_days: None,
+            exclude_tags: Vec::new(),
+        }];
+        let (warnings, errors) = config.validate();
+        assert!(errors.is_empty());
+        assert!(warnings.is_empty());
+    }
+
     #[test]
     fn test_env_override_docker_proxies_and_backward_compat() {
         // Test new NORA_DOCKER_PROXIES name

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -379,25 +379,6 @@ async fn run_server(config: Config, storage: Storage) {
         "Rate limiting configured"
     );
 
-    // Initialize secrets provider
-    let secrets_provider = match secrets::create_secrets_provider(&config.secrets) {
-        Ok(provider) => {
-            info!(
-                provider = provider.provider_name(),
-                clear_env = config.secrets.clear_env,
-                "Secrets provider initialized"
-            );
-            Some(provider)
-        }
-        Err(e) => {
-            warn!(error = %e, "Failed to initialize secrets provider, using defaults");
-            None
-        }
-    };
-
-    // Store secrets provider for future use (S3 credentials, etc.)
-    let _secrets = secrets_provider;
-
     // Load auth if enabled
     let auth = if config.auth.enabled {
         let path = Path::new(&config.auth.htpasswd_file);
@@ -508,11 +489,13 @@ async fn run_server(config: Config, storage: Storage) {
             state.storage.clone(),
             state.config.retention.rules.clone(),
             state.config.retention.interval,
+            state.config.retention.dry_run,
             Some(std::sync::Arc::new(audit::AuditLog::new(&storage_path))),
         );
         info!(
             interval_secs = state.config.retention.interval,
             rules = state.config.retention.rules.len(),
+            dry_run = state.config.retention.dry_run,
             "Retention scheduler started"
         );
     }

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -18,7 +18,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.5.0",
+        version = "0.6.2",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, and Raw",
         license(name = "MIT"),
         contact(name = "DevITWay", url = "https://github.com/getnora-io/nora")
@@ -70,6 +70,14 @@ use crate::AppState;
         // PyPI
         crate::openapi::pypi_simple,
         crate::openapi::pypi_package,
+        // Go
+        crate::openapi::go_module_latest,
+        crate::openapi::go_module_info,
+        crate::openapi::go_module_mod,
+        crate::openapi::go_module_zip,
+        // Raw
+        crate::openapi::raw_file_get,
+        crate::openapi::raw_file_put,
         // Tokens
         crate::openapi::create_token,
         crate::openapi::list_tokens,
@@ -600,6 +608,103 @@ pub async fn pypi_simple() {}
     )
 )]
 pub async fn pypi_package() {}
+
+// -------------------- Go Modules --------------------
+
+/// Get latest version of a Go module
+#[utoipa::path(
+    get,
+    path = "/go/{module}/@latest",
+    tag = "go",
+    params(
+        ("module" = String, Path, description = "Module path (e.g., 'golang.org/x/text')")
+    ),
+    responses(
+        (status = 200, description = "Latest version info (JSON)"),
+        (status = 404, description = "Module not found")
+    )
+)]
+pub async fn go_module_latest() {}
+
+/// Get Go module version info
+#[utoipa::path(
+    get,
+    path = "/go/{module}/@v/{version}.info",
+    tag = "go",
+    params(
+        ("module" = String, Path, description = "Module path"),
+        ("version" = String, Path, description = "Module version (e.g., 'v1.14.0')")
+    ),
+    responses(
+        (status = 200, description = "Version info (JSON)"),
+        (status = 404, description = "Version not found")
+    )
+)]
+pub async fn go_module_info() {}
+
+/// Get Go module go.mod file
+#[utoipa::path(
+    get,
+    path = "/go/{module}/@v/{version}.mod",
+    tag = "go",
+    params(
+        ("module" = String, Path, description = "Module path"),
+        ("version" = String, Path, description = "Module version")
+    ),
+    responses(
+        (status = 200, description = "go.mod file content"),
+        (status = 404, description = "Version not found")
+    )
+)]
+pub async fn go_module_mod() {}
+
+/// Download Go module zip
+#[utoipa::path(
+    get,
+    path = "/go/{module}/@v/{version}.zip",
+    tag = "go",
+    params(
+        ("module" = String, Path, description = "Module path"),
+        ("version" = String, Path, description = "Module version")
+    ),
+    responses(
+        (status = 200, description = "Module zip archive"),
+        (status = 404, description = "Version not found")
+    )
+)]
+pub async fn go_module_zip() {}
+
+// -------------------- Raw Files --------------------
+
+/// Get raw file
+#[utoipa::path(
+    get,
+    path = "/raw/{path}",
+    tag = "raw",
+    params(
+        ("path" = String, Path, description = "File path (e.g., 'myproject/config.yaml')")
+    ),
+    responses(
+        (status = 200, description = "File content"),
+        (status = 404, description = "File not found")
+    )
+)]
+pub async fn raw_file_get() {}
+
+/// Upload raw file
+#[utoipa::path(
+    put,
+    path = "/raw/{path}",
+    tag = "raw",
+    params(
+        ("path" = String, Path, description = "File path")
+    ),
+    responses(
+        (status = 201, description = "File uploaded"),
+        (status = 409, description = "File already exists (immutable)")
+    )
+)]
+pub async fn raw_file_put() {}
 
 // -------------------- Auth / Tokens --------------------
 

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -397,8 +397,12 @@ async fn publish(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
     let name = name.to_lowercase();
     let vers = vers.to_string();
 
-    // Check version immutability
+    // TOCTOU protection: lock per crate version to prevent concurrent publishes
     let crate_key = format!("cargo/{}/{}/{}-{}.crate", name, vers, name, vers);
+    let lock = state.publish_lock(&crate_key);
+    let _guard = lock.lock().await;
+
+    // Check version immutability
     if state.storage.stat(&crate_key).await.is_some() {
         let err = serde_json::json!({
             "errors": [{"detail": format!("crate version `{}@{}` already exists", name, vers)}]

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -282,8 +282,12 @@ async fn handle_publish(
         None => return (StatusCode::BAD_REQUEST, "Missing versions").into_response(),
     };
 
-    // Load or create metadata
+    // TOCTOU protection: lock per package to prevent concurrent version conflicts
     let metadata_key = format!("npm/{}/metadata.json", package_name);
+    let lock = state.publish_lock(&metadata_key);
+    let _guard = lock.lock().await;
+
+    // Load or create metadata
     let mut metadata = if let Ok(existing) = state.storage.get(&metadata_key).await {
         serde_json::from_slice::<serde_json::Value>(&existing)
             .unwrap_or_else(|_| serde_json::json!({}))

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -329,8 +329,12 @@ async fn upload(State(state): State<Arc<AppState>>, mut multipart: Multipart) ->
     // Normalize name and store
     let normalized = normalize_name(&name);
 
-    // Check immutability (same filename = already exists)
+    // TOCTOU protection: lock per file to prevent concurrent uploads
     let file_key = format!("pypi/{}/{}", normalized, filename);
+    let lock = state.publish_lock(&file_key);
+    let _guard = lock.lock().await;
+
+    // Check immutability (same filename = already exists)
     if state.storage.stat(&file_key).await.is_some() {
         return (
             StatusCode::CONFLICT,

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -608,6 +608,7 @@ pub fn spawn_retention_scheduler(
     storage: Storage,
     rules: Vec<RetentionRule>,
     interval_secs: u64,
+    dry_run: bool,
     audit: Option<Arc<crate::audit::AuditLog>>,
 ) {
     let lock = Arc::new(tokio::sync::Mutex::new(()));
@@ -627,8 +628,11 @@ pub fn spawn_retention_scheduler(
                 continue;
             }
 
-            info!("Retention scheduler: starting periodic run");
-            let result = run_retention(&storage, &rules, false).await;
+            info!(
+                dry_run = dry_run,
+                "Retention scheduler: starting periodic run"
+            );
+            let result = run_retention(&storage, &rules, dry_run).await;
             info!(
                 "Retention scheduler: done in {:.1}s — {} versions, {} keys, {} bytes freed",
                 result.duration_secs, result.planned, result.deleted_keys, result.bytes_freed

--- a/nora-registry/src/secrets/env.rs
+++ b/nora-registry/src/secrets/env.rs
@@ -12,6 +12,7 @@ use super::{SecretsError, SecretsProvider};
 use crate::secrets::protected::ProtectedString;
 use async_trait::async_trait;
 
+#[allow(dead_code)] // Scaffolding for future secrets integration
 /// Environment variables secrets provider
 ///
 /// Reads secrets from environment variables.

--- a/nora-registry/src/secrets/mod.rs
+++ b/nora-registry/src/secrets/mod.rs
@@ -65,6 +65,7 @@ pub trait SecretsProvider: Send + Sync {
     }
 
     /// Get provider name for logging
+    #[allow(dead_code)]
     fn provider_name(&self) -> &'static str;
 }
 
@@ -101,6 +102,7 @@ impl Default for SecretsConfig {
     }
 }
 
+#[allow(dead_code)] // Scaffolding for future secrets integration (Vault, AWS SM, K8s)
 /// Create a secrets provider based on configuration
 ///
 /// Currently supports:


### PR DESCRIPTION
## Summary

- Add `NORA_CONFIG_PATH` env var with fatal error if file missing (Helm ConfigMap fix)
- Add config validation warnings: `gc.enabled+dry_run`, `retention.enabled+empty rules`
- Add `retention.dry_run` config field and `NORA_RETENTION_DRY_RUN` env var (parity with GC)
- Add `publish_lock` to npm, pypi, cargo handlers (TOCTOU race condition fix)
- Add Go (4 endpoints) and Raw (2 endpoints) OpenAPI stubs
- Fix OpenAPI version `0.5.0` → `0.6.2`
- Fix `Cargo.toml` homepage `getnora.io` → `getnora.dev`
- Fix README: Cargo upstream, `/raw/` endpoint, Helm chart in roadmap
- Fix `llms.txt`: test count, architectures, format descriptions
- Fix `rate_limit` doc comment defaults
- Remove dead `secrets_provider` init from `main.rs`

## Test plan

- [x] `cargo test -p nora-registry` — 592 tests pass
- [x] `cargo clippy -p nora-registry -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean