### PR TITLE
fix: warn on docker proxy credentials in env, recommend config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ See [Authentication guide](https://getnora.dev/configuration/authentication/) fo
 | `NORA_STORAGE_MODE` | local | `local` or `s3` |
 | `NORA_AUTH_ENABLED` | false | Enable authentication |
 | `NORA_AUTH_ANONYMOUS_READ` | false | Allow unauthenticated read access |
-| `NORA_DOCKER_PROXIES` | `https://registry-1.docker.io` | Docker upstreams (`url\|user:pass,...`) |
+| `NORA_DOCKER_PROXIES` | `https://registry-1.docker.io` | Docker upstreams for quick start (`url\|user:pass,...`). For production, use `config.toml` |
 | `NORA_PUBLIC_URL` | — | Public URL for rewriting artifact links |
 | `NORA_RATE_LIMIT_ENABLED` | true | Enable rate limiting |
 | `NORA_RETENTION_ENABLED` | false | Enable background retention scheduler |
@@ -181,6 +181,10 @@ proxy_timeout = 60
 
 [[docker.upstreams]]
 url = "https://registry-1.docker.io"
+
+[[docker.upstreams]]
+url = "https://private.registry.io"
+auth = "user:token"
 
 [go]
 proxy = "https://proxy.golang.org"

--- a/docs-ru/admin-guide.md
+++ b/docs-ru/admin-guide.md
@@ -122,7 +122,18 @@ htpasswd -Bc /etc/nora/users.htpasswd admin
 | `NORA_NPM_METADATA_TTL` | TTL кэша метаданных (секунды) | `300` |
 | `NORA_PYPI_PROXY` | URL PyPI-реестра | `https://pypi.org/simple/` |
 | `NORA_MAVEN_PROXIES` | Список Maven-репозиториев через запятую | `https://repo1.maven.org/maven2` |
-| `NORA_DOCKER_PROXIES` | Docker-реестры, формат: `url\|auth,url2` | `https://registry-1.docker.io` |
+| `NORA_DOCKER_PROXIES` | Docker-реестры (quick start), формат: `url\|auth,url2` | `https://registry-1.docker.io` |
+
+> **Рекомендация для production.** Для Docker-прокси с аутентификацией используйте `config.toml` вместо переменной окружения. Это позволяет хранить учётные данные отдельно (например, в Kubernetes Secret, смонтированном как файл) и упрощает ротацию токенов.
+>
+> ```toml
+> [[docker.upstreams]]
+> url = "https://registry-1.docker.io"
+>
+> [[docker.upstreams]]
+> url = "https://private.registry.io"
+> auth = "user:token"
+> ```
 
 ### 3.4. Ограничение частоты запросов
 

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -882,6 +882,12 @@ impl Config {
                     }
                 })
                 .collect();
+            if self.docker.upstreams.iter().any(|u| u.auth.is_some()) {
+                tracing::warn!(
+                    "Docker upstream credentials passed via NORA_DOCKER_PROXIES environment variable. \
+                     For production use config.toml with [[docker.upstreams]] and mount credentials from a Kubernetes Secret."
+                );
+            }
         }
 
         // Go config


### PR DESCRIPTION
## Summary

- Warn at startup when `NORA_DOCKER_PROXIES` contains inline credentials (`url|user:pass`)
- Update documentation to recommend `config.toml` with `[[docker.upstreams]]` for production
- Add private registry auth example to config.toml docs

Addresses #155.

## Test plan

- `cargo check` passes
- Coherence check passes
- CI validates