### PR TITLE
fix: share cleanup lock between GC and Retention schedulers

### DIFF
--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -394,10 +394,13 @@ async fn detect_cargo_orphans(storage: &Storage) -> DetectionResult {
 // ============================================================================
 
 /// Spawn a background GC task that runs periodically.
-/// Uses a tokio::sync::Mutex as single-flight lock to prevent overlapping runs.
-pub fn spawn_gc_scheduler(storage: Storage, interval_secs: u64, dry_run: bool) {
-    let lock = Arc::new(tokio::sync::Mutex::new(()));
-
+/// Accepts a shared cleanup lock to prevent concurrent runs with retention scheduler.
+pub fn spawn_gc_scheduler(
+    storage: Storage,
+    interval_secs: u64,
+    dry_run: bool,
+    cleanup_lock: Arc<tokio::sync::Mutex<()>>,
+) {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
         // First tick fires immediately — skip it so GC doesn't run on startup
@@ -406,10 +409,10 @@ pub fn spawn_gc_scheduler(storage: Storage, interval_secs: u64, dry_run: bool) {
         loop {
             interval.tick().await;
 
-            // Single-flight: skip if previous run is still going
-            let guard = lock.try_lock();
+            // Cross-scheduler lock: skip if GC or retention is already running
+            let guard = cleanup_lock.try_lock();
             if guard.is_err() {
-                info!("GC: previous run still active, skipping");
+                info!("GC: cleanup lock held (GC or retention running), skipping");
                 continue;
             }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -469,12 +469,16 @@ async fn run_server(config: Config, storage: Storage) {
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
     });
 
+    // Shared lock: GC and Retention must not run concurrently (both call storage.delete)
+    let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+
     // Spawn background GC scheduler if enabled
     if state.config.gc.enabled {
         gc::spawn_gc_scheduler(
             state.storage.clone(),
             state.config.gc.interval,
             state.config.gc.dry_run,
+            cleanup_lock.clone(),
         );
         info!(
             interval_secs = state.config.gc.interval,
@@ -491,6 +495,7 @@ async fn run_server(config: Config, storage: Storage) {
             state.config.retention.interval,
             state.config.retention.dry_run,
             Some(std::sync::Arc::new(audit::AuditLog::new(&storage_path))),
+            cleanup_lock.clone(),
         );
         info!(
             interval_secs = state.config.retention.interval,

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -603,16 +603,15 @@ fn find_matching_rule<'a>(
 // ============================================================================
 
 /// Spawn a background retention task that runs periodically.
-/// Uses a tokio::sync::Mutex as single-flight lock to prevent overlapping runs.
+/// Accepts a shared cleanup lock to prevent concurrent runs with GC scheduler.
 pub fn spawn_retention_scheduler(
     storage: Storage,
     rules: Vec<RetentionRule>,
     interval_secs: u64,
     dry_run: bool,
     audit: Option<Arc<crate::audit::AuditLog>>,
+    cleanup_lock: Arc<tokio::sync::Mutex<()>>,
 ) {
-    let lock = Arc::new(tokio::sync::Mutex::new(()));
-
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
         // First tick fires immediately — skip it so retention doesn't run on startup
@@ -621,10 +620,10 @@ pub fn spawn_retention_scheduler(
         loop {
             interval.tick().await;
 
-            // Single-flight: skip if previous run is still going
-            let guard = lock.try_lock();
+            // Cross-scheduler lock: skip if GC or retention is already running
+            let guard = cleanup_lock.try_lock();
             if guard.is_err() {
-                info!("Retention: previous run still active, skipping");
+                info!("Retention: cleanup lock held (GC or retention running), skipping");
                 continue;
             }
 


### PR DESCRIPTION
## Problem

GC and Retention background schedulers each create an independent `tokio::sync::Mutex` for single-flight protection. This prevents overlapping runs *within* the same scheduler, but does not prevent GC and Retention from running concurrently.

Both call `storage.delete()` on potentially overlapping keys. If both fire at the same time (default interval is 86400s for both), the second delete can silently fail or worse — delete a blob that was just re-referenced.

## Fix

Create a shared `Arc<tokio::sync::Mutex<()>>` in `main.rs` and pass it to both `spawn_gc_scheduler()` and `spawn_retention_scheduler()`. The cross-scheduler lock ensures only one cleanup process runs at a time.

- 3 files changed, +20 -13 lines
- All 597 tests pass
- No performance impact (schedulers run at most once per 24h)

## Files

- `nora-registry/src/main.rs` — create shared lock, pass to both
- `nora-registry/src/gc.rs` — accept external `cleanup_lock` parameter
- `nora-registry/src/retention.rs` — accept external `cleanup_lock` parameter

Closes #164