### PR TITLE
fix: S3 storage mode config override and directory creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,7 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1930,7 +1930,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2175,7 +2175,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2204,9 +2204,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2504,7 +2504,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3202,7 +3202,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ COPY --chown=nora:nora nora /usr/local/bin/nora
 ENV RUST_LOG=info
 ENV NORA_HOST=0.0.0.0
 ENV NORA_PORT=4000
-ENV NORA_STORAGE_MODE=local
 ENV NORA_STORAGE_PATH=/data/storage
 ENV NORA_AUTH_TOKEN_STORAGE=/data/tokens
 

--- a/nora-registry/src/audit.rs
+++ b/nora-registry/src/audit.rs
@@ -46,6 +46,9 @@ pub struct AuditLog {
 impl AuditLog {
     pub fn new(storage_path: &str) -> Self {
         let path = PathBuf::from(storage_path).join("audit.jsonl");
+        if let Some(parent) = path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
         let writer = match OpenOptions::new().create(true).append(true).open(&path) {
             Ok(f) => {
                 info!(path = %path.display(), "Audit log initialized");

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1746,4 +1746,31 @@ mod tests {
         assert_eq!(c.proxy, Some("https://crates.io".to_string()));
         assert_eq!(c.proxy_timeout, 30);
     }
+
+    #[test]
+    fn test_config_file_sets_s3_mode_without_env() {
+        // Regression test for issue #4: config.toml mode="s3" must work
+        // without NORA_STORAGE_MODE env var (previously overridden by
+        // Dockerfile ENV NORA_STORAGE_MODE=local)
+        std::env::remove_var("NORA_STORAGE_MODE");
+
+        let toml = r#"
+            [server]
+            host = "0.0.0.0"
+            port = 4000
+
+            [storage]
+            mode = "s3"
+            s3_url = "http://minio:9000"
+            bucket = "nora"
+        "#;
+
+        let mut config: Config = toml::from_str(toml).unwrap();
+        config.apply_env_overrides();
+        assert_eq!(
+            config.storage.mode,
+            StorageMode::S3,
+            "config.toml mode=s3 must not be overridden when NORA_STORAGE_MODE is unset"
+        );
+    }
 }

--- a/nora-registry/src/dashboard_metrics.rs
+++ b/nora-registry/src/dashboard_metrics.rs
@@ -143,6 +143,9 @@ impl DashboardMetrics {
             registry_uploads: self.registry_uploads.snapshot(),
         };
         let tmp = path.with_extension("json.tmp");
+        if let Some(parent) = tmp.parent() {
+            let _ = tokio::fs::create_dir_all(parent).await;
+        }
         if let Ok(data) = serde_json::to_string_pretty(&snap) {
             if tokio::fs::write(&tmp, &data).await.is_ok() {
                 let _ = tokio::fs::rename(&tmp, path).await;


### PR DESCRIPTION
## Summary
- Remove `ENV NORA_STORAGE_MODE=local` from Dockerfile that overrode config.toml storage mode setting
- Add `create_dir_all` before audit log and metrics file creation for containerized environments with read-only root filesystem
- Add regression test: config.toml `mode = "s3"` works without `NORA_STORAGE_MODE` env var

## Context
When deploying via Helm chart with `config.storage.mode: s3`, the Dockerfile ENV took precedence over the mounted config.toml, forcing local storage mode. Additionally, audit log and dashboard metrics failed to initialize when the storage directory did not exist (common in S3 mode with `readOnlyRootFilesystem: true`).

Verified on dev K8s cluster with MinIO: push/pull artifacts through S3, audit log writes to emptyDir, health check confirms S3 reachable.

Fixes getnora-io/helm-charts#4

## Test plan
- [x] `make check` passes (635 tests, 0 failed, clippy clean, coherence OK)
- [x] E2E: S3 mode push/pull on dev K8s with MinIO
- [x] Regression: local mode still works (pod Ready, audit OK, 7 registries OK)