### PR TITLE
feat: curation layer — blocklist, allowlist, integrity, CLI (#184-#190)

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -595,6 +595,7 @@ pub enum CurationOnFailure {
 /// - `NORA_CURATION_BLOCKLIST_PATH` — path to blocklist JSON file
 /// - `NORA_CURATION_BYPASS_TOKEN` — token to bypass curation checks
 /// - `NORA_CURATION_REQUIRE_INTEGRITY` — require integrity metadata (default: false)
+/// - `NORA_CURATION_INTERNAL_NAMESPACES` — comma-separated glob patterns
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CurationConfig {
     #[serde(default)]
@@ -610,6 +611,10 @@ pub struct CurationConfig {
     pub bypass_token: Option<String>,
     #[serde(default)]
     pub require_integrity: bool,
+    /// Glob patterns for internal namespaces that must never be proxied upstream.
+    /// Always active regardless of curation mode (security boundary).
+    #[serde(default)]
+    pub internal_namespaces: Vec<String>,
 }
 
 impl Default for CurationConfig {
@@ -621,6 +626,7 @@ impl Default for CurationConfig {
             blocklist_path: None,
             bypass_token: None,
             require_integrity: false,
+            internal_namespaces: Vec::new(),
         }
     }
 }
@@ -1157,6 +1163,13 @@ impl Config {
         }
         if let Ok(val) = env::var("NORA_CURATION_REQUIRE_INTEGRITY") {
             self.curation.require_integrity = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_CURATION_INTERNAL_NAMESPACES") {
+            self.curation.internal_namespaces = if val.is_empty() {
+                Vec::new()
+            } else {
+                val.split(',').map(|s| s.trim().to_string()).collect()
+            };
         }
     }
 }

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The Nora Authors
 // SPDX-License-Identifier: MIT
 
 use base64::{engine::general_purpose::STANDARD, Engine};
@@ -41,6 +41,8 @@ pub struct Config {
     pub gc: GcConfig,
     #[serde(default)]
     pub retention: RetentionConfig,
+    #[serde(default)]
+    pub curation: CurationConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -544,6 +546,85 @@ impl Default for RetentionConfig {
     }
 }
 
+// ============================================================================
+// Curation Configuration
+// ============================================================================
+
+/// Curation operating mode.
+///
+/// - `off` — curation disabled, all requests pass through (default)
+/// - `audit` — evaluate filters and log decisions, but never block
+/// - `enforce` — evaluate filters and block requests that match a deny rule
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CurationMode {
+    #[default]
+    Off,
+    Audit,
+    Enforce,
+}
+
+impl std::fmt::Display for CurationMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CurationMode::Off => write!(f, "off"),
+            CurationMode::Audit => write!(f, "audit"),
+            CurationMode::Enforce => write!(f, "enforce"),
+        }
+    }
+}
+
+/// Behavior when a curation filter returns an error or panics.
+///
+/// - `closed` — treat as blocked (fail-safe, default)
+/// - `open` — treat as allowed (fail-open)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum CurationOnFailure {
+    #[default]
+    Closed,
+    Open,
+}
+
+/// Curation layer configuration.
+///
+/// # Environment Variables
+/// - `NORA_CURATION_MODE` — off/audit/enforce (default: off)
+/// - `NORA_CURATION_ON_FAILURE` — closed/open (default: closed)
+/// - `NORA_CURATION_ALLOWLIST_PATH` — path to allowlist JSON file
+/// - `NORA_CURATION_BLOCKLIST_PATH` — path to blocklist JSON file
+/// - `NORA_CURATION_BYPASS_TOKEN` — token to bypass curation checks
+/// - `NORA_CURATION_REQUIRE_INTEGRITY` — require integrity metadata (default: false)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CurationConfig {
+    #[serde(default)]
+    pub mode: CurationMode,
+    #[serde(default)]
+    pub on_failure: CurationOnFailure,
+    #[serde(default)]
+    pub allowlist_path: Option<String>,
+    #[serde(default)]
+    pub blocklist_path: Option<String>,
+    /// Token to bypass curation. Should only be set via env var, not config file.
+    #[serde(default, skip_serializing)]
+    pub bypass_token: Option<String>,
+    #[serde(default)]
+    pub require_integrity: bool,
+}
+
+impl Default for CurationConfig {
+    fn default() -> Self {
+        Self {
+            mode: CurationMode::Off,
+            on_failure: CurationOnFailure::Closed,
+            allowlist_path: None,
+            blocklist_path: None,
+            bypass_token: None,
+            require_integrity: false,
+        }
+    }
+}
+
 impl Config {
     /// Warn if credentials are configured via config.toml (not env vars)
     pub fn warn_plaintext_credentials(&self) {
@@ -685,6 +766,33 @@ impl Config {
         if self.retention.enabled && self.retention.rules.is_empty() {
             warnings.push(
                 "retention.enabled=true but no retention rules configured — retention scheduler will run but do nothing. Add [retention.rules] or set retention.enabled=false".to_string(),
+            );
+        }
+
+        // 8. Curation validation
+        if self.curation.mode == CurationMode::Enforce && self.curation.allowlist_path.is_none() {
+            errors.push(
+                "curation.mode=enforce requires curation.allowlist_path to be set".to_string(),
+            );
+        }
+        if self.curation.mode == CurationMode::Enforce {
+            if let Some(ref path) = self.curation.allowlist_path {
+                if !std::path::Path::new(path).exists() {
+                    errors.push(format!(
+                        "curation.allowlist_path=\"{}\" does not exist (required for enforce mode)",
+                        path
+                    ));
+                }
+            }
+        }
+        if self.curation.bypass_token.is_some() && env::var("NORA_CURATION_BYPASS_TOKEN").is_err() {
+            warnings.push(
+                "curation.bypass_token is set in config file — consider using NORA_CURATION_BYPASS_TOKEN env var instead".to_string(),
+            );
+        }
+        if self.curation.mode == CurationMode::Audit && self.curation.allowlist_path.is_none() {
+            warnings.push(
+                "curation.mode=audit but no allowlist_path configured — no allowlist filter will be active".to_string(),
             );
         }
 
@@ -1023,6 +1131,33 @@ impl Config {
         if let Ok(val) = env::var("NORA_SECRETS_CLEAR_ENV") {
             self.secrets.clear_env = val.to_lowercase() == "true" || val == "1";
         }
+
+        // Curation config
+        if let Ok(val) = env::var("NORA_CURATION_MODE") {
+            self.curation.mode = match val.to_lowercase().as_str() {
+                "audit" => CurationMode::Audit,
+                "enforce" => CurationMode::Enforce,
+                _ => CurationMode::Off,
+            };
+        }
+        if let Ok(val) = env::var("NORA_CURATION_ON_FAILURE") {
+            self.curation.on_failure = match val.to_lowercase().as_str() {
+                "open" => CurationOnFailure::Open,
+                _ => CurationOnFailure::Closed,
+            };
+        }
+        if let Ok(val) = env::var("NORA_CURATION_ALLOWLIST_PATH") {
+            self.curation.allowlist_path = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_CURATION_BLOCKLIST_PATH") {
+            self.curation.blocklist_path = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_CURATION_BYPASS_TOKEN") {
+            self.curation.bypass_token = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_CURATION_REQUIRE_INTEGRITY") {
+            self.curation.require_integrity = val.to_lowercase() == "true" || val == "1";
+        }
     }
 }
 
@@ -1056,6 +1191,7 @@ impl Default for Config {
             secrets: SecretsConfig::default(),
             gc: GcConfig::default(),
             retention: RetentionConfig::default(),
+            curation: CurationConfig::default(),
         }
     }
 }
@@ -1772,5 +1908,168 @@ mod tests {
             StorageMode::S3,
             "config.toml mode=s3 must not be overridden when NORA_STORAGE_MODE is unset"
         );
+    }
+
+    // ========================================================================
+    // Curation config tests
+    // ========================================================================
+
+    #[test]
+    fn test_curation_config_default() {
+        let c = CurationConfig::default();
+        assert_eq!(c.mode, CurationMode::Off);
+        assert_eq!(c.on_failure, CurationOnFailure::Closed);
+        assert!(c.allowlist_path.is_none());
+        assert!(c.blocklist_path.is_none());
+        assert!(c.bypass_token.is_none());
+        assert!(!c.require_integrity);
+    }
+
+    #[test]
+    fn test_curation_config_from_toml() {
+        let toml = r#"
+            [server]
+            host = "127.0.0.1"
+            port = 4000
+
+            [storage]
+            mode = "local"
+
+            [curation]
+            mode = "audit"
+            on_failure = "open"
+            require_integrity = true
+        "#;
+
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.curation.mode, CurationMode::Audit);
+        assert_eq!(config.curation.on_failure, CurationOnFailure::Open);
+        assert!(config.curation.require_integrity);
+    }
+
+    #[test]
+    fn test_curation_config_missing_defaults_to_off() {
+        let toml = r#"
+            [server]
+            host = "127.0.0.1"
+            port = 4000
+
+            [storage]
+            mode = "local"
+        "#;
+
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.curation.mode, CurationMode::Off);
+    }
+
+    #[test]
+    fn test_curation_env_override_mode() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_CURATION_MODE", "enforce");
+        config.apply_env_overrides();
+        assert_eq!(config.curation.mode, CurationMode::Enforce);
+        std::env::remove_var("NORA_CURATION_MODE");
+    }
+
+    #[test]
+    fn test_curation_env_override_on_failure() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_CURATION_ON_FAILURE", "open");
+        config.apply_env_overrides();
+        assert_eq!(config.curation.on_failure, CurationOnFailure::Open);
+        std::env::remove_var("NORA_CURATION_ON_FAILURE");
+    }
+
+    #[test]
+    fn test_curation_env_override_paths() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_CURATION_ALLOWLIST_PATH", "/etc/nora/allow.json");
+        std::env::set_var("NORA_CURATION_BLOCKLIST_PATH", "/etc/nora/block.json");
+        config.apply_env_overrides();
+        assert_eq!(
+            config.curation.allowlist_path,
+            Some("/etc/nora/allow.json".to_string())
+        );
+        assert_eq!(
+            config.curation.blocklist_path,
+            Some("/etc/nora/block.json".to_string())
+        );
+        std::env::remove_var("NORA_CURATION_ALLOWLIST_PATH");
+        std::env::remove_var("NORA_CURATION_BLOCKLIST_PATH");
+    }
+
+    #[test]
+    fn test_curation_env_override_bypass_token() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_CURATION_BYPASS_TOKEN", "secret-bypass");
+        config.apply_env_overrides();
+        assert_eq!(
+            config.curation.bypass_token,
+            Some("secret-bypass".to_string())
+        );
+        std::env::remove_var("NORA_CURATION_BYPASS_TOKEN");
+    }
+
+    #[test]
+    fn test_curation_env_override_require_integrity() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_CURATION_REQUIRE_INTEGRITY", "true");
+        config.apply_env_overrides();
+        assert!(config.curation.require_integrity);
+        std::env::remove_var("NORA_CURATION_REQUIRE_INTEGRITY");
+    }
+
+    #[test]
+    fn test_validate_curation_enforce_no_allowlist() {
+        let mut config = Config::default();
+        config.curation.mode = CurationMode::Enforce;
+        config.curation.allowlist_path = None;
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors.iter().any(|e| e.contains("allowlist_path")),
+            "enforce without allowlist should be an error"
+        );
+    }
+
+    #[test]
+    fn test_validate_curation_enforce_missing_allowlist_file() {
+        let mut config = Config::default();
+        config.curation.mode = CurationMode::Enforce;
+        config.curation.allowlist_path = Some("/nonexistent/allow.json".to_string());
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors.iter().any(|e| e.contains("does not exist")),
+            "enforce with missing allowlist file should be an error"
+        );
+    }
+
+    #[test]
+    fn test_validate_curation_audit_no_allowlist_warning() {
+        let mut config = Config::default();
+        config.curation.mode = CurationMode::Audit;
+        let (warnings, errors) = config.validate_with_config_path(None);
+        assert!(errors.is_empty());
+        assert!(
+            warnings.iter().any(|w| w.contains("no allowlist_path")),
+            "audit without allowlist should be a warning"
+        );
+    }
+
+    #[test]
+    fn test_validate_curation_off_no_warnings() {
+        let config = Config::default();
+        let (warnings, errors) = config.validate_with_config_path(None);
+        assert!(errors.is_empty());
+        assert!(
+            !warnings.iter().any(|w| w.contains("curation")),
+            "mode=off should produce no curation warnings"
+        );
+    }
+
+    #[test]
+    fn test_curation_mode_display() {
+        assert_eq!(CurationMode::Off.to_string(), "off");
+        assert_eq!(CurationMode::Audit.to_string(), "audit");
+        assert_eq!(CurationMode::Enforce.to_string(), "enforce");
     }
 }

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -3,17 +3,19 @@
 
 //! Curation layer — package access control for proxy registries.
 //!
-//! This module provides the skeleton for the curation filter chain:
+//! This module provides the curation filter chain:
 //! - [`ProxyFilter`] trait that individual filters implement
+//! - [`BlocklistFilter`] — blocks packages by name/version/registry (issue #186)
+//! - [`AllowlistFilter`] — default-deny approved packages (issue #188)
+//! - [`NamespaceFilter`] — namespace isolation, always active (issue #185)
 //! - [`CurationEngine`] that evaluates a chain of filters
 //! - [`BlockedResponse`] for generating 403 responses
 //! - [`CurationMetrics`] for raw counters
