### PR TITLE
fix: use public_url in UI install commands (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- UI install commands now respect `NORA_PUBLIC_URL` for all registries — PyPI, npm, Go, Raw, Docker (#177)
+
 ## [0.6.4] - 2026-04-22
 
 ### Fixed
 - S3 storage mode: removed Dockerfile ENV override that forced local mode regardless of config.toml (#173)
 - Audit log and dashboard metrics: create parent directories before file open (fixes crash with readOnlyRootFilesystem)
 - Security: update rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)
-
 ## [0.6.3] - 2026-04-19
 
 ### Fixed

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -21,6 +21,23 @@ use api::*;
 use i18n::Lang;
 use templates::*;
 
+/// Returns base URL for UI install commands.
+/// Uses public_url if set (trimming trailing slash), otherwise http://host:port.
+fn resolve_base_url(state: &AppState) -> String {
+    state
+        .config
+        .server
+        .public_url
+        .as_deref()
+        .map(|u| u.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| {
+            format!(
+                "http://{}:{}",
+                state.config.server.host, state.config.server.port
+            )
+        })
+}
+
 #[derive(Debug, serde::Deserialize)]
 struct LangQuery {
     lang: Option<String>,
@@ -147,8 +164,9 @@ async fn docker_detail(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
+    let base_url = resolve_base_url(&state);
     let detail = get_docker_detail(&state, &name).await;
-    Html(render_docker_detail(&name, &detail, lang))
+    Html(render_docker_detail(&name, &detail, lang, &base_url))
 }
 
 // Maven pages
@@ -223,8 +241,11 @@ async fn npm_detail(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
+    let base_url = resolve_base_url(&state);
     let detail = get_npm_detail(&state.storage, &name).await;
-    Html(render_package_detail("npm", &name, &detail, lang))
+    Html(render_package_detail(
+        "npm", &name, &detail, lang, &base_url,
+    ))
 }
 
 // Cargo pages
@@ -261,8 +282,11 @@ async fn cargo_detail(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
+    let base_url = resolve_base_url(&state);
     let detail = get_cargo_detail(&state.storage, &name).await;
-    Html(render_package_detail("cargo", &name, &detail, lang))
+    Html(render_package_detail(
+        "cargo", &name, &detail, lang, &base_url,
+    ))
 }
 
 // PyPI pages
@@ -299,8 +323,11 @@ async fn pypi_detail(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
+    let base_url = resolve_base_url(&state);
     let detail = get_pypi_detail(&state.storage, &name).await;
-    Html(render_package_detail("pypi", &name, &detail, lang))
+    Html(render_package_detail(
+        "pypi", &name, &detail, lang, &base_url,
+    ))
 }
 
 // Go pages
@@ -337,8 +364,9 @@ async fn go_detail(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
+    let base_url = resolve_base_url(&state);
     let detail = get_go_detail(&state.storage, &name).await;
-    Html(render_package_detail("go", &name, &detail, lang))
+    Html(render_package_detail("go", &name, &detail, lang, &base_url))
 }
 
 // Raw pages
@@ -375,6 +403,9 @@ async fn raw_detail(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
+    let base_url = resolve_base_url(&state);
     let detail = get_raw_detail(&state.storage, &name).await;
-    Html(render_package_detail("raw", &name, &detail, lang))
+    Html(render_package_detail(
+        "raw", &name, &detail, lang, &base_url,
+    ))
 }

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -519,7 +519,12 @@ pub fn render_registry_list_paginated(
 }
 
 /// Renders Docker image detail page
-pub fn render_docker_detail(name: &str, detail: &DockerDetail, lang: Lang) -> String {
+pub fn render_docker_detail(
+    name: &str,
+    detail: &DockerDetail,
+    lang: Lang,
+    base_url: &str,
+) -> String {
     let _t = get_translations(lang);
     let tags_rows = if detail.tags.is_empty() {
         r##"<tr><td colspan="3" class="px-6 py-8 text-center text-slate-500">No tags found</td></tr>"##.to_string()
@@ -547,7 +552,10 @@ pub fn render_docker_detail(name: &str, detail: &DockerDetail, lang: Lang) -> St
             .join("")
     };
 
-    let pull_cmd = format!("docker pull 127.0.0.1:4000/{}", name);
+    let registry_host = base_url
+        .trim_start_matches("https://")
+        .trim_start_matches("http://");
+    let pull_cmd = format!("docker pull {}/{}", registry_host, name);
 
     let content = format!(
         r##"
@@ -617,6 +625,7 @@ pub fn render_package_detail(
     name: &str,
     detail: &PackageDetail,
     lang: Lang,
+    base_url: &str,
 ) -> String {
     let _t = get_translations(lang);
     let icon = get_registry_icon(registry_type);
@@ -649,14 +658,11 @@ pub fn render_package_detail(
     };
 
     let install_cmd = match registry_type {
-        "npm" => format!("npm install {} --registry http://127.0.0.1:4000/npm", name),
+        "npm" => format!("npm install {} --registry {}/npm", name, base_url),
         "cargo" => format!("cargo add {}", name),
-        "pypi" => format!(
-            "pip install {} --index-url http://127.0.0.1:4000/simple",
-            name
-        ),
-        "go" => format!("GOPROXY=http://127.0.0.1:4000/go go get {}", name),
-        "raw" => format!("curl -O http://127.0.0.1:4000/raw/{}/<file>", name),
+        "pypi" => format!("pip install {} --index-url {}/simple", name, base_url),
+        "go" => format!("GOPROXY={}/go go get {}", base_url, name),
+        "raw" => format!("curl -O {}/raw/{}/<file>", base_url, name),
         _ => String::new(),
     };
 
@@ -858,4 +864,93 @@ pub fn encode_uri_component(s: &str) -> String {
         }
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui::api::PackageDetail;
+
+    fn empty_detail() -> PackageDetail {
+        PackageDetail { versions: vec![] }
+    }
+
+    #[test]
+    fn test_package_detail_uses_public_url() {
+        let base_url = "https://registry.example.com";
+        let html = render_package_detail("pypi", "requests", &empty_detail(), Lang::En, base_url);
+        assert!(
+            html.contains("https://registry.example.com/simple"),
+            "PyPI install command must use public_url"
+        );
+        assert!(
+            !html.contains("127.0.0.1"),
+            "Must not contain hardcoded localhost"
+        );
+
+        let html = render_package_detail("npm", "lodash", &empty_detail(), Lang::En, base_url);
+        assert!(
+            html.contains("https://registry.example.com/npm"),
+            "npm install command must use public_url"
+        );
+
+        let html = render_package_detail(
+            "go",
+            "github.com/foo/bar",
+            &empty_detail(),
+            Lang::En,
+            base_url,
+        );
+        assert!(
+            html.contains("https://registry.example.com/go"),
+            "Go proxy command must use public_url"
+        );
+
+        let html = render_package_detail("raw", "myfiles", &empty_detail(), Lang::En, base_url);
+        assert!(
+            html.contains("https://registry.example.com/raw"),
+            "Raw download command must use public_url"
+        );
+    }
+
+    #[test]
+    fn test_package_detail_fallback_url() {
+        let base_url = "http://0.0.0.0:4000";
+        let html = render_package_detail("pypi", "flask", &empty_detail(), Lang::En, base_url);
+        assert!(
+            html.contains("http://0.0.0.0:4000/simple"),
+            "Must use fallback host:port when public_url is not set"
+        );
+    }
+
+    #[test]
+    fn test_docker_detail_strips_scheme() {
+        let detail = super::super::api::DockerDetail { tags: vec![] };
+
+        let html = render_docker_detail("myapp", &detail, Lang::En, "https://registry.example.com");
+        assert!(
+            html.contains("docker pull registry.example.com/myapp"),
+            "Docker pull must strip https:// scheme"
+        );
+        assert!(
+            !html.contains("https://registry.example.com/myapp"),
+            "Docker pull must not include scheme"
+        );
+
+        let html = render_docker_detail("myapp", &detail, Lang::En, "http://localhost:4000");
+        assert!(
+            html.contains("docker pull localhost:4000/myapp"),
+            "Docker pull must strip http:// scheme"
+        );
+    }
+
+    #[test]
+    fn test_trailing_slash_no_double_slash() {
+        let base_url = "https://registry.example.com";
+        let html = render_package_detail("pypi", "pkg", &empty_detail(), Lang::En, base_url);
+        assert!(
+            !html.contains("com//simple"),
+            "Must not produce double slashes"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- UI install commands (pip, npm, go, curl, docker pull) now respect `NORA_PUBLIC_URL` instead of hardcoded `127.0.0.1:4000`
- Affects all registries: PyPI, npm, Go, Raw, Docker
- Added `resolve_base_url()` helper, trailing slash handled, Docker scheme stripped

## Test plan
- [x] 4 unit tests added (public_url set, fallback, Docker scheme strip, no double slash)
- [x] 602 tests pass (598 existing + 4 new)
- [ ] CI gates

Closes #177