### PR TITLE
fix: raw immutability, retention validation, test count update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 
 - **Zero-config** — single 32 MB binary, no database, no dependencies. `docker run` and it works.
 - **Production-tested** — Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw. Used in real CI/CD with ArgoCD, Buildx cache, and air-gapped environments.
-- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 588 tests.
+- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 633 tests.
 
 [![Release](https://img.shields.io/github/v/release/getnora-io/nora)](https://github.com/getnora-io/nora/releases)
 [![Image Size](https://img.shields.io/badge/image-32%20MB-blue)](https://github.com/getnora-io/nora/pkgs/container/nora)
@@ -192,10 +192,12 @@ proxy = "https://proxy.golang.org"
 [gc]
 enabled = true        # background GC scheduler
 interval = 86400      # run every 24h
+dry_run = false       # true = log only, no deletions
 
 [retention]
 enabled = true        # background retention scheduler
 interval = 86400      # run every 24h
+dry_run = false       # true = log only, no deletions
 
 [[retention.rules]]
 registry = "docker"

--- a/llms.txt
+++ b/llms.txt
@@ -321,8 +321,8 @@ A: Cosign verification and policy enforcement are on the roadmap. Currently, NOR
 - Language: Rust
 - Platforms: Linux (amd64, arm64). Docker images: Alpine, Astra Linux SE, RED OS
 - Binary name: nora (crate name: nora-registry)
-- Tests: 592 (unit + integration + proptest + Playwright e2e)
-- Coverage: 61.5%
+- Tests: 633 (unit + integration + proptest + Playwright e2e)
+- Coverage: ~62% (tarpaulin)
 - No garbage collector pauses (Rust, not Java/Go)
 - Async I/O with Tokio, Axum web framework
 - SHA256 digest verification on every blob upload

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -677,6 +677,11 @@ impl Config {
                 "gc.enabled=true with gc.dry_run=true — GC will run but never delete anything. Set gc.dry_run=false to actually free space".to_string(),
             );
         }
+        if self.retention.enabled && self.retention.dry_run && !self.retention.rules.is_empty() {
+            warnings.push(
+                "retention.enabled=true with retention.dry_run=true — retention will run but never delete anything. Set retention.dry_run=false to actually enforce policies".to_string(),
+            );
+        }
         if self.retention.enabled && self.retention.rules.is_empty() {
             warnings.push(
                 "retention.enabled=true but no retention rules configured — retention scheduler will run but do nothing. Add [retention.rules] or set retention.enabled=false".to_string(),

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -70,6 +70,19 @@ async fn upload(
     }
 
     let key = format!("raw/{}", path);
+
+    // Immutable: reject overwrite of existing files
+    let lock = state.publish_lock(&key);
+    let _guard = lock.lock().await;
+
+    if state.storage.stat(&key).await.is_some() {
+        return (
+            StatusCode::CONFLICT,
+            format!("File already exists: {}", path),
+        )
+            .into_response();
+    }
+
     match state.storage.put(&key, &body).await {
         Ok(()) => {
             state.metrics.record_upload("raw");
@@ -284,6 +297,34 @@ mod integration_tests {
         let ctx = create_test_context();
         let resp = send(&ctx.app, Method::GET, "/raw/missing.txt", "").await;
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_raw_immutable_overwrite_rejected() {
+        let ctx = create_test_context();
+        let put1 = send(
+            &ctx.app,
+            Method::PUT,
+            "/raw/immutable.txt",
+            b"first".to_vec(),
+        )
+        .await;
+        assert_eq!(put1.status(), StatusCode::CREATED);
+
+        let put2 = send(
+            &ctx.app,
+            Method::PUT,
+            "/raw/immutable.txt",
+            b"second".to_vec(),
+        )
+        .await;
+        assert_eq!(put2.status(), StatusCode::CONFLICT);
+
+        // Verify original content preserved
+        let get = send(&ctx.app, Method::GET, "/raw/immutable.txt", "").await;
+        assert_eq!(get.status(), StatusCode::OK);
+        let body = body_bytes(get).await;
+        assert_eq!(&body[..], b"first");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Raw registry now enforces immutability: overwrite returns 409 Conflict (M7)
- Add `retention.dry_run=true` validation warning, symmetric with GC (M3)
- Add `dry_run` field to GC and retention config examples in README (M2)
- Update test count: 588/592 → 633 in README and llms.txt (M5)
- Update coverage to ~62% in llms.txt (M6)
- New test: `test_raw_immutable_overwrite_rejected`

## Cogcheck findings addressed
- M2: README config.toml example missing dry_run
- M3: validate() asymmetry — no warning for retention.dry_run=true
- M5: Test count mismatch (README 588, llms.txt 592, actual 633)
- M6: Coverage 61.5% → ~62%
- M7: Raw registry overwrites files despite OpenAPI claiming 409/immutable

## Test plan
- [ ] `cargo test -p nora-registry raw` — 27 tests pass (including new immutable test)
- [ ] `cargo check` passes
- [ ] CI green