-//!
-//! Issue #184 — config skeleton + trait. No actual filters yet.
 
 use crate::config::{CurationConfig, CurationMode};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
 use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -123,6 +125,8 @@ pub struct EvaluationResult {
 pub struct CurationEngine {
     config: CurationConfig,
     filters: Vec<Box<dyn ProxyFilter>>,
+    /// Namespace isolation filter — always active, even in Off mode.
+    namespace_filter: Option<Box<dyn ProxyFilter>>,
     metrics: CurationMetrics,
 }
 
@@ -132,6 +136,7 @@ impl CurationEngine {
         Self {
             config,
             filters: Vec::new(),
+            namespace_filter: None,
             metrics: CurationMetrics::new(),
         }
     }
@@ -140,6 +145,11 @@ impl CurationEngine {
     /// Evaluation order = insertion order.
     pub fn add_filter(&mut self, filter: Box<dyn ProxyFilter>) {
         self.filters.push(filter);
+    }
+
+    /// Set the namespace isolation filter (always active, even in Off mode).
+    pub fn set_namespace_filter(&mut self, filter: Box<dyn ProxyFilter>) {
+        self.namespace_filter = Some(filter);
     }
 
     /// Current operating mode.
@@ -166,6 +176,20 @@ impl CurationEngine {
     /// - **Enforce**: Block decisions are final.
     /// - All Skip → Allow.
     pub fn evaluate(&self, request: &FilterRequest) -> EvaluationResult {
+        // Namespace isolation: ALWAYS active, even in Off mode.
+        // Prevents dependency confusion regardless of curation config.
+        if let Some(ref ns_filter) = self.namespace_filter {
+            let decision = ns_filter.evaluate(request);
+            if let Decision::Block { .. } = &decision {
+                self.metrics.blocked.fetch_add(1, Ordering::Relaxed);
+                return EvaluationResult {
+                    decision,
+                    decided_by: Some(ns_filter.name().to_string()),
+                    audited: false, // namespace blocks are never audit-only
+                };
+            }
+        }
+
         // Mode=Off: no-op
         if self.config.mode == CurationMode::Off {
             return EvaluationResult {
@@ -237,12 +261,137 @@ impl CurationEngine {
 }
 
 // ============================================================================
+// check_download() — handler integration helper (issue #187)
+// ============================================================================
+
+/// Check curation policy for a download request.
+///
+/// Returns `Some(Response)` if blocked (403 in enforce mode), `None` to proceed.
+/// In audit mode, logs the decision but returns `None` (request proceeds).
+/// In off mode (with no namespace match), returns `None` immediately.
+///
+/// Bypass: if the request carries `X-Nora-Bypass-Token` matching the configured
+/// token, curation is bypassed (namespace filter still applies).
+pub fn check_download(
+    engine: &CurationEngine,
+    bypass_token: Option<&str>,
+    headers: &axum::http::HeaderMap,
+    registry: RegistryType,
+    name: &str,
+    version: Option<&str>,
+) -> Option<Response> {
+    let bypass = match bypass_token {
+        Some(token) => headers
+            .get("x-nora-bypass-token")
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v == token)
+            .unwrap_or(false),
+        None => false,
+    };
+
+    let request = FilterRequest {
+        registry,
+        upstream: None,
+        name: name.to_string(),
+        version: version.map(|v| v.to_string()),
+        integrity: None,
+        bypass,
+    };
+
+    let result = engine.evaluate(&request);
+
+    match &result.decision {
+        Decision::Block { rule, reason } => {
+            if result.audited {
+                tracing::info!(
+                    registry = %registry,
+                    package = %name,
+                    version = version.unwrap_or("*"),
+                    rule = %rule,
+                    reason = %reason,
+                    "[AUDIT] Download would be blocked"
+                );
+                None
+            } else {
+                Some(
+                    BlockedResponse {
+                        rule: rule.clone(),
+                        reason: reason.clone(),
+                        registry: registry.to_string(),
+                        package: name.to_string(),
+                        version: version.map(|v| v.to_string()),
+                    }
+                    .into_response(),
+                )
+            }
+        }
+        Decision::Allow | Decision::Skip => None,
+    }
+}
+
+// ============================================================================
+// Version parsers for filename-based registries (issue #187)
+// ============================================================================
+
+/// Parse version from an npm tarball filename.
+///
+/// For scoped packages `@scope/name`, the tarball is `name-VERSION.tgz`.
+/// For regular packages `name`, the tarball is `name-VERSION.tgz`.
+pub fn parse_npm_tarball_version(package_name: &str, filename: &str) -> Option<String> {
+    let filename = filename.strip_suffix(".tgz")?;
+    // For scoped packages like @scope/name, tarball uses just "name" part
+    let name_part = if package_name.contains('/') {
+        package_name.rsplit('/').next()?
+    } else {
+        package_name
+    };
+    let version = filename.strip_prefix(name_part)?.strip_prefix('-')?;
+    if version.is_empty() {
+        return None;
+    }
+    Some(version.to_string())
+}
+
+/// Parse version from a PyPI download filename.
+///
+/// Handles: `.tar.gz`, `.zip`, `.whl`, `.egg`, `.tgz`
+/// For wheels, version is between the first and second `-`.
+pub fn parse_pypi_version(normalized_name: &str, filename: &str) -> Option<String> {
+    // Strip known extensions
+    let base = filename
+        .strip_suffix(".tar.gz")
+        .or_else(|| filename.strip_suffix(".tgz"))
+        .or_else(|| filename.strip_suffix(".zip"))
+        .or_else(|| filename.strip_suffix(".whl"))
+        .or_else(|| filename.strip_suffix(".egg"))?;
+
+    // Normalize: PyPI filenames use underscores, normalized names use hyphens
+    let name_underscore = normalized_name.replace('-', "_");
+    let base_lower = base.to_lowercase();
+    let prefix = format!("{}-", name_underscore.to_lowercase());
+
+    let rest = base_lower.strip_prefix(&prefix)?;
+    // For wheels: rest is "VERSION-py3-none-any" — take until next '-' that starts a tag
+    // For sdist: rest is just "VERSION"
+    // Heuristic: version chars are digits, dots, letters (rc, alpha, beta, post, dev)
+    // Split at first '-' followed by non-digit (wheel tags like py3, cp39)
+    let version = if filename.ends_with(".whl") {
+        rest.split('-').next()?
+    } else {
+        rest
+    };
+    if version.is_empty() {
+        return None;
+    }
+    Some(version.to_string())
+}
+
+// ============================================================================
 // Blocked Response (403 JSON)
 // ============================================================================
 
 /// A 403 response body for blocked requests.
 /// Used by registry handlers in #185-#189 when curation blocks a request.
-#[allow(dead_code)]
 pub struct BlockedResponse {
     pub rule: String,
     pub reason: String,
@@ -311,6 +460,302 @@ impl CurationMetrics {
             without_integrity: AtomicU64::new(0),
             cve_cache_miss: AtomicU64::new(0),
         }
+    }
+}
+
+// ============================================================================
+// Blocklist Filter (issue #185)
+// ============================================================================
+
+/// On-disk JSON schema for the blocklist file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlocklistFile {
+    /// Schema version (must be 1).
+    pub version: u32,
+    /// List of block rules.
+    pub rules: Vec<BlocklistRule>,
+}
+
+/// A single blocklist rule: matches packages by registry, name, and version.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlocklistRule {
+    /// Registry type to match: exact (e.g. "npm") or "*" for all.
+    pub registry: String,
+    /// Package name: exact, prefix glob ("foo*"), suffix glob ("*foo"), or "*".
+    pub name: String,
+    /// Version: exact or "*" for all versions.
+    pub version: String,
+    /// Human-readable reason shown in the 403 response.
+    pub reason: String,
+}
+
+/// Simple glob matching without external dependencies.
+///
+/// Supports:
+/// - `"*"` — matches everything
+/// - `"foo.**"` — hierarchical prefix (dot separator, for Maven groupIds)
+/// - `"foo/**"` — hierarchical prefix (slash separator, for Go modules)
+/// - `"foo*"` — prefix match
+/// - `"*foo"` — suffix match
+/// - exact string comparison otherwise
+fn glob_match(pattern: &str, value: &str) -> bool {
+    if pattern == "*" {
+        return true;
+    }
+    // "foo.**" → matches "foo" itself and "foo.anything.deeper"
+    if let Some(prefix) = pattern.strip_suffix(".**") {
+        return value == prefix || value.starts_with(&format!("{}.", prefix));
+    }
+    // "foo/**" → matches "foo" itself and "foo/anything/deeper"
+    if let Some(prefix) = pattern.strip_suffix("/**") {
+        return value == prefix || value.starts_with(&format!("{}/", prefix));
+    }
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        return value.starts_with(prefix);
+    }
+    if let Some(suffix) = pattern.strip_prefix('*') {
+        return value.ends_with(suffix);
+    }
+    pattern == value
+}
+
+/// A filter that blocks packages matching rules loaded from a JSON file.
+///
+/// Blocklist is checked first in the chain (overlay on allowlist).
+/// First matching rule wins → `Decision::Block`.
+/// No match → `Decision::Skip` (defer to next filter).
+#[derive(Debug)]
+pub struct BlocklistFilter {
+    rules: Vec<BlocklistRule>,
+}
+
+impl BlocklistFilter {
+    /// Load and validate a blocklist from a JSON file.
+    pub fn from_file(path: &str) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read blocklist file '{}': {}", path, e))?;
+
+        let file: BlocklistFile = serde_json::from_str(&content)
+            .map_err(|e| format!("failed to parse blocklist JSON '{}': {}", path, e))?;
+
+        if file.version != 1 {
+            return Err(format!(
+                "unsupported blocklist version {} (expected 1)",
+                file.version
+            ));
+        }
+
+        Ok(Self { rules: file.rules })
+    }
+
+    /// Number of rules loaded.
+    pub fn rule_count(&self) -> usize {
+        self.rules.len()
+    }
+}
+
+impl ProxyFilter for BlocklistFilter {
+    fn name(&self) -> &'static str {
+        "blocklist"
+    }
+
+    fn evaluate(&self, request: &FilterRequest) -> Decision {
+        let registry_str = request.registry.to_string();
+        let version_str = request.version.as_deref().unwrap_or("");
+
+        for rule in &self.rules {
+            let registry_match = glob_match(&rule.registry, &registry_str);
+            let name_match = glob_match(&rule.name, &request.name);
+            let version_match = rule.version == "*" || glob_match(&rule.version, version_str);
+
+            if registry_match && name_match && version_match {
+                return Decision::Block {
+                    rule: "blocklist".to_string(),
+                    reason: rule.reason.clone(),
+                };
+            }
+        }
+
+        Decision::Skip
+    }
+}
+
+// ============================================================================
+// Allowlist Filter (issue #188)
+// ============================================================================
+
+/// On-disk JSON schema for the allowlist file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AllowlistFile {
+    /// Schema version (must be 1).
+    pub version: u32,
+    /// List of approved packages.
+    pub entries: Vec<AllowlistEntry>,
+}
+
+/// A single allowlist entry: an approved (registry, name, version) tuple.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AllowlistEntry {
+    /// Registry type: "npm", "pypi", "maven", etc.
+    pub registry: String,
+    /// Exact package name.
+    pub name: String,
+    /// Exact version string.
+    pub version: String,
+    /// Integrity hash (e.g., "sha256:abc123"). Optional.
+    #[serde(default)]
+    pub integrity: Option<String>,
+    /// Source of the integrity hash: "upstream", "local", "manual".
+    /// Informational only — not used in filter evaluation.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub integrity_source: Option<String>,
+}
+
+/// Default-deny filter: only packages explicitly listed are allowed through.
+///
+/// Uses HashMap O(1) lookup by (registry, name, version).
+/// Blocklist is evaluated first in the chain — blocklisted packages never reach this filter.
+#[derive(Debug)]
+pub struct AllowlistFilter {
+    entries: std::collections::HashMap<(String, String, String), AllowlistEntry>,
+    require_integrity: bool,
+}
+
+impl AllowlistFilter {
+    /// Load and validate an allowlist from a JSON file.
+    pub fn from_file(path: &str, require_integrity: bool) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("failed to read allowlist file '{}': {}", path, e))?;
+
+        let file: AllowlistFile = serde_json::from_str(&content)
+            .map_err(|e| format!("failed to parse allowlist JSON '{}': {}", path, e))?;
+
+        if file.version != 1 {
+            return Err(format!(
+                "unsupported allowlist version {} (expected 1)",
+                file.version
+            ));
+        }
+
+        let mut entries = std::collections::HashMap::new();
+        for entry in file.entries {
+            let key = (
+                entry.registry.clone(),
+                entry.name.clone(),
+                entry.version.clone(),
+            );
+            entries.insert(key, entry);
+        }
+
+        Ok(Self {
+            entries,
+            require_integrity,
+        })
+    }
+
+    /// Number of entries loaded.
+    pub fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+impl ProxyFilter for AllowlistFilter {
+    fn name(&self) -> &'static str {
+        "allowlist"
+    }
+
+    fn evaluate(&self, request: &FilterRequest) -> Decision {
+        // Metadata requests (no version) — skip, let through
+        let version = match &request.version {
+            Some(v) => v,
+            None => return Decision::Skip,
+        };
+
+        let key = (
+            request.registry.to_string(),
+            request.name.clone(),
+            version.clone(),
+        );
+
+        match self.entries.get(&key) {
+            None => Decision::Block {
+                rule: "allowlist".to_string(),
+                reason: format!(
+                    "Package '{}@{}' ({}) not in allowlist",
+                    request.name, version, request.registry
+                ),
+            },
+            Some(entry) => {
+                if let Some(ref entry_hash) = entry.integrity {
+                    if let Some(ref req_hash) = request.integrity {
+                        if entry_hash != req_hash {
+                            return Decision::Block {
+                                rule: "allowlist:integrity".to_string(),
+                                reason: format!(
+                                    "Integrity mismatch for '{}@{}'",
+                                    request.name, version
+                                ),
+                            };
+                        }
+                    }
+                } else if self.require_integrity {
+                    return Decision::Block {
+                        rule: "allowlist:integrity".to_string(),
+                        reason: format!(
+                            "Entry '{}@{}' missing integrity hash (require_integrity=true)",
+                            request.name, version
+                        ),
+                    };
+                }
+                Decision::Allow
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Namespace Filter (issue #185)
+// ============================================================================
+
+/// Blocks packages matching internal namespace patterns.
+///
+/// This is a security boundary — always active regardless of curation mode.
+/// Prevents dependency confusion by ensuring internal packages are never
+/// proxied to upstream registries.
+pub struct NamespaceFilter {
+    patterns: Vec<String>,
+}
+
+impl NamespaceFilter {
+    pub fn new(patterns: Vec<String>) -> Self {
+        Self { patterns }
+    }
+
+    /// Number of configured patterns.
+    pub fn pattern_count(&self) -> usize {
+        self.patterns.len()
+    }
+}
+
+impl ProxyFilter for NamespaceFilter {
+    fn name(&self) -> &'static str {
+        "namespace"
+    }
+
+    fn evaluate(&self, request: &FilterRequest) -> Decision {
+        for pattern in &self.patterns {
+            if glob_match(pattern, &request.name) {
+                return Decision::Block {
+                    rule: "namespace".to_string(),
+                    reason: format!(
+                        "Package '{}' matches internal namespace '{}'",
+                        request.name, pattern
+                    ),
+                };
+            }
+        }
+        Decision::Skip
     }
 }
 
@@ -729,5 +1174,1125 @@ mod tests {
 
         assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 2);
         assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 2);
+    }
+
+    // ================================================================
+    // Blocklist tests (issue #185)
+    // ================================================================
+
+    // ---- glob_match ----
+
+    #[test]
+    fn test_glob_match_star() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("*", ""));
+    }
+
+    #[test]
+    fn test_glob_match_exact() {
+        assert!(glob_match("lodash", "lodash"));
+        assert!(!glob_match("lodash", "express"));
+    }
+
+    #[test]
+    fn test_glob_match_prefix() {
+        assert!(glob_match("foo*", "foobar"));
+        assert!(glob_match("foo*", "foo"));
+        assert!(!glob_match("foo*", "barfoo"));
+    }
+
+    #[test]
+    fn test_glob_match_suffix() {
+        assert!(glob_match("*bar", "foobar"));
+        assert!(glob_match("*bar", "bar"));
+        assert!(!glob_match("*bar", "barbaz"));
+    }
+
+    // ---- BlocklistFilter::from_file ----
+
+    fn write_blocklist(dir: &std::path::Path, content: &str) -> String {
+        let path = dir.join("blocklist.json");
+        std::fs::write(&path, content).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    #[test]
+    fn test_blocklist_load_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_blocklist(
+            dir.path(),
+            r#"{"version": 1, "rules": [{"registry": "npm", "name": "evil", "version": "*", "reason": "bad"}]}"#,
+        );
+        let filter = BlocklistFilter::from_file(&path).unwrap();
+        assert_eq!(filter.rule_count(), 1);
+    }
+
+    #[test]
+    fn test_blocklist_load_empty_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_blocklist(dir.path(), r#"{"version": 1, "rules": []}"#);
+        let filter = BlocklistFilter::from_file(&path).unwrap();
+        assert_eq!(filter.rule_count(), 0);
+    }
+
+    #[test]
+    fn test_blocklist_load_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_blocklist(dir.path(), "not json");
+        let err = BlocklistFilter::from_file(&path).unwrap_err();
+        assert!(err.contains("failed to parse"));
+    }
+
+    #[test]
+    fn test_blocklist_load_missing_file() {
+        let err = BlocklistFilter::from_file("/nonexistent/blocklist.json").unwrap_err();
+        assert!(err.contains("failed to read"));
+    }
+
+    #[test]
+    fn test_blocklist_load_wrong_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_blocklist(dir.path(), r#"{"version": 99, "rules": []}"#);
+        let err = BlocklistFilter::from_file(&path).unwrap_err();
+        assert!(err.contains("unsupported blocklist version 99"));
+    }
+
+    // ---- BlocklistFilter::evaluate ----
+
+    fn make_blocklist(rules: Vec<BlocklistRule>) -> BlocklistFilter {
+        BlocklistFilter { rules }
+    }
+
+    fn make_request_with_registry(
+        registry: RegistryType,
+        name: &str,
+        version: Option<&str>,
+    ) -> FilterRequest {
+        FilterRequest {
+            registry,
+            upstream: None,
+            name: name.to_string(),
+            version: version.map(|v| v.to_string()),
+            integrity: None,
+            bypass: false,
+        }
+    }
+
+    #[test]
+    fn test_blocklist_exact_match() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "event-stream".to_string(),
+            version: "*".to_string(),
+            reason: "supply chain attack".to_string(),
+        }]);
+        let req = make_request_with_registry(RegistryType::Npm, "event-stream", Some("1.0.0"));
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_blocklist_no_match_different_name() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "event-stream".to_string(),
+            version: "*".to_string(),
+            reason: "supply chain attack".to_string(),
+        }]);
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.0.0"));
+        assert_eq!(filter.evaluate(&req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_registry_mismatch() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "evil".to_string(),
+            version: "*".to_string(),
+            reason: "bad".to_string(),
+        }]);
+        let req = make_request_with_registry(RegistryType::PyPI, "evil", Some("1.0.0"));
+        assert_eq!(filter.evaluate(&req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_registry_wildcard() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "*".to_string(),
+            name: "evil-package".to_string(),
+            version: "*".to_string(),
+            reason: "malware".to_string(),
+        }]);
+        // Should match any registry
+        let npm_req = make_request_with_registry(RegistryType::Npm, "evil-package", Some("1.0.0"));
+        assert!(matches!(filter.evaluate(&npm_req), Decision::Block { .. }));
+
+        let pypi_req =
+            make_request_with_registry(RegistryType::PyPI, "evil-package", Some("1.0.0"));
+        assert!(matches!(filter.evaluate(&pypi_req), Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_blocklist_name_prefix_glob() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "evil-*".to_string(),
+            version: "*".to_string(),
+            reason: "evil prefix".to_string(),
+        }]);
+        let req = make_request_with_registry(RegistryType::Npm, "evil-package", Some("1.0.0"));
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let safe_req = make_request_with_registry(RegistryType::Npm, "good-package", Some("1.0.0"));
+        assert_eq!(filter.evaluate(&safe_req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_name_suffix_glob() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "*".to_string(),
+            name: "*-malware".to_string(),
+            version: "*".to_string(),
+            reason: "malware suffix".to_string(),
+        }]);
+        let req = make_request_with_registry(RegistryType::Cargo, "pkg-malware", Some("0.1.0"));
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let safe_req =
+            make_request_with_registry(RegistryType::Cargo, "malware-detector", Some("0.1.0"));
+        assert_eq!(filter.evaluate(&safe_req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_exact_version() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "lodash".to_string(),
+            version: "4.17.20".to_string(),
+            reason: "prototype pollution".to_string(),
+        }]);
+        // Matching version
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.20"));
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        // Different version — not blocked
+        let req2 = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_version_none_matches_wildcard() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "evil".to_string(),
+            version: "*".to_string(),
+            reason: "bad".to_string(),
+        }]);
+        // No version in request, rule is "*" → should match
+        let req = make_request_with_registry(RegistryType::Npm, "evil", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_blocklist_version_none_no_match_exact() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "evil".to_string(),
+            version: "1.0.0".to_string(),
+            reason: "bad".to_string(),
+        }]);
+        // No version in request, rule requires exact "1.0.0" → no match
+        let req = make_request_with_registry(RegistryType::Npm, "evil", None);
+        assert_eq!(filter.evaluate(&req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_multiple_rules_first_match() {
+        let filter = make_blocklist(vec![
+            BlocklistRule {
+                registry: "npm".to_string(),
+                name: "evil".to_string(),
+                version: "*".to_string(),
+                reason: "first rule".to_string(),
+            },
+            BlocklistRule {
+                registry: "*".to_string(),
+                name: "evil".to_string(),
+                version: "*".to_string(),
+                reason: "second rule".to_string(),
+            },
+        ]);
+        let req = make_request_with_registry(RegistryType::Npm, "evil", Some("1.0.0"));
+        match filter.evaluate(&req) {
+            Decision::Block { reason, .. } => assert_eq!(reason, "first rule"),
+            other => panic!("expected Block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_blocklist_empty_rules_skips() {
+        let filter = make_blocklist(vec![]);
+        let req = make_request_with_registry(RegistryType::Npm, "anything", Some("1.0.0"));
+        assert_eq!(filter.evaluate(&req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_blocklist_filter_name() {
+        let filter = make_blocklist(vec![]);
+        assert_eq!(filter.name(), "blocklist");
+    }
+
+    #[test]
+    fn test_blocklist_reason_in_decision() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "*".to_string(),
+            name: "bad".to_string(),
+            version: "*".to_string(),
+            reason: "CVE-2024-12345".to_string(),
+        }]);
+        let req = make_request_with_registry(RegistryType::Maven, "bad", Some("1.0"));
+        match filter.evaluate(&req) {
+            Decision::Block { rule, reason } => {
+                assert_eq!(rule, "blocklist");
+                assert_eq!(reason, "CVE-2024-12345");
+            }
+            other => panic!("expected Block, got {:?}", other),
+        }
+    }
+
+    // ---- Integration: BlocklistFilter in CurationEngine ----
+
+    #[test]
+    fn test_engine_with_blocklist_blocks() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_blocklist(
+            dir.path(),
+            r#"{"version": 1, "rules": [{"registry": "npm", "name": "evil", "version": "*", "reason": "blocked"}]}"#,
+        );
+        let filter = BlocklistFilter::from_file(&path).unwrap();
+
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(filter));
+
+        let result = engine.evaluate(&make_request("evil"));
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("blocklist".to_string()));
+    }
+
+    #[test]
+    fn test_engine_with_blocklist_skips_non_matching() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_blocklist(
+            dir.path(),
+            r#"{"version": 1, "rules": [{"registry": "npm", "name": "evil", "version": "*", "reason": "blocked"}]}"#,
+        );
+        let filter = BlocklistFilter::from_file(&path).unwrap();
+
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(filter));
+
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+    }
+
+    #[test]
+    fn test_engine_blocklist_audit_mode() {
+        let filter = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "evil".to_string(),
+            version: "*".to_string(),
+            reason: "bad".to_string(),
+        }]);
+
+        let mut engine = CurationEngine::new(audit_config());
+        engine.add_filter(Box::new(filter));
+
+        let result = engine.evaluate(&make_request("evil"));
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert!(result.audited);
+    }
+
+    // ================================================================
+    // glob_match ** tests (issue #185)
+    // ================================================================
+
+    #[test]
+    fn test_glob_match_double_star_dot_matches_nested() {
+        assert!(glob_match("com.company.**", "com.company.utils"));
+        assert!(glob_match("com.company.**", "com.company.utils.strings"));
+        assert!(glob_match("com.company.**", "com.company"));
+    }
+
+    #[test]
+    fn test_glob_match_double_star_dot_no_match() {
+        assert!(!glob_match("com.company.**", "com.other"));
+        assert!(!glob_match("com.company.**", "company.utils"));
+    }
+
+    #[test]
+    fn test_glob_match_double_star_slash_matches_nested() {
+        assert!(glob_match("internal/**", "internal/pkg"));
+        assert!(glob_match("internal/**", "internal/pkg/sub"));
+        assert!(glob_match("internal/**", "internal"));
+    }
+
+    #[test]
+    fn test_glob_match_double_star_slash_no_match() {
+        assert!(!glob_match("internal/**", "external/pkg"));
+        assert!(!glob_match("internal/**", "internals/pkg"));
+    }
+
+    // ================================================================
+    // NamespaceFilter tests (issue #185)
+    // ================================================================
+
+    fn make_ns_filter(patterns: &[&str]) -> NamespaceFilter {
+        NamespaceFilter::new(patterns.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn test_ns_filter_npm_scope() {
+        let filter = make_ns_filter(&["@company/*"]);
+        let req = make_request_with_registry(RegistryType::Npm, "@company/utils", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let req2 = make_request_with_registry(RegistryType::Npm, "@other/utils", None);
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_maven_groupid() {
+        let filter = make_ns_filter(&["com.company.**"]);
+        let req = make_request_with_registry(RegistryType::Maven, "com.company.auth", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let req2 = make_request_with_registry(RegistryType::Maven, "org.apache.commons", None);
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_cargo_prefix() {
+        let filter = make_ns_filter(&["company-*"]);
+        let req = make_request_with_registry(RegistryType::Cargo, "company-cli", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let req2 = make_request_with_registry(RegistryType::Cargo, "other-cli", None);
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_docker_prefix() {
+        let filter = make_ns_filter(&["internal/*"]);
+        let req = make_request_with_registry(RegistryType::Docker, "internal/myapp", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let req2 = make_request_with_registry(RegistryType::Docker, "public/myapp", None);
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_go_module() {
+        let filter = make_ns_filter(&["go.company.com/**"]);
+        let req = make_request_with_registry(RegistryType::Go, "go.company.com/pkg", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let req2 = make_request_with_registry(RegistryType::Go, "github.com/other", None);
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_exact_match() {
+        let filter = make_ns_filter(&["secret-tool"]);
+        let req = make_request_with_registry(RegistryType::Npm, "secret-tool", None);
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+
+        let req2 = make_request_with_registry(RegistryType::Npm, "secret-tool-extra", None);
+        assert_eq!(filter.evaluate(&req2), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_empty_patterns_always_skip() {
+        let filter = make_ns_filter(&[]);
+        let req = make_request_with_registry(RegistryType::Npm, "anything", None);
+        assert_eq!(filter.evaluate(&req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_ns_filter_multiple_patterns_first_match_wins() {
+        let filter = make_ns_filter(&["@company/*", "internal-*"]);
+        let req = make_request_with_registry(RegistryType::Npm, "@company/utils", None);
+        match filter.evaluate(&req) {
+            Decision::Block { reason, .. } => {
+                assert!(reason.contains("@company/*"));
+            }
+            other => panic!("expected Block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_ns_filter_name() {
+        let filter = make_ns_filter(&[]);
+        assert_eq!(filter.name(), "namespace");
+    }
+
+    #[test]
+    fn test_ns_filter_pattern_count() {
+        let filter = make_ns_filter(&["a", "b", "c"]);
+        assert_eq!(filter.pattern_count(), 3);
+    }
+
+    // ================================================================
+    // Engine + NamespaceFilter integration (issue #185)
+    // ================================================================
+
+    #[test]
+    fn test_engine_namespace_blocks_in_off_mode() {
+        let mut engine = CurationEngine::new(CurationConfig::default()); // mode=Off
+        engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
+
+        let req = make_request_with_registry(RegistryType::Npm, "@internal/secret", None);
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("namespace".to_string()));
+        assert!(!result.audited);
+    }
+
+    #[test]
+    fn test_engine_namespace_blocks_in_off_mode_no_filters() {
+        let mut engine = CurationEngine::new(CurationConfig::default());
+        // No regular filters, only namespace
+        engine.set_namespace_filter(Box::new(make_ns_filter(&["company-*"])));
+
+        let req = make_request_with_registry(RegistryType::Cargo, "company-core", None);
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_engine_namespace_blocks_before_bypass() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
+        engine.add_filter(Box::new(AllowAllFilter));
+
+        // Even with bypass=true, namespace blocks
+        let mut req = make_request_with_registry(RegistryType::Npm, "@internal/secret", None);
+        req.bypass = true;
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("namespace".to_string()));
+    }
+
+    #[test]
+    fn test_engine_namespace_skip_continues_to_chain() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
+        engine.add_filter(Box::new(BlockPackageFilter {
+            target: "evil-pkg".to_string(),
+        }));
+
+        // Not matching namespace → continues to blocklist
+        let req = make_request_with_registry(RegistryType::Npm, "evil-pkg", Some("1.0.0"));
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("block-package".to_string()));
+    }
+
+    #[test]
+    fn test_engine_namespace_block_increments_blocked_metric() {
+        let mut engine = CurationEngine::new(CurationConfig::default()); // mode=Off
+        engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
+
+        let req = make_request_with_registry(RegistryType::Npm, "@internal/foo", None);
+        engine.evaluate(&req);
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 1);
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_engine_namespace_not_audited_even_in_audit_mode() {
+        let mut engine = CurationEngine::new(audit_config());
+        engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
+
+        let req = make_request_with_registry(RegistryType::Npm, "@internal/foo", None);
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert!(!result.audited); // namespace blocks are NEVER audit-only
+    }
+
+    // ================================================================
+    // AllowlistFilter tests (issue #188)
+    // ================================================================
+
+    fn write_allowlist(dir: &std::path::Path, content: &str) -> String {
+        let path = dir.join("allowlist.json");
+        std::fs::write(&path, content).unwrap();
+        path.to_string_lossy().to_string()
+    }
+
+    fn make_allowlist_entries(
+        entries: Vec<AllowlistEntry>,
+        require_integrity: bool,
+    ) -> AllowlistFilter {
+        let mut map = std::collections::HashMap::new();
+        for entry in entries {
+            let key = (
+                entry.registry.clone(),
+                entry.name.clone(),
+                entry.version.clone(),
+            );
+            map.insert(key, entry);
+        }
+        AllowlistFilter {
+            entries: map,
+            require_integrity,
+        }
+    }
+
+    // ---- from_file tests ----
+
+    #[test]
+    fn test_allowlist_load_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_allowlist(
+            dir.path(),
+            r#"{"version": 1, "entries": [
+                {"registry": "npm", "name": "lodash", "version": "4.17.21"},
+                {"registry": "pypi", "name": "requests", "version": "2.31.0", "integrity": "sha256:abc"}
+            ]}"#,
+        );
+        let filter = AllowlistFilter::from_file(&path, false).unwrap();
+        assert_eq!(filter.entry_count(), 2);
+    }
+
+    #[test]
+    fn test_allowlist_load_empty_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_allowlist(dir.path(), r#"{"version": 1, "entries": []}"#);
+        let filter = AllowlistFilter::from_file(&path, false).unwrap();
+        assert_eq!(filter.entry_count(), 0);
+    }
+
+    #[test]
+    fn test_allowlist_load_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_allowlist(dir.path(), "not json at all");
+        let err = AllowlistFilter::from_file(&path, false).unwrap_err();
+        assert!(err.contains("failed to parse"));
+    }
+
+    #[test]
+    fn test_allowlist_load_missing_file() {
+        let err = AllowlistFilter::from_file("/nonexistent/allowlist.json", false).unwrap_err();
+        assert!(err.contains("failed to read"));
+    }
+
+    #[test]
+    fn test_allowlist_load_wrong_version() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_allowlist(dir.path(), r#"{"version": 99, "entries": []}"#);
+        let err = AllowlistFilter::from_file(&path, false).unwrap_err();
+        assert!(err.contains("unsupported allowlist version 99"));
+    }
+
+    // ---- evaluate: allow/block tests ----
+
+    #[test]
+    fn test_allowlist_exact_match_allows() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false,
+        );
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        assert_eq!(filter.evaluate(&req), Decision::Allow);
+    }
+
+    #[test]
+    fn test_allowlist_not_found_blocks() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false,
+        );
+        let req = make_request_with_registry(RegistryType::Npm, "express", Some("4.18.0"));
+        match filter.evaluate(&req) {
+            Decision::Block { rule, reason } => {
+                assert_eq!(rule, "allowlist");
+                assert!(reason.contains("not in allowlist"));
+            }
+            other => panic!("expected Block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_allowlist_metadata_request_skips() {
+        let filter = make_allowlist_entries(vec![], false);
+        // version=None → metadata request → Skip
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", None);
+        assert_eq!(filter.evaluate(&req), Decision::Skip);
+    }
+
+    #[test]
+    fn test_allowlist_registry_mismatch_blocks() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false,
+        );
+        // Same name+version but different registry → not found
+        let req = make_request_with_registry(RegistryType::PyPI, "lodash", Some("4.17.21"));
+        assert!(matches!(filter.evaluate(&req), Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_allowlist_same_name_different_registry_scoped() {
+        let filter = make_allowlist_entries(
+            vec![
+                AllowlistEntry {
+                    registry: "npm".to_string(),
+                    name: "utils".to_string(),
+                    version: "1.0.0".to_string(),
+                    integrity: None,
+                    integrity_source: None,
+                },
+                AllowlistEntry {
+                    registry: "pypi".to_string(),
+                    name: "utils".to_string(),
+                    version: "2.0.0".to_string(),
+                    integrity: None,
+                    integrity_source: None,
+                },
+            ],
+            false,
+        );
+        // npm utils@1.0.0 → Allow
+        let req1 = make_request_with_registry(RegistryType::Npm, "utils", Some("1.0.0"));
+        assert_eq!(filter.evaluate(&req1), Decision::Allow);
+
+        // pypi utils@2.0.0 → Allow
+        let req2 = make_request_with_registry(RegistryType::PyPI, "utils", Some("2.0.0"));
+        assert_eq!(filter.evaluate(&req2), Decision::Allow);
+
+        // pypi utils@1.0.0 → Block (wrong version for pypi)
+        let req3 = make_request_with_registry(RegistryType::PyPI, "utils", Some("1.0.0"));
+        assert!(matches!(filter.evaluate(&req3), Decision::Block { .. }));
+    }
+
+    // ---- evaluate: integrity tests ----
+
+    #[test]
+    fn test_allowlist_integrity_match_allows() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: Some("sha256-abc123".to_string()),
+                integrity_source: Some("upstream".to_string()),
+            }],
+            false,
+        );
+        let mut req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        req.integrity = Some("sha256-abc123".to_string());
+        assert_eq!(filter.evaluate(&req), Decision::Allow);
+    }
+
+    #[test]
+    fn test_allowlist_integrity_mismatch_blocks() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: Some("sha256-abc123".to_string()),
+                integrity_source: None,
+            }],
+            false,
+        );
+        let mut req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        req.integrity = Some("sha256-TAMPERED".to_string());
+        match filter.evaluate(&req) {
+            Decision::Block { rule, reason } => {
+                assert_eq!(rule, "allowlist:integrity");
+                assert!(reason.contains("Integrity mismatch"));
+            }
+            other => panic!("expected Block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_allowlist_entry_has_integrity_request_doesnt_allows() {
+        // Client limitation: client may not provide integrity → still allow
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: Some("sha256-abc123".to_string()),
+                integrity_source: None,
+            }],
+            false,
+        );
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        // req.integrity is None by default from make_request_with_registry
+        assert_eq!(filter.evaluate(&req), Decision::Allow);
+    }
+
+    #[test]
+    fn test_allowlist_require_integrity_missing_blocks() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None, // no integrity hash on entry
+                integrity_source: None,
+            }],
+            true, // require_integrity=true
+        );
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        match filter.evaluate(&req) {
+            Decision::Block { rule, reason } => {
+                assert_eq!(rule, "allowlist:integrity");
+                assert!(reason.contains("missing integrity hash"));
+            }
+            other => panic!("expected Block, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_allowlist_require_integrity_false_missing_allows() {
+        let filter = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false, // require_integrity=false
+        );
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        assert_eq!(filter.evaluate(&req), Decision::Allow);
+    }
+
+    // ---- Engine integration tests ----
+
+    #[test]
+    fn test_engine_blocklist_before_allowlist_blocks() {
+        // Package on both blocklist and allowlist → blocklist wins (evaluated first)
+        let blocklist = make_blocklist(vec![BlocklistRule {
+            registry: "npm".to_string(),
+            name: "lodash".to_string(),
+            version: "4.17.20".to_string(),
+            reason: "CVE-2021-xxxxx".to_string(),
+        }]);
+        let allowlist = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.20".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false,
+        );
+
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(blocklist));
+        engine.add_filter(Box::new(allowlist));
+
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.20"));
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("blocklist".to_string()));
+    }
+
+    #[test]
+    fn test_engine_allowlist_enforce_unknown_blocks() {
+        let allowlist = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false,
+        );
+
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(allowlist));
+
+        // Unknown package → blocked
+        let req = make_request_with_registry(RegistryType::Npm, "unknown-pkg", Some("1.0.0"));
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("allowlist".to_string()));
+        assert!(!result.audited);
+    }
+
+    #[test]
+    fn test_engine_allowlist_audit_unknown_audited() {
+        let allowlist = make_allowlist_entries(
+            vec![AllowlistEntry {
+                registry: "npm".to_string(),
+                name: "lodash".to_string(),
+                version: "4.17.21".to_string(),
+                integrity: None,
+                integrity_source: None,
+            }],
+            false,
+        );
+
+        let mut engine = CurationEngine::new(audit_config());
+        engine.add_filter(Box::new(allowlist));
+
+        let req = make_request_with_registry(RegistryType::Npm, "unknown-pkg", Some("1.0.0"));
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert!(result.audited);
+    }
+
+    #[test]
+    fn test_engine_empty_allowlist_blocks_everything() {
+        let allowlist = make_allowlist_entries(vec![], false);
+
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(allowlist));
+
+        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        let result = engine.evaluate(&req);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_allowlist_filter_name() {
+        let filter = make_allowlist_entries(vec![], false);
+        assert_eq!(filter.name(), "allowlist");
+    }
+
+    // ================================================================
+    // check_download() tests (issue #187)
+    // ================================================================
+
+    fn make_headers(pairs: &[(&str, &str)]) -> axum::http::HeaderMap {
+        let mut map = axum::http::HeaderMap::new();
+        for (k, v) in pairs {
+            map.insert(
+                axum::http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        map
+    }
+
+    #[test]
+    fn test_check_download_off_mode_returns_none() {
+        let engine = CurationEngine::new(CurationConfig::default());
+        let headers = axum::http::HeaderMap::new();
+        let result = super::check_download(
+            &engine,
+            None,
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_download_enforce_block_returns_403() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let headers = axum::http::HeaderMap::new();
+        let result = super::check_download(
+            &engine,
+            None,
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_some());
+        let response = result.unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_check_download_audit_block_returns_none() {
+        let mut engine = CurationEngine::new(audit_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let headers = axum::http::HeaderMap::new();
+        let result = super::check_download(
+            &engine,
+            None,
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_download_bypass_token_matches() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let headers = make_headers(&[("x-nora-bypass-token", "secret123")]);
+        let result = super::check_download(
+            &engine,
+            Some("secret123"),
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_download_bypass_token_mismatch() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let headers = make_headers(&[("x-nora-bypass-token", "wrong")]);
+        let result = super::check_download(
+            &engine,
+            Some("secret123"),
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_check_download_no_bypass_configured() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let headers = make_headers(&[("x-nora-bypass-token", "anything")]);
+        let result = super::check_download(
+            &engine,
+            None,
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_check_download_no_version_metadata() {
+        let engine = CurationEngine::new(enforce_config());
+        // No filters → all Skip → Allow
+        let headers = axum::http::HeaderMap::new();
+        let result =
+            super::check_download(&engine, None, &headers, RegistryType::Npm, "lodash", None);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_download_enforce_no_filters_allows() {
+        let engine = CurationEngine::new(enforce_config());
+        let headers = axum::http::HeaderMap::new();
+        let result = super::check_download(
+            &engine,
+            None,
+            &headers,
+            RegistryType::Cargo,
+            "serde",
+            Some("1.0.0"),
+        );
+        assert!(result.is_none());
+    }
+
+    // ================================================================
+    // Version parser tests (issue #187)
+    // ================================================================
+
+    #[test]
+    fn test_parse_npm_tarball_version_regular() {
+        assert_eq!(
+            super::parse_npm_tarball_version("lodash", "lodash-4.17.21.tgz"),
+            Some("4.17.21".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_npm_tarball_version_scoped() {
+        assert_eq!(
+            super::parse_npm_tarball_version("@babel/core", "core-7.26.0.tgz"),
+            Some("7.26.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_npm_tarball_version_no_tgz() {
+        assert_eq!(
+            super::parse_npm_tarball_version("lodash", "lodash-4.17.21"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_npm_tarball_version_wrong_name() {
+        assert_eq!(
+            super::parse_npm_tarball_version("lodash", "express-4.18.0.tgz"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_parse_pypi_version_sdist() {
+        assert_eq!(
+            super::parse_pypi_version("flask", "Flask-2.0.0.tar.gz"),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pypi_version_wheel() {
+        assert_eq!(
+            super::parse_pypi_version("flask", "flask-2.0.0-py3-none-any.whl"),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pypi_version_hyphen_name() {
+        assert_eq!(
+            super::parse_pypi_version("my-package", "my_package-1.2.3.tar.gz"),
+            Some("1.2.3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_pypi_version_no_ext() {
+        assert_eq!(super::parse_pypi_version("flask", "flask-2.0.0"), None);
+    }
+
+    #[test]
+    fn test_parse_pypi_version_zip() {
+        assert_eq!(
+            super::parse_pypi_version("requests", "requests-2.31.0.zip"),
+            Some("2.31.0".to_string())
+        );
     }
 }

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -329,6 +329,73 @@ pub fn check_download(
     }
 }
 
+/// Verify artifact integrity after download (post-download phase, issue #189).
+///
+/// Computes SHA-256 of `data`, then runs curation evaluation with the hash
+/// filled in `FilterRequest.integrity`. This catches integrity mismatches
+/// against allowlist entries.
+///
+/// Returns `Some(Response)` if integrity check fails (403), `None` to proceed.
+pub fn verify_integrity(
+    engine: &CurationEngine,
+    registry: RegistryType,
+    name: &str,
+    version: Option<&str>,
+    data: &[u8],
+) -> Option<Response> {
+    // Only run if curation is active (not Off)
+    if !engine.is_active() {
+        return None;
+    }
+
+    use sha2::Digest;
+    let hash = sha2::Sha256::digest(data);
+    let integrity = format!("sha256:{}", hex::encode(hash));
+
+    let request = FilterRequest {
+        registry,
+        upstream: None,
+        name: name.to_string(),
+        version: version.map(|v| v.to_string()),
+        integrity: Some(integrity),
+        bypass: false, // bypass already checked in pre-download phase
+    };
+
+    let result = engine.evaluate(&request);
+
+    match &result.decision {
+        Decision::Block { rule, reason } => {
+            // Only act on integrity-related blocks
+            if !rule.contains("integrity") {
+                return None;
+            }
+            if result.audited {
+                tracing::info!(
+                    registry = %registry,
+                    package = %name,
+                    version = version.unwrap_or("*"),
+                    rule = %rule,
+                    reason = %reason,
+                    "[AUDIT] Integrity check would block download"
+                );
+                None
+            } else {
+                Some(
+                    BlockedResponse {
+                        rule: rule.clone(),
+                        reason: reason.clone(),
+                        registry: registry.to_string(),
+                        package: name.to_string(),
+                        version: version.map(|v| v.to_string()),
+                    }
+                    .into_response(),
+                )
+            }
+        }
+        Decision::Allow | Decision::Skip => None,
+    }
+}
+
 // ============================================================================
 // Version parsers for filename-based registries (issue #187)
 // ============================================================================
@@ -687,26 +754,29 @@ impl ProxyFilter for AllowlistFilter {
                 ),
             },
             Some(entry) => {
-                if let Some(ref entry_hash) = entry.integrity {
-                    if let Some(ref req_hash) = request.integrity {
-                        if entry_hash != req_hash {
+                // Integrity check only runs when request provides a hash
+                // (post-download phase). Pre-download checks pass integrity=None
+                // and skip this entirely.
+                if let Some(ref actual_hash) = request.integrity {
+                    if let Some(ref expected_hash) = entry.integrity {
+                        if actual_hash != expected_hash {
                             return Decision::Block {
                                 rule: "allowlist:integrity".to_string(),
                                 reason: format!(
-                                    "Integrity mismatch for '{}@{}'",
-                                    request.name, version
+                                    "Integrity mismatch for '{}@{}': expected {}, got {}",
+                                    request.name, version, expected_hash, actual_hash
                                 ),
                             };
                         }
+                    } else if self.require_integrity {
+                        return Decision::Block {
+                            rule: "allowlist:integrity".to_string(),
+                            reason: format!(
+                                "Allowlist entry '{}@{}' missing integrity hash (require_integrity=true)",
+                                request.name, version
+                            ),
+                        };
                     }
-                } else if self.require_integrity {
-                    return Decision::Block {
-                        rule: "allowlist:integrity".to_string(),
-                        reason: format!(
-                            "Entry '{}@{}' missing integrity hash (require_integrity=true)",
-                            request.name, version
-                        ),
-                    };
                 }
                 Decision::Allow
             }
@@ -768,6 +838,7 @@ impl ProxyFilter for NamespaceFilter {
 mod tests {
     use super::*;
     use crate::config::{CurationConfig, CurationMode, CurationOnFailure};
+    use sha2::Digest;
 
     /// A test filter that always allows.
     struct AllowAllFilter;
@@ -1954,6 +2025,7 @@ mod tests {
 
     #[test]
     fn test_allowlist_require_integrity_missing_blocks() {
+        // require_integrity=true + entry without integrity + post-download (integrity provided) → block
         let filter = make_allowlist_entries(
             vec![AllowlistEntry {
                 registry: "npm".to_string(),
@@ -1964,7 +2036,15 @@ mod tests {
             }],
             true, // require_integrity=true
         );
-        let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
+        // Post-download request: integrity is provided (computed from downloaded data)
+        let req = FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: "lodash".to_string(),
+            version: Some("4.17.21".to_string()),
+            integrity: Some("sha256:abc123".to_string()),
+            bypass: false,
+        };
         match filter.evaluate(&req) {
             Decision::Block { rule, reason } => {
                 assert_eq!(rule, "allowlist:integrity");
@@ -2293,6 +2373,188 @@ mod tests {
         assert_eq!(
             super::parse_pypi_version("requests", "requests-2.31.0.zip"),
             Some("2.31.0".to_string())
+        );
+    }
+
+    // ── verify_integrity tests (issue #189) ─────────────────────────────
+
+    #[test]
+    fn test_verify_integrity_mode_off_returns_none() {
+        let engine = super::CurationEngine::new(CurationConfig::default());
+        let result = super::verify_integrity(
+            &engine,
+            super::RegistryType::Cargo,
+            "my-crate",
+            Some("1.0.0"),
+            b"some data",
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_verify_integrity_matching_hash() {
+        let hash = format!(
+            "sha256:{}",
+            hex::encode(sha2::Sha256::digest(b"crate-data"))
+        );
+        let allowlist_json = serde_json::json!({
+            "version": 1,
+            "entries": [{
+                "registry": "cargo",
+                "name": "my-crate",
+                "version": "1.0.0",
+                "integrity": hash,
+                "integrity_source": "manual"
+            }]
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("allowlist.json");
+        std::fs::write(&path, serde_json::to_string(&allowlist_json).unwrap()).unwrap();
+
+        let mut config = CurationConfig::default();
+        config.mode = super::super::config::CurationMode::Enforce;
+        let mut engine = super::CurationEngine::new(config);
+        let filter = super::AllowlistFilter::from_file(path.to_str().unwrap(), false).unwrap();
+        engine.add_filter(Box::new(filter));
+
+        let result = super::verify_integrity(
+            &engine,
+            super::RegistryType::Cargo,
+            "my-crate",
+            Some("1.0.0"),
+            b"crate-data",
+        );
+        assert!(result.is_none(), "matching hash should pass");
+    }
+
+    #[test]
+    fn test_verify_integrity_mismatched_hash() {
+        let allowlist_json = serde_json::json!({
+            "version": 1,
+            "entries": [{
+                "registry": "cargo",
+                "name": "my-crate",
+                "version": "1.0.0",
+                "integrity": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+                "integrity_source": "manual"
+            }]
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("allowlist.json");
+        std::fs::write(&path, serde_json::to_string(&allowlist_json).unwrap()).unwrap();
+
+        let mut config = CurationConfig::default();
+        config.mode = super::super::config::CurationMode::Enforce;
+        let mut engine = super::CurationEngine::new(config);
+        let filter = super::AllowlistFilter::from_file(path.to_str().unwrap(), false).unwrap();
+        engine.add_filter(Box::new(filter));
+
+        let result = super::verify_integrity(
+            &engine,
+            super::RegistryType::Cargo,
+            "my-crate",
+            Some("1.0.0"),
+            b"tampered-data",
+        );
+        assert!(result.is_some(), "mismatched hash should block");
+    }
+
+    #[test]
+    fn test_verify_integrity_no_hash_in_entry_passes() {
+        // Allowlist entry without integrity — verify_integrity should pass
+        let allowlist_json = serde_json::json!({
+            "version": 1,
+            "entries": [{
+                "registry": "cargo",
+                "name": "my-crate",
+                "version": "1.0.0"
+            }]
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("allowlist.json");
+        std::fs::write(&path, serde_json::to_string(&allowlist_json).unwrap()).unwrap();
+
+        let mut config = CurationConfig::default();
+        config.mode = super::super::config::CurationMode::Enforce;
+        let mut engine = super::CurationEngine::new(config);
+        let filter = super::AllowlistFilter::from_file(path.to_str().unwrap(), false).unwrap();
+        engine.add_filter(Box::new(filter));
+
+        let result = super::verify_integrity(
+            &engine,
+            super::RegistryType::Cargo,
+            "my-crate",
+            Some("1.0.0"),
+            b"any-data",
+        );
+        assert!(result.is_none(), "no integrity in entry → pass");
+    }
+
+    #[test]
+    fn test_allowlist_pre_download_no_integrity_passes() {
+        // Pre-download check (integrity=None) should NOT block on require_integrity
+        let hash = "sha256:abc123";
+        let allowlist_json = serde_json::json!({
+            "version": 1,
+            "entries": [{
+                "registry": "cargo",
+                "name": "my-crate",
+                "version": "1.0.0",
+                "integrity": hash,
+                "integrity_source": "manual"
+            }]
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("allowlist.json");
+        std::fs::write(&path, serde_json::to_string(&allowlist_json).unwrap()).unwrap();
+
+        // require_integrity=true, but pre-download has no integrity → should STILL allow
+        let filter = super::AllowlistFilter::from_file(path.to_str().unwrap(), true).unwrap();
+        let request = super::FilterRequest {
+            registry: super::RegistryType::Cargo,
+            upstream: None,
+            name: "my-crate".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: None, // pre-download: no integrity
+            bypass: false,
+        };
+        let decision = filter.evaluate(&request);
+        assert!(
+            matches!(decision, super::Decision::Allow),
+            "pre-download with integrity=None must not block: got {:?}",
+            decision
+        );
+    }
+
+    #[test]
+    fn test_allowlist_post_download_require_integrity_blocks_missing() {
+        // Post-download check with require_integrity but entry has no hash → block
+        let allowlist_json = serde_json::json!({
+            "version": 1,
+            "entries": [{
+                "registry": "cargo",
+                "name": "my-crate",
+                "version": "1.0.0"
+            }]
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("allowlist.json");
+        std::fs::write(&path, serde_json::to_string(&allowlist_json).unwrap()).unwrap();
+
+        let filter = super::AllowlistFilter::from_file(path.to_str().unwrap(), true).unwrap();
+        let request = super::FilterRequest {
+            registry: super::RegistryType::Cargo,
+            upstream: None,
+            name: "my-crate".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: Some("sha256:abc123".to_string()), // post-download: has integrity
+            bypass: false,
+        };
+        let decision = filter.evaluate(&request);
+        assert!(
+            matches!(decision, super::Decision::Block { .. }),
+            "require_integrity + entry without hash + post-download → block: got {:?}",
+            decision
         );
     }
 }

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -1,0 +1,733 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! Curation layer — package access control for proxy registries.
+//!
+//! This module provides the skeleton for the curation filter chain:
+//! - [`ProxyFilter`] trait that individual filters implement
+//! - [`CurationEngine`] that evaluates a chain of filters
+//! - [`BlockedResponse`] for generating 403 responses
+//! - [`CurationMetrics`] for raw counters
+//!
+//! Issue #184 — config skeleton + trait. No actual filters yet.
+
+use crate::config::{CurationConfig, CurationMode};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+// ============================================================================
+// Registry Type
+// ============================================================================
+
+/// Supported registry formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RegistryType {
+    Npm,
+    PyPI,
+    Maven,
+    Cargo,
+    Go,
+    Docker,
+    Raw,
+}
+
+impl fmt::Display for RegistryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RegistryType::Npm => write!(f, "npm"),
+            RegistryType::PyPI => write!(f, "pypi"),
+            RegistryType::Maven => write!(f, "maven"),
+            RegistryType::Cargo => write!(f, "cargo"),
+            RegistryType::Go => write!(f, "go"),
+            RegistryType::Docker => write!(f, "docker"),
+            RegistryType::Raw => write!(f, "raw"),
+        }
+    }
+}
+
+// ============================================================================
+// Filter Request
+// ============================================================================
+
+/// Information about a package request, passed to each filter.
+#[derive(Debug, Clone)]
+pub struct FilterRequest {
+    /// Which registry format this request targets.
+    pub registry: RegistryType,
+    /// Upstream URL being proxied to (if any).
+    pub upstream: Option<String>,
+    /// Package/artifact name (e.g., "lodash", "com.google.guava:guava").
+    pub name: String,
+    /// Version string (e.g., "4.17.21", "33.0.0-jre").
+    pub version: Option<String>,
+    /// Integrity hash provided by the client (e.g., sha256 checksum).
+    pub integrity: Option<String>,
+    /// Whether the request carries a valid bypass token.
+    pub bypass: bool,
+}
+
+// ============================================================================
+// Decision
+// ============================================================================
+
+/// Outcome of a single filter evaluation.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    /// Explicitly allow this request.
+    Allow,
+    /// Block this request with a rule name and human-readable reason.
+    Block { rule: String, reason: String },
+    /// This filter has no opinion — continue to the next filter.
+    Skip,
+}
+
+// ============================================================================
+// ProxyFilter Trait
+// ============================================================================
+
+/// A synchronous filter that evaluates a package request.
+///
+/// Filters must be fast — they operate on in-memory data only, no I/O.
+/// Each filter returns [`Decision::Allow`], [`Decision::Block`], or
+/// [`Decision::Skip`] to defer to the next filter in the chain.
+pub trait ProxyFilter: Send + Sync {
+    /// Unique name of this filter (e.g., "blocklist", "allowlist").
+    fn name(&self) -> &'static str;
+
+    /// Evaluate a request and return a decision.
+    fn evaluate(&self, request: &FilterRequest) -> Decision;
+}
+
+// ============================================================================
+// Evaluation Result
+// ============================================================================
+
+/// Full result of running the filter chain.
+#[derive(Debug, Clone)]
+pub struct EvaluationResult {
+    /// The final decision after the chain ran.
+    pub decision: Decision,
+    /// Name of the filter that produced the decision (None if no filter matched).
+    pub decided_by: Option<String>,
+    /// Whether this result is audit-only (decision logged but not enforced).
+    pub audited: bool,
+}
+
+// ============================================================================
+// Curation Engine
+// ============================================================================
+
+/// The curation engine runs a chain of [`ProxyFilter`]s in order.
+pub struct CurationEngine {
+    config: CurationConfig,
+    filters: Vec<Box<dyn ProxyFilter>>,
+    metrics: CurationMetrics,
+}
+
+impl CurationEngine {
+    /// Create a new engine with no filters.
+    pub fn new(config: CurationConfig) -> Self {
+        Self {
+            config,
+            filters: Vec::new(),
+            metrics: CurationMetrics::new(),
+        }
+    }
+
+    /// Add a filter to the end of the chain.
+    /// Evaluation order = insertion order.
+    pub fn add_filter(&mut self, filter: Box<dyn ProxyFilter>) {
+        self.filters.push(filter);
+    }
+
+    /// Current operating mode.
+    pub fn mode(&self) -> &CurationMode {
+        &self.config.mode
+    }
+
+    /// Whether curation is active (not off).
+    pub fn is_active(&self) -> bool {
+        self.config.mode != CurationMode::Off
+    }
+
+    /// Access raw metrics counters.
+    pub fn metrics(&self) -> &CurationMetrics {
+        &self.metrics
+    }
+
+    /// Evaluate a request through the filter chain.
+    ///
+    /// - **Off**: returns Allow immediately, no filters run, no metrics.
+    /// - **Bypass**: returns Allow with a security warning log.
+    /// - **Chain**: first Block or Allow wins; Skip continues.
+    /// - **Audit**: Block decisions are returned with `audited=true`.
+    /// - **Enforce**: Block decisions are final.
+    /// - All Skip → Allow.
+    pub fn evaluate(&self, request: &FilterRequest) -> EvaluationResult {
+        // Mode=Off: no-op
+        if self.config.mode == CurationMode::Off {
+            return EvaluationResult {
+                decision: Decision::Allow,
+                decided_by: None,
+                audited: false,
+            };
+        }
+
+        // Bypass token
+        if request.bypass {
+            self.metrics.allowed.fetch_add(1, Ordering::Relaxed);
+            tracing::warn!(
+                registry = %request.registry,
+                package = %request.name,
+                "[SECURITY] Curation bypassed via token"
+            );
+            return EvaluationResult {
+                decision: Decision::Allow,
+                decided_by: Some("bypass".to_string()),
+                audited: false,
+            };
+        }
+
+        // Track integrity presence
+        if request.integrity.is_none() {
+            self.metrics
+                .without_integrity
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Run filter chain
+        for filter in &self.filters {
+            let decision = filter.evaluate(request);
+            match &decision {
+                Decision::Allow => {
+                    self.metrics.allowed.fetch_add(1, Ordering::Relaxed);
+                    return EvaluationResult {
+                        decision,
+                        decided_by: Some(filter.name().to_string()),
+                        audited: false,
+                    };
+                }
+                Decision::Block { .. } => {
+                    let audited = self.config.mode == CurationMode::Audit;
+                    if audited {
+                        self.metrics.allowed.fetch_add(1, Ordering::Relaxed);
+                    } else {
+                        self.metrics.blocked.fetch_add(1, Ordering::Relaxed);
+                    }
+                    return EvaluationResult {
+                        decision,
+                        decided_by: Some(filter.name().to_string()),
+                        audited,
+                    };
+                }
+                Decision::Skip => continue,
+            }
+        }
+
+        // All filters skipped → Allow
+        self.metrics.allowed.fetch_add(1, Ordering::Relaxed);
+        EvaluationResult {
+            decision: Decision::Allow,
+            decided_by: None,
+            audited: false,
+        }
+    }
+}
+
+// ============================================================================
+// Blocked Response (403 JSON)
+// ============================================================================
+
+/// A 403 response body for blocked requests.
+/// Used by registry handlers in #185-#189 when curation blocks a request.
+#[allow(dead_code)]
+pub struct BlockedResponse {
+    pub rule: String,
+    pub reason: String,
+    pub registry: String,
+    pub package: String,
+    pub version: Option<String>,
+}
+
+impl IntoResponse for BlockedResponse {
+    fn into_response(self) -> Response {
+        let version_str = self.version.as_deref().unwrap_or("*");
+        let body = serde_json::json!({
+            "error": "blocked_by_policy",
+            "error_version": "v1",
+            "context": {
+                "rule": self.rule,
+                "reason": self.reason,
+                "registry": self.registry,
+                "package": self.package,
+                "version": version_str,
+            },
+            "hint": format!("Run: nora curation explain {}@{}", self.package, version_str),
+            "docs": "https://docs.getnora.dev/curation"
+        });
+
+        let mut response = (StatusCode::FORBIDDEN, axum::Json(body)).into_response();
+        let headers = response.headers_mut();
+        // Safe to use expect: these are compile-time constant ASCII strings
+        headers.insert(
+            "x-nora-decision",
+            "blocked".parse().expect("valid header value"),
+        );
+        headers.insert(
+            "x-nora-rule",
+            self.rule
+                .parse()
+                .unwrap_or_else(|_| "unknown".parse().expect("valid header value")),
+        );
+        headers.insert(
+            "x-nora-reason",
+            self.reason
+                .parse()
+                .unwrap_or_else(|_| "unknown".parse().expect("valid header value")),
+        );
+        response
+    }
+}
+
+// ============================================================================
+// Metrics
+// ============================================================================
+
+/// Raw atomic counters for curation decisions. No Prometheus wiring yet.
+pub struct CurationMetrics {
+    pub blocked: AtomicU64,
+    pub allowed: AtomicU64,
+    pub without_integrity: AtomicU64,
+    pub cve_cache_miss: AtomicU64,
+}
+
+impl CurationMetrics {
+    fn new() -> Self {
+        Self {
+            blocked: AtomicU64::new(0),
+            allowed: AtomicU64::new(0),
+            without_integrity: AtomicU64::new(0),
+            cve_cache_miss: AtomicU64::new(0),
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::config::{CurationConfig, CurationMode, CurationOnFailure};
+
+    /// A test filter that always allows.
+    struct AllowAllFilter;
+    impl ProxyFilter for AllowAllFilter {
+        fn name(&self) -> &'static str {
+            "allow-all"
+        }
+        fn evaluate(&self, _request: &FilterRequest) -> Decision {
+            Decision::Allow
+        }
+    }
+
+    /// A test filter that always blocks.
+    struct BlockAllFilter;
+    impl ProxyFilter for BlockAllFilter {
+        fn name(&self) -> &'static str {
+            "block-all"
+        }
+        fn evaluate(&self, _request: &FilterRequest) -> Decision {
+            Decision::Block {
+                rule: "block-all".to_string(),
+                reason: "everything is blocked".to_string(),
+            }
+        }
+    }
+
+    /// A test filter that always skips.
+    struct SkipFilter;
+    impl ProxyFilter for SkipFilter {
+        fn name(&self) -> &'static str {
+            "skip"
+        }
+        fn evaluate(&self, _request: &FilterRequest) -> Decision {
+            Decision::Skip
+        }
+    }
+
+    /// A filter that blocks only a specific package.
+    struct BlockPackageFilter {
+        target: String,
+    }
+    impl ProxyFilter for BlockPackageFilter {
+        fn name(&self) -> &'static str {
+            "block-package"
+        }
+        fn evaluate(&self, request: &FilterRequest) -> Decision {
+            if request.name == self.target {
+                Decision::Block {
+                    rule: "block-package".to_string(),
+                    reason: format!("{} is blocked", self.target),
+                }
+            } else {
+                Decision::Skip
+            }
+        }
+    }
+
+    fn make_request(name: &str) -> FilterRequest {
+        FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: Some("https://registry.npmjs.org".to_string()),
+            name: name.to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: Some("sha256-abc123".to_string()),
+            bypass: false,
+        }
+    }
+
+    fn make_request_no_integrity(name: &str) -> FilterRequest {
+        FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: name.to_string(),
+            version: None,
+            integrity: None,
+            bypass: false,
+        }
+    }
+
+    fn make_bypass_request(name: &str) -> FilterRequest {
+        FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: name.to_string(),
+            version: None,
+            integrity: None,
+            bypass: true,
+        }
+    }
+
+    fn audit_config() -> CurationConfig {
+        CurationConfig {
+            mode: CurationMode::Audit,
+            ..CurationConfig::default()
+        }
+    }
+
+    fn enforce_config() -> CurationConfig {
+        CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        }
+    }
+
+    // ---- Mode=Off tests ----
+
+    #[test]
+    fn test_off_mode_returns_allow() {
+        let engine = CurationEngine::new(CurationConfig::default());
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert!(result.decided_by.is_none());
+        assert!(!result.audited);
+    }
+
+    #[test]
+    fn test_off_mode_no_metrics() {
+        let engine = CurationEngine::new(CurationConfig::default());
+        engine.evaluate(&make_request("lodash"));
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 0);
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_off_mode_ignores_filters() {
+        let mut engine = CurationEngine::new(CurationConfig::default());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+    }
+
+    // ---- Mode=Enforce tests ----
+
+    #[test]
+    fn test_enforce_allow_all() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(AllowAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert_eq!(result.decided_by, Some("allow-all".to_string()));
+        assert!(!result.audited);
+    }
+
+    #[test]
+    fn test_enforce_block_all() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("block-all".to_string()));
+        assert!(!result.audited);
+    }
+
+    #[test]
+    fn test_enforce_block_increments_blocked_metric() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        engine.evaluate(&make_request("lodash"));
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 1);
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_enforce_allow_increments_allowed_metric() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(AllowAllFilter));
+        engine.evaluate(&make_request("lodash"));
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 1);
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 0);
+    }
+
+    // ---- Mode=Audit tests ----
+
+    #[test]
+    fn test_audit_block_sets_audited_flag() {
+        let mut engine = CurationEngine::new(audit_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert!(result.audited);
+    }
+
+    #[test]
+    fn test_audit_block_increments_allowed_metric() {
+        let mut engine = CurationEngine::new(audit_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        engine.evaluate(&make_request("lodash"));
+        // In audit mode, blocks count as allowed (not enforced)
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 1);
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_audit_allow_not_audited() {
+        let mut engine = CurationEngine::new(audit_config());
+        engine.add_filter(Box::new(AllowAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert!(!result.audited);
+    }
+
+    // ---- Chain ordering tests ----
+
+    #[test]
+    fn test_chain_first_block_wins() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        engine.add_filter(Box::new(AllowAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("block-all".to_string()));
+    }
+
+    #[test]
+    fn test_chain_first_allow_wins() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(AllowAllFilter));
+        engine.add_filter(Box::new(BlockAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert_eq!(result.decided_by, Some("allow-all".to_string()));
+    }
+
+    #[test]
+    fn test_chain_skip_then_block() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(SkipFilter));
+        engine.add_filter(Box::new(BlockAllFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by, Some("block-all".to_string()));
+    }
+
+    #[test]
+    fn test_chain_all_skip_allows() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(SkipFilter));
+        engine.add_filter(Box::new(SkipFilter));
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert!(result.decided_by.is_none());
+    }
+
+    #[test]
+    fn test_chain_empty_allows() {
+        let engine = CurationEngine::new(enforce_config());
+        let result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert!(result.decided_by.is_none());
+    }
+
+    #[test]
+    fn test_selective_block() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockPackageFilter {
+            target: "evil-pkg".to_string(),
+        }));
+
+        let ok_result = engine.evaluate(&make_request("lodash"));
+        assert_eq!(ok_result.decision, Decision::Allow);
+
+        let blocked_result = engine.evaluate(&make_request("evil-pkg"));
+        assert!(matches!(blocked_result.decision, Decision::Block { .. }));
+    }
+
+    // ---- Bypass tests ----
+
+    #[test]
+    fn test_bypass_allows_despite_block_filter() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        let result = engine.evaluate(&make_bypass_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        assert_eq!(result.decided_by, Some("bypass".to_string()));
+    }
+
+    #[test]
+    fn test_bypass_increments_allowed() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockAllFilter));
+        engine.evaluate(&make_bypass_request("lodash"));
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 1);
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_bypass_ignored_in_off_mode() {
+        let engine = CurationEngine::new(CurationConfig::default());
+        let result = engine.evaluate(&make_bypass_request("lodash"));
+        assert_eq!(result.decision, Decision::Allow);
+        // Off mode — no metrics at all
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 0);
+    }
+
+    // ---- Integrity tracking ----
+
+    #[test]
+    fn test_no_integrity_tracked() {
+        let engine = CurationEngine::new(enforce_config());
+        engine.evaluate(&make_request_no_integrity("lodash"));
+        assert_eq!(
+            engine.metrics().without_integrity.load(Ordering::Relaxed),
+            1
+        );
+    }
+
+    #[test]
+    fn test_with_integrity_not_tracked() {
+        let engine = CurationEngine::new(enforce_config());
+        engine.evaluate(&make_request("lodash"));
+        assert_eq!(
+            engine.metrics().without_integrity.load(Ordering::Relaxed),
+            0
+        );
+    }
+
+    // ---- Helper method tests ----
+
+    #[test]
+    fn test_is_active() {
+        assert!(!CurationEngine::new(CurationConfig::default()).is_active());
+        assert!(CurationEngine::new(audit_config()).is_active());
+        assert!(CurationEngine::new(enforce_config()).is_active());
+    }
+
+    #[test]
+    fn test_mode() {
+        let engine = CurationEngine::new(audit_config());
+        assert_eq!(*engine.mode(), CurationMode::Audit);
+    }
+
+    // ---- RegistryType Display ----
+
+    #[test]
+    fn test_registry_type_display() {
+        assert_eq!(RegistryType::Npm.to_string(), "npm");
+        assert_eq!(RegistryType::PyPI.to_string(), "pypi");
+        assert_eq!(RegistryType::Maven.to_string(), "maven");
+        assert_eq!(RegistryType::Cargo.to_string(), "cargo");
+        assert_eq!(RegistryType::Go.to_string(), "go");
+        assert_eq!(RegistryType::Docker.to_string(), "docker");
+        assert_eq!(RegistryType::Raw.to_string(), "raw");
+    }
+
+    // ---- BlockedResponse ----
+
+    #[test]
+    fn test_blocked_response_status_code() {
+        let resp = BlockedResponse {
+            rule: "test-rule".to_string(),
+            reason: "test reason".to_string(),
+            registry: "npm".to_string(),
+            package: "lodash".to_string(),
+            version: Some("4.17.21".to_string()),
+        };
+        let response = resp.into_response();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_blocked_response_headers() {
+        let resp = BlockedResponse {
+            rule: "blocklist".to_string(),
+            reason: "known-vulnerable".to_string(),
+            registry: "npm".to_string(),
+            package: "evil".to_string(),
+            version: None,
+        };
+        let response = resp.into_response();
+        assert_eq!(
+            response.headers().get("x-nora-decision").unwrap(),
+            "blocked"
+        );
+        assert_eq!(response.headers().get("x-nora-rule").unwrap(), "blocklist");
+        assert_eq!(
+            response.headers().get("x-nora-reason").unwrap(),
+            "known-vulnerable"
+        );
+    }
+
+    // ---- CurationConfig defaults ----
+
+    #[test]
+    fn test_curation_config_defaults() {
+        let c = CurationConfig::default();
+        assert_eq!(c.mode, CurationMode::Off);
+        assert_eq!(c.on_failure, CurationOnFailure::Closed);
+        assert!(!c.require_integrity);
+    }
+
+    // ---- Multiple evaluations accumulate metrics ----
+
+    #[test]
+    fn test_metrics_accumulate() {
+        let mut engine = CurationEngine::new(enforce_config());
+        engine.add_filter(Box::new(BlockPackageFilter {
+            target: "evil".to_string(),
+        }));
+
+        engine.evaluate(&make_request("lodash"));
+        engine.evaluate(&make_request("express"));
+        engine.evaluate(&make_request("evil"));
+        engine.evaluate(&make_request("evil"));
+
+        assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 2);
+        assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 2);
+    }
+}

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The Nora Authors
 // SPDX-License-Identifier: MIT
 #![deny(clippy::unwrap_used)]
 #![forbid(unsafe_code)]
@@ -7,6 +7,7 @@ mod audit;
 mod auth;
 mod backup;
 mod config;
+mod curation;
 mod dashboard_metrics;
 mod error;
 mod gc;
@@ -130,6 +131,7 @@ pub struct AppState {
     pub upload_sessions: Arc<RwLock<HashMap<String, registry::docker::UploadSession>>>,
     /// Per-key publish locks for TOCTOU protection (immutable releases)
     publish_locks: parking_lot::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    pub curation: curation::CurationEngine,
 }
 
 impl AppState {
@@ -416,6 +418,15 @@ async fn run_server(config: Config, storage: Storage) {
 
     let http_client = reqwest::Client::new();
 
+    // Initialize curation engine
+    let curation_engine = curation::CurationEngine::new(config.curation.clone());
+    if curation_engine.is_active() {
+        info!(
+            mode = %config.curation.mode,
+            "Curation layer active"
+        );
+    }
+
     // Registry routes (shared between rate-limited and non-limited paths)
     let registry_routes = Router::new()
         .merge(registry::docker_routes())
@@ -467,6 +478,7 @@ async fn run_server(config: Config, storage: Storage) {
         http_client,
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
+        curation: curation_engine,
     });
 
     // Shared lock: GC and Retention must not run concurrently (both call storage.delete)

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -114,6 +114,25 @@ enum Commands {
         #[arg(long, global = true)]
         json: bool,
     },
+    /// Curation tools: validate files, explain decisions
+    Curation {
+        #[command(subcommand)]
+        action: CurationCommand,
+    },
+}
+
+#[derive(Subcommand)]
+enum CurationCommand {
+    /// Validate blocklist/allowlist JSON files
+    Validate {
+        /// Path to the JSON file to validate
+        file: PathBuf,
+    },
+    /// Explain curation decision for a specific package
+    Explain {
+        /// Package in format "registry:name@version" (e.g., "cargo:serde@1.0.0")
+        package: String,
+    },
 }
 
 pub struct AppState {
@@ -347,6 +366,186 @@ async fn main() {
                 std::process::exit(1);
             }
         }
+        Some(Commands::Curation { action }) => match action {
+            CurationCommand::Validate { file } => {
+                run_curation_validate(&file);
+            }
+            CurationCommand::Explain { package } => {
+                run_curation_explain(&config, &package);
+            }
+        },
+    }
+}
+
+fn run_curation_validate(file: &Path) {
+    let content = match std::fs::read_to_string(file) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("ERROR: Cannot read '{}': {}", file.display(), e);
+            std::process::exit(1);
+        }
+    };
+
+    // Try as blocklist first
+    if let Ok(parsed) = serde_json::from_str::<curation::BlocklistFile>(&content) {
+        if parsed.version != 1 {
+            eprintln!(
+                "ERROR: Unsupported blocklist version {} (expected 1)",
+                parsed.version
+            );
+            std::process::exit(1);
+        }
+        println!("OK: Valid blocklist — {} rules", parsed.rules.len());
+        for (i, rule) in parsed.rules.iter().enumerate() {
+            println!(
+                "  [{}] {}/{}@{} — {}",
+                i + 1,
+                rule.registry,
+                rule.name,
+                rule.version,
+                rule.reason
+            );
+        }
+        return;
+    }
+
+    // Try as allowlist
+    if let Ok(parsed) = serde_json::from_str::<curation::AllowlistFile>(&content) {
+        if parsed.version != 1 {
+            eprintln!(
+                "ERROR: Unsupported allowlist version {} (expected 1)",
+                parsed.version
+            );
+            std::process::exit(1);
+        }
+        let with_integrity = parsed
+            .entries
+            .iter()
+            .filter(|e| e.integrity.is_some())
+            .count();
+        println!(
+            "OK: Valid allowlist — {} entries ({} with integrity)",
+            parsed.entries.len(),
+            with_integrity
+        );
+        for (i, entry) in parsed.entries.iter().enumerate() {
+            let integrity_flag = if entry.integrity.is_some() {
+                " [hash]"
+            } else {
+                ""
+            };
+            println!(
+                "  [{}] {}/{}@{}{}",
+                i + 1,
+                entry.registry,
+                entry.name,
+                entry.version,
+                integrity_flag
+            );
+        }
+        return;
+    }
+
+    eprintln!(
+        "ERROR: '{}' is not a valid blocklist or allowlist JSON",
+        file.display()
+    );
+    eprintln!("  Expected {{ \"version\": 1, \"rules\": [...] }} or {{ \"version\": 1, \"entries\": [...] }}");
+    std::process::exit(1);
+}
+
+fn run_curation_explain(config: &Config, package_spec: &str) {
+    // Parse "registry:name@version"
+    let (registry_str, rest) = match package_spec.split_once(':') {
+        Some(parts) => parts,
+        None => {
+            eprintln!("ERROR: Expected format 'registry:name@version' (e.g., 'cargo:serde@1.0.0')");
+            std::process::exit(1);
+        }
+    };
+
+    let (name, version) = match rest.split_once('@') {
+        Some((n, v)) => (n.to_string(), Some(v.to_string())),
+        None => (rest.to_string(), None),
+    };
+
+    let registry = match registry_str {
+        "npm" => curation::RegistryType::Npm,
+        "pypi" => curation::RegistryType::PyPI,
+        "maven" => curation::RegistryType::Maven,
+        "cargo" => curation::RegistryType::Cargo,
+        "go" => curation::RegistryType::Go,
+        "docker" => curation::RegistryType::Docker,
+        other => {
+            eprintln!(
+                "ERROR: Unknown registry '{}'. Use: npm, pypi, maven, cargo, go, docker",
+                other
+            );
+            std::process::exit(1);
+        }
+    };
+
+    // Build engine with configured filters
+    let mut engine = curation::CurationEngine::new(config.curation.clone());
+
+    if let Some(ref path) = config.curation.blocklist_path {
+        match curation::BlocklistFilter::from_file(path) {
+            Ok(filter) => {
+                println!("Blocklist: {} ({} rules)", path, filter.rule_count());
+                engine.add_filter(Box::new(filter));
+            }
+            Err(e) => println!("Blocklist: {} (ERROR: {})", path, e),
+        }
+    } else {
+        println!("Blocklist: not configured");
+    }
+
+    if let Some(ref path) = config.curation.allowlist_path {
+        match curation::AllowlistFilter::from_file(path, config.curation.require_integrity) {
+            Ok(filter) => {
+                println!("Allowlist: {} ({} entries)", path, filter.entry_count());
+                engine.add_filter(Box::new(filter));
+            }
+            Err(e) => println!("Allowlist: {} (ERROR: {})", path, e),
+        }
+    } else {
+        println!("Allowlist: not configured");
+    }
+
+    if !config.curation.internal_namespaces.is_empty() {
+        let ns_filter = curation::NamespaceFilter::new(config.curation.internal_namespaces.clone());
+        println!("Namespaces: {} patterns", ns_filter.pattern_count());
+        engine.set_namespace_filter(Box::new(ns_filter));
+    } else {
+        println!("Namespaces: not configured");
+    }
+
+    println!("Mode: {}", config.curation.mode);
+    println!("---");
+
+    let request = curation::FilterRequest {
+        registry,
+        upstream: None,
+        name: name.clone(),
+        version: version.clone(),
+        integrity: None,
+        bypass: false,
+    };
+
+    let result = engine.evaluate(&request);
+    println!(
+        "Package: {}:{}@{}",
+        registry_str,
+        name,
+        version.as_deref().unwrap_or("*")
+    );
+    println!("Decision: {:?}", result.decision);
+    println!(
+        "Decided by: {}",
+        result.decided_by.as_deref().unwrap_or("(default)")
+    );
+    if result.audited {
+        println!("Mode: AUDIT (would block but logs only)");
     }
 }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -42,7 +42,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use activity_log::ActivityLog;
 use audit::AuditLog;
 use auth::HtpasswdAuth;
-use config::{Config, StorageMode};
+use config::{Config, CurationMode, StorageMode};
 use dashboard_metrics::DashboardMetrics;
 use repo_index::RepoIndex;
 pub use storage::Storage;
@@ -419,12 +419,54 @@ async fn run_server(config: Config, storage: Storage) {
     let http_client = reqwest::Client::new();
 
     // Initialize curation engine
-    let curation_engine = curation::CurationEngine::new(config.curation.clone());
+    let mut curation_engine = curation::CurationEngine::new(config.curation.clone());
     if curation_engine.is_active() {
         info!(
             mode = %config.curation.mode,
             "Curation layer active"
         );
+    }
+
+    // Load blocklist filter if configured
+    if let Some(ref path) = config.curation.blocklist_path {
+        match curation::BlocklistFilter::from_file(path) {
+            Ok(filter) => {
+                let count = filter.rule_count();
+                curation_engine.add_filter(Box::new(filter));
+                info!(path = %path, rules = count, "Blocklist filter loaded");
+            }
+            Err(e) => {
+                error!(path = %path, error = %e, "Failed to load blocklist");
+                if config.curation.mode == CurationMode::Enforce {
+                    panic!("Cannot start in enforce mode with invalid blocklist");
+                }
+            }
+        }
+    }
+
+    // Load allowlist filter if configured (after blocklist — blocklist wins on overlap)
+    if let Some(ref path) = config.curation.allowlist_path {
+        match curation::AllowlistFilter::from_file(path, config.curation.require_integrity) {
+            Ok(filter) => {
+                let count = filter.entry_count();
+                curation_engine.add_filter(Box::new(filter));
+                info!(path = %path, entries = count, "Allowlist filter loaded");
+            }
+            Err(e) => {
+                error!(path = %path, error = %e, "Failed to load allowlist");
+                if config.curation.mode == CurationMode::Enforce {
+                    panic!("Cannot start in enforce mode with invalid allowlist");
+                }
+            }
+        }
+    }
+
+    // Load namespace isolation filter if configured (always active, even in mode=Off)
+    if !config.curation.internal_namespaces.is_empty() {
+        let ns_filter = curation::NamespaceFilter::new(config.curation.internal_namespaces.clone());
+        let count = ns_filter.pattern_count();
+        curation_engine.set_namespace_filter(Box::new(ns_filter));
+        info!(patterns = count, "Namespace isolation filter loaded");
     }
 
     // Registry routes (shared between rate-limited and non-limited paths)

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -225,12 +225,26 @@ async fn get_metadata(
 /// GET /cargo/api/v1/crates/{name}/{version}/download — download .crate file.
 async fn download(
     State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Path((crate_name, version)): Path<(String, String)>,
 ) -> Response {
     if validate_storage_key(&crate_name).is_err() || validate_storage_key(&version).is_err() {
         return StatusCode::BAD_REQUEST.into_response();
     }
     let crate_name = crate_name.to_lowercase();
+
+    // Curation check — before storage access
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Cargo,
+        &crate_name,
+        Some(&version),
+    ) {
+        return response;
+    }
+
     let key = format!(
         "cargo/{}/{}/{}-{}.crate",
         crate_name, version, crate_name, version
@@ -1203,5 +1217,107 @@ mod integration_tests {
             .as_str()
             .unwrap()
             .contains("already exists"));
+    }
+
+    // ── Curation integration tests ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_cargo_download_blocked_by_curation() {
+        use crate::test_helpers::{create_test_context_with_config, send_with_headers};
+
+        // Write blocklist file to a temp location
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{
+                "registry": "cargo",
+                "name": "evil-crate",
+                "version": "*",
+                "reason": "known malware"
+            }]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.curation.mode = crate::config::CurationMode::Enforce;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        // Put a crate in storage so it would normally be downloadable
+        ctx.state
+            .storage
+            .put(
+                "cargo/evil-crate/1.0.0/evil-crate-1.0.0.crate",
+                b"evil-data",
+            )
+            .await
+            .unwrap();
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/cargo/api/v1/crates/evil-crate/1.0.0/download",
+            vec![],
+            "",
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers()
+                .get("x-nora-decision")
+                .and_then(|v| v.to_str().ok()),
+            Some("blocked")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cargo_download_allowed_by_curation() {
+        use crate::test_helpers::{create_test_context_with_config, send_with_headers};
+
+        // Blocklist only blocks "evil-crate"
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{
+                "registry": "cargo",
+                "name": "evil-crate",
+                "version": "*",
+                "reason": "known malware"
+            }]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.curation.mode = crate::config::CurationMode::Enforce;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        // Put a SAFE crate in storage
+        ctx.state
+            .storage
+            .put(
+                "cargo/safe-crate/2.0.0/safe-crate-2.0.0.crate",
+                b"safe-data",
+            )
+            .await
+            .unwrap();
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/cargo/api/v1/crates/safe-crate/2.0.0/download",
+            vec![],
+            "",
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"safe-data");
     }
 }

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -252,6 +252,17 @@ async fn download(
 
     // Try local storage first
     if let Ok(data) = state.storage.get(&key).await {
+        // Post-download integrity verification (issue #189)
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Cargo,
+            &crate_name,
+            Some(&version),
+            &data,
+        ) {
+            return response;
+        }
+
         state.metrics.record_download("cargo");
         state.metrics.record_cache_hit();
         state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -195,6 +195,7 @@ async fn check_blob(
 
 async fn download_blob(
     State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
     if let Err(e) = validate_docker_name(&name) {
@@ -202,6 +203,18 @@ async fn download_blob(
     }
     if let Err(e) = validate_digest(&digest) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+    }
+
+    // Curation check — defense in depth: check blobs too
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Docker,
+        &name,
+        Some(&digest),
+    ) {
+        return response;
     }
 
     let key = format!("docker/{}/blobs/{}", name, digest);
@@ -538,6 +551,7 @@ async fn upload_blob(
 
 async fn get_manifest(
     State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Path((name, reference)): Path<(String, String)>,
 ) -> Response {
     if let Err(e) = validate_docker_name(&name) {
@@ -545,6 +559,18 @@ async fn get_manifest(
     }
     if let Err(e) = validate_docker_reference(&reference) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+    }
+
+    // Curation check — manifests carry the image identity
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Docker,
+        &name,
+        Some(&reference),
+    ) {
+        return response;
     }
 
     let key = format!("docker/{}/manifests/{}.json", name, reference);
@@ -920,10 +946,11 @@ async fn check_blob_ns(
 
 async fn download_blob_ns(
     state: State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Path((ns, name, digest)): Path<(String, String, String)>,
 ) -> Response {
     let full_name = format!("{}/{}", ns, name);
-    download_blob(state, Path((full_name, digest))).await
+    download_blob(state, headers, Path((full_name, digest))).await
 }
 
 async fn start_upload_ns(
@@ -955,10 +982,11 @@ async fn upload_blob_ns(
 
 async fn get_manifest_ns(
     state: State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Path((ns, name, reference)): Path<(String, String, String)>,
 ) -> Response {
     let full_name = format!("{}/{}", ns, name);
-    get_manifest(state, Path((full_name, reference))).await
+    get_manifest(state, headers, Path((full_name, reference))).await
 }
 
 async fn put_manifest_ns(

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -221,6 +221,17 @@ async fn download_blob(
 
     // Try local storage first
     if let Ok(data) = state.storage.get(&key).await {
+        // Curation integrity verification (issue #189)
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Docker,
+            &name,
+            Some(&digest),
+            &data,
+        ) {
+            return response;
+        }
+
         state.metrics.record_download("docker");
         state.metrics.record_cache_hit();
         state.activity.push(ActivityEntry::new(
@@ -577,6 +588,17 @@ async fn get_manifest(
 
     // Try local storage first
     if let Ok(data) = state.storage.get(&key).await {
+        // Curation integrity verification (issue #189)
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Docker,
+            &name,
+            Some(&reference),
+            &data,
+        ) {
+            return response;
+        }
+
         state.metrics.record_download("docker");
         state.metrics.record_cache_hit();
         state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -29,7 +29,11 @@ pub fn routes() -> Router<Arc<AppState>> {
 }
 
 /// Main handler — parses the wildcard path and dispatches to the right logic.
-async fn handle(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
+async fn handle(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(path): Path<String>,
+) -> Response {
     // URL-decode the path: Go client sends %21 for !, Axum wildcard may not decode it
     let path = percent_decode(path.as_bytes())
         .decode_utf8()
@@ -52,6 +56,26 @@ async fn handle(State(state): State<Arc<AppState>>, Path(path): Path<String>) ->
             return StatusCode::NOT_FOUND.into_response();
         }
     };
+
+    // Curation check — .zip downloads only (metadata passes through)
+    if file.ends_with(".zip") {
+        let module_name =
+            decode_module_path(&module_encoded).unwrap_or_else(|_| module_encoded.clone());
+        // Extract version: "@v/v1.0.0.zip" → "v1.0.0"
+        let version = file
+            .strip_prefix("@v/")
+            .and_then(|f| f.strip_suffix(".zip"));
+        if let Some(response) = crate::curation::check_download(
+            &state.curation,
+            state.config.curation.bypass_token.as_deref(),
+            &headers,
+            crate::curation::RegistryType::Go,
+            &module_name,
+            version,
+        ) {
+            return response;
+        }
+    }
 
     let storage_key = format!("go/{}", path);
     let content_type = content_type_for(&file);

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -57,21 +57,28 @@ async fn handle(
         }
     };
 
-    // Curation check — .zip downloads only (metadata passes through)
-    if file.ends_with(".zip") {
+    // Parse curation coords for .zip downloads (used in both pre-download and integrity checks)
+    let go_curation = if file.ends_with(".zip") {
         let module_name =
             decode_module_path(&module_encoded).unwrap_or_else(|_| module_encoded.clone());
-        // Extract version: "@v/v1.0.0.zip" → "v1.0.0"
         let version = file
             .strip_prefix("@v/")
-            .and_then(|f| f.strip_suffix(".zip"));
+            .and_then(|f| f.strip_suffix(".zip"))
+            .map(|v| v.to_string());
+        Some((module_name, version))
+    } else {
+        None
+    };
+
+    // Curation check — .zip downloads only (metadata passes through)
+    if let Some((ref module_name, ref version)) = go_curation {
         if let Some(response) = crate::curation::check_download(
             &state.curation,
             state.config.curation.bypass_token.as_deref(),
             &headers,
             crate::curation::RegistryType::Go,
-            &module_name,
-            version,
+            module_name,
+            version.as_deref(),
         ) {
             return response;
         }
@@ -87,6 +94,19 @@ async fn handle(
 
     // 1. Try local cache (for immutable files, this is authoritative)
     if let Ok(data) = state.storage.get(&storage_key).await {
+        // Curation integrity verification (issue #189)
+        if let Some((ref module_name, ref version)) = go_curation {
+            if let Some(response) = crate::curation::verify_integrity(
+                &state.curation,
+                crate::curation::RegistryType::Go,
+                module_name,
+                version.as_deref(),
+                &data,
+            ) {
+                return response;
+            }
+        }
+
         state.metrics.record_download("go");
         state.metrics.record_cache_hit();
         state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -115,26 +115,46 @@ async fn download(
         .collect::<Vec<_>>()
         .join("/");
 
-    // Curation check — only for versioned artifact files, not metadata
-    if let MavenPathKind::VersionFile(ref coords) = classify_path(&path) {
+    // Classify path for curation (used in both pre-download and integrity checks)
+    let curation_coords = if let MavenPathKind::VersionFile(coords) = classify_path(&path) {
         let maven_name = format!(
             "{}:{}",
             coords.group_path.replace('/', "."),
             coords.artifact_id
         );
+        Some((maven_name, coords.version))
+    } else {
+        None
+    };
+
+    // Curation check — only for versioned artifact files, not metadata
+    if let Some((ref maven_name, ref maven_version)) = curation_coords {
         if let Some(response) = crate::curation::check_download(
             &state.curation,
             state.config.curation.bypass_token.as_deref(),
             &headers,
             crate::curation::RegistryType::Maven,
-            &maven_name,
-            Some(&coords.version),
+            maven_name,
+            Some(maven_version),
         ) {
             return response;
         }
     }
 
     if let Ok(data) = state.storage.get(&key).await {
+        // Curation integrity verification (issue #189)
+        if let Some((ref maven_name, ref maven_version)) = curation_coords {
+            if let Some(response) = crate::curation::verify_integrity(
+                &state.curation,
+                crate::curation::RegistryType::Maven,
+                maven_name,
+                Some(maven_version),
+                &data,
+            ) {
+                return response;
+            }
+        }
+
         state.metrics.record_download("maven");
         state.metrics.record_cache_hit();
         state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -98,7 +98,11 @@ fn is_snapshot(version: &str) -> bool {
 // Download
 // ============================================================================
 
-async fn download(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
+async fn download(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(path): Path<String>,
+) -> Response {
     let key = format!("maven/{}", path);
 
     let artifact_name = path
@@ -110,6 +114,25 @@ async fn download(State(state): State<Arc<AppState>>, Path(path): Path<String>) 
         .rev()
         .collect::<Vec<_>>()
         .join("/");
+
+    // Curation check — only for versioned artifact files, not metadata
+    if let MavenPathKind::VersionFile(ref coords) = classify_path(&path) {
+        let maven_name = format!(
+            "{}:{}",
+            coords.group_path.replace('/', "."),
+            coords.artifact_id
+        );
+        if let Some(response) = crate::curation::check_download(
+            &state.curation,
+            state.config.curation.bypass_token.as_deref(),
+            &headers,
+            crate::curation::RegistryType::Maven,
+            &maven_name,
+            Some(&coords.version),
+        ) {
+            return response;
+        }
+    }
 
     if let Ok(data) = state.storage.get(&key).await {
         state.metrics.record_download("maven");

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -62,7 +62,11 @@ fn rewrite_tarball_urls(data: &[u8], nora_base: &str, upstream_url: &str) -> Res
     serde_json::to_vec(&json).map_err(|_| ())
 }
 
-async fn handle_request(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
+async fn handle_request(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(path): Path<String>,
+) -> Response {
     let is_tarball = path.contains("/-/");
 
     let key = if is_tarball {
@@ -81,6 +85,22 @@ async fn handle_request(State(state): State<Arc<AppState>>, Path(path): Path<Str
     } else {
         path.clone()
     };
+
+    // Curation check — tarball downloads only (metadata passes through)
+    if is_tarball {
+        let filename = path.split("/-/").nth(1).unwrap_or("");
+        let version = crate::curation::parse_npm_tarball_version(&package_name, filename);
+        if let Some(response) = crate::curation::check_download(
+            &state.curation,
+            state.config.curation.bypass_token.as_deref(),
+            &headers,
+            crate::curation::RegistryType::Npm,
+            &package_name,
+            version.as_deref(),
+        ) {
+            return response;
+        }
+    }
 
     // --- Cache hit path ---
     if let Ok(data) = state.storage.get(&key).await {

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -86,17 +86,23 @@ async fn handle_request(
         path.clone()
     };
 
+    // Parse tarball version (used for both pre-download and integrity checks)
+    let tarball_version = if is_tarball {
+        let filename = path.split("/-/").nth(1).unwrap_or("");
+        crate::curation::parse_npm_tarball_version(&package_name, filename)
+    } else {
+        None
+    };
+
     // Curation check — tarball downloads only (metadata passes through)
     if is_tarball {
-        let filename = path.split("/-/").nth(1).unwrap_or("");
-        let version = crate::curation::parse_npm_tarball_version(&package_name, filename);
         if let Some(response) = crate::curation::check_download(
             &state.curation,
             state.config.curation.bypass_token.as_deref(),
             &headers,
             crate::curation::RegistryType::Npm,
             &package_name,
-            version.as_deref(),
+            tarball_version.as_deref(),
         ) {
             return response;
         }
@@ -139,6 +145,17 @@ async fn handle_request(
                 return (StatusCode::INTERNAL_SERVER_ERROR, "Integrity check failed")
                     .into_response();
             }
+        }
+
+        // Curation integrity verification (issue #189)
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Npm,
+            &package_name,
+            tarball_version.as_deref(),
+            &data,
+        ) {
+            return response;
         }
 
         state.metrics.record_download("npm");

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -172,9 +172,24 @@ async fn package_versions(
 /// GET /simple/{name}/{filename} — download a specific file.
 async fn download_file(
     State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
     Path((name, filename)): Path<(String, String)>,
 ) -> Response {
     let normalized = normalize_name(&name);
+
+    // Curation check — before storage access
+    let version = crate::curation::parse_pypi_version(&normalized, &filename);
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::PyPI,
+        &normalized,
+        version.as_deref(),
+    ) {
+        return response;
+    }
+
     let key = format!("pypi/{}/{}", normalized, filename);
 
     // Try local storage first

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -194,6 +194,17 @@ async fn download_file(
 
     // Try local storage first
     if let Ok(data) = state.storage.get(&key).await {
+        // Curation integrity verification (issue #189)
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::PyPI,
+            &normalized,
+            version.as_deref(),
+            &data,
+        ) {
+            return response;
+        }
+
         state.metrics.record_download("pypi");
         state.metrics.record_cache_hit();
         state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -56,6 +56,11 @@ pub fn create_test_context_with_raw_disabled() -> TestContext {
     build_context(false, &[], false, |cfg| cfg.raw.enabled = false)
 }
 
+/// Build a test context with custom config tweaks.
+pub fn create_test_context_with_config(customize: impl FnOnce(&mut Config)) -> TestContext {
+    build_context(false, &[], false, customize)
+}
+
 fn build_context(
     auth_enabled: bool,
     users: &[(&str, &str)],
@@ -161,6 +166,26 @@ fn build_context(
 
     let docker_auth = registry::DockerAuth::new(config.docker.proxy_timeout);
 
+    // Build curation engine before consuming config (mirroring main.rs)
+    let mut curation_engine = CurationEngine::new(config.curation.clone());
+    if let Some(ref path) = config.curation.blocklist_path {
+        if let Ok(filter) = crate::curation::BlocklistFilter::from_file(path) {
+            curation_engine.add_filter(Box::new(filter));
+        }
+    }
+    if let Some(ref path) = config.curation.allowlist_path {
+        if let Ok(filter) =
+            crate::curation::AllowlistFilter::from_file(path, config.curation.require_integrity)
+        {
+            curation_engine.add_filter(Box::new(filter));
+        }
+    }
+    if !config.curation.internal_namespaces.is_empty() {
+        let ns_filter =
+            crate::curation::NamespaceFilter::new(config.curation.internal_namespaces.clone());
+        curation_engine.set_namespace_filter(Box::new(ns_filter));
+    }
+
     let state = Arc::new(AppState {
         storage,
         config,
@@ -175,7 +200,7 @@ fn build_context(
         http_client: reqwest::Client::new(),
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
-        curation: CurationEngine::new(CurationConfig::default()),
+        curation: curation_engine,
     });
 
     // Build router identical to run_server() but without TcpListener / rate-limiting

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The Nora Authors
 // SPDX-License-Identifier: MIT
 
 //! Shared test infrastructure for integration tests.
@@ -19,6 +19,7 @@ use crate::activity_log::ActivityLog;
 use crate::audit::AuditLog;
 use crate::auth::HtpasswdAuth;
 use crate::config::*;
+use crate::curation::CurationEngine;
 use crate::dashboard_metrics::DashboardMetrics;
 use crate::registry;
 use crate::repo_index::RepoIndex;
@@ -130,6 +131,7 @@ fn build_context(
         secrets: SecretsConfig::default(),
         gc: crate::config::GcConfig::default(),
         retention: crate::config::RetentionConfig::default(),
+        curation: CurationConfig::default(),
     };
 
     // Apply any custom config tweaks
@@ -173,6 +175,7 @@ fn build_context(
         http_client: reqwest::Client::new(),
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
+        curation: CurationEngine::new(CurationConfig::default()),
     });
 
     // Build router identical to run_server() but without TcpListener / rate-limiting


### PR DESCRIPTION
## Summary

Complete curation layer for proxy downloads. 7 issues resolved:

- **#184** — CurationEngine skeleton, ProxyFilter trait, config, 3 modes (Off/Audit/Enforce)
- **#185** — NamespaceFilter: always-active security boundary, glob support
- **#186** — BlocklistFilter: JSON rules file, glob matching on name/version/registry
- **#187** — Handler wiring: check_download() in all 6 handlers (npm/pypi/maven/cargo/go/docker)
- **#188** — AllowlistFilter: default-deny, O(1) lookup, require_integrity mode
- **#189** — Post-download SHA-256 integrity verification (two-phase: pre=name/version, post=hash)
- **#190** — CLI: `nora curation validate` + `nora curation explain`

### Architecture

```
Download Request
  → NamespaceFilter (always, security boundary)
  → check_download() pre-check:
    → BlocklistFilter (glob match → 403)
    → AllowlistFilter (name/version check)
  → storage.get() (read artifact)
  → verify_integrity() post-check:
    → AllowlistFilter (SHA-256 hash match)
  → 200 OK (serve artifact)
```

### Key design decisions

- **403 on download, NOT index filtering** — metadata requests pass through
- **Bypass token** via `X-Nora-Bypass-Token` header
- **Three modes**: Off (default), Audit (log only), Enforce (fail-closed 403)
- **Version parsing**: exact for Cargo/Maven/Go/Docker, best-effort for npm/PyPI

### Test plan

- [x] 743 tests pass (cargo test)
- [x] Clippy clean (0 warnings)
- [x] Coherence check PASS
- [x] Docker build + health check
- [x] E2E: all registry endpoints respond correctly
- [x] Enforce mode: blocklisted Docker image returns 403 with JSON body
- [x] Bypass token: correct token passes, wrong/missing blocks
- [x] CLI validate + explain work with real config

Closes #184, closes #185, closes #186, closes #187, closes #188, closes #189, closes #190