### PR TITLE
chore: release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 ## [Unreleased]
 
+## [0.6.5] - 2026-04-23
+
 ### Fixed
 - UI install commands now respect `NORA_PUBLIC_URL` for all registries — PyPI, npm, Go, Raw, Docker (#177)
+- Docker `WWW-Authenticate` realm uses `NORA_PUBLIC_URL` instead of hardcoded "Nora" (#177)
+- PyPI simple index generates absolute download URLs using `NORA_PUBLIC_URL` (#177)
 
 ## [0.6.4] - 2026-04-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -18,7 +18,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.6.4",
+        version = "0.6.5",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, and Raw",
         license(name = "MIT"),
         contact(name = "DevITWay", url = "https://getnora.dev")


### PR DESCRIPTION
## Summary
- Version bump to 0.6.5
- CHANGELOG finalized

## Changes in v0.6.5
- UI install commands respect `NORA_PUBLIC_URL` for all registries (#177)
- Docker `WWW-Authenticate` realm uses `NORA_PUBLIC_URL`
- PyPI simple index generates absolute download URLs

## Quality gates
- [x] 602 tests pass
- [x] clippy -D warnings: 0 warnings
- [x] rustfmt: clean
- [x] Playwright: 6/6 pass
- [ ] CI