### PR TITLE
chore: release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 ## [Unreleased]
 
+## [0.6.3] - 2026-04-19
+
+### Fixed
+- GC and Retention schedulers now share a cleanup lock preventing concurrent `storage.delete()` races (#164)
+- Publish lock race conditions: Maven lock guard was inside if-block (P0), Cargo lock key was per-version instead of per-crate (P1), Docker pull counter lacked lock (P2) (#160)
+- Raw registry enforces immutability — overwrites return 409 Conflict instead of silently replacing files (#162)
+- Retention `dry_run=true` validation warning added (symmetric with GC) (#162)
+- Flaky test: `validate()` read env var directly, parallel tests broke each other (#160)
+- `llms.txt` mirror CLI examples corrected: `--image` → `--images`, `--package` → `--packages`, pip/cargo/maven use `--lockfile` (#161)
+
+### Changed
+- OpenAPI spec expanded: npm publish, Cargo publish, PyPI upload, Cargo sparse index, Docker manifest delete endpoints documented (#161, #163)
+- README env var table expanded from 10 to 24 variables with full descriptions (#163)
+- README mirror subcommand examples added for all 6 formats (#163)
+- Maven auth column corrected from "proxy-only" to full auth support (#163)
+- Coherence CI pipeline added: version sync, env var coverage, registry list, dead code budget, license check (#156)
+- Negative integration tests added for auth and validation (#156)
+- Config validation warns on Docker proxy credentials in env var (#157)
+- Config validation warns on relative paths with explicit config (#154)
+- Maven env var overrides added, S3 default port fixed to 9000 (#153)
+- Docker pull counter added with publish lock (#160)
+- `lock-audit.sh` script and Makefile targets added (#160)
+- 633 total tests (up from 588)
+
 ## [0.6.2] - 2026-04-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -18,7 +18,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.6.2",
+        version = "0.6.3",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, and Raw",
         license(name = "MIT"),
         contact(name = "DevITWay", url = "https://getnora.dev")


### PR DESCRIPTION
## Summary

Version bump to 0.6.3 with CHANGELOG update.

### Fixed (6)
- GC/Retention shared cleanup lock (#164)
- Publish lock races: Maven P0, Cargo P1, Docker P2 (#160)
- Raw registry immutability enforcement (#162)
- Retention dry_run validation warning (#162)
- Flaky test from env var pollution (#160)
- llms.txt mirror CLI flag corrections (#161)

### Changed (11)
- OpenAPI expanded: npm/Cargo/PyPI publish, sparse index, Docker delete (#161, #163)
- README: 24 env vars, mirror examples, Maven auth fix (#163)
- Coherence CI pipeline + negative integration tests (#156)
- Config validation: proxy credentials, relative paths (#154, #157)
- Maven env overrides, S3 default port (#153)
- Docker pull counter, lock-audit.sh, Makefile (#160)
- 633 total tests (up from 588)