### PR TITLE
docs: add CHANGELOG entries for v0.6.1 and v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 ## [Unreleased]
 
+## [0.6.2] - 2026-04-17
+
+### Fixed
+- Upgrade Alpine 3.20 → 3.21, patching 18 CVEs (5 HIGH: OpenSSL, musl, zlib-ng)
+
+### Changed
+- ArtifactHub logo added to Helm chart metadata
+
+## [0.6.1] - 2026-04-17
+
+### Added
+- Helm chart support — `helm repo add nora https://getnora-io.github.io/helm-charts`
+
+### Changed
+- README updated for v0.6.0
+
 ## [0.6.0] - 2026-04-17
 
 ### Added


### PR DESCRIPTION
## Summary

- Add missing CHANGELOG entries for v0.6.1 (Helm chart) and v0.6.2 (Alpine 3.21 security patch)

## Test plan

- [x] Entries match git tags and commit history