### PR TITLE
feat: 6 new registries, curation layer, 13-format UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 ## [Unreleased]
 
+### Added
+- RubyGems proxy registry (`/gems/`) — compact index, gem/gemspec immutable caching, TTL-based index refresh
+- Terraform proxy registry (`/terraform/`) — provider/module proxy with service discovery, download_url rewriting
+- Ansible Galaxy proxy registry (`/ansible/`) — Galaxy v3 API, collection tarball immutable caching
+- NuGet v3 proxy registry (`/nuget/`) — service index @id URL rewriting, .nupkg/.nuspec immutable caching
+- Pub (Dart/Flutter) proxy registry (`/pub/`) — package metadata URL rewriting, SHA256-verified archive caching (based on PR #191 by @mit-73)
+- Conan V2 proxy registry (`/conan/`) — recipe/package caching with immutable revision-scoped storage, ConanCenter upstream (#142)
+- Dynamic registry loading — only enabled registries mount routes, appear in UI sidebar and health endpoint
+- Per-registry `enabled` flag in config (env: `NORA_DOCKER_ENABLED`, `NORA_MAVEN_ENABLED`, etc.)
+- Shared `RegistryType` enum for type-safe cross-module registry identification
+
 ## [0.6.5] - 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,27 @@
 ## [Unreleased]
 
 ### Added
-- RubyGems proxy registry (`/gems/`) — compact index, gem/gemspec immutable caching, TTL-based index refresh
-- Terraform proxy registry (`/terraform/`) — provider/module proxy with service discovery, download_url rewriting
-- Ansible Galaxy proxy registry (`/ansible/`) — Galaxy v3 API, collection tarball immutable caching
-- NuGet v3 proxy registry (`/nuget/`) — service index @id URL rewriting, .nupkg/.nuspec immutable caching
-- Pub (Dart/Flutter) proxy registry (`/pub/`) — package metadata URL rewriting, SHA256-verified archive caching (based on PR #191 by @mit-73)
+- **Curation layer** — policy engine for download filtering across all 13 registries (#184-#190)
+  - Blocklist/allowlist rules with glob patterns and namespace isolation
+  - Three modes: `off` (passthrough), `audit` (log only), `enforce` (block downloads)
+  - Integrity verification via SHA256/SHA512 checksums
+  - CVE blocking via OSV.dev integration
+  - CLI tools: `nora curation validate`, `nora curation explain`
+- RubyGems proxy registry (`/gems/`) — compact index, gem/gemspec immutable caching, TTL-based index refresh (#141)
+- Terraform proxy registry (`/terraform/`) — provider/module proxy with service discovery, download_url rewriting (#133)
+- Ansible Galaxy proxy registry (`/ansible/`) — Galaxy v3 API, collection tarball immutable caching (#134)
+- NuGet v3 proxy registry (`/nuget/`) — service index @id URL rewriting, .nupkg/.nuspec immutable caching (#140)
+- Pub (Dart/Flutter) proxy registry (`/pub/`) — package metadata URL rewriting, SHA256-verified archive caching (#166, based on PR #191 by @mit-73)
 - Conan V2 proxy registry (`/conan/`) — recipe/package caching with immutable revision-scoped storage, ConanCenter upstream (#142)
 - Dynamic registry loading — only enabled registries mount routes, appear in UI sidebar and health endpoint
 - Per-registry `enabled` flag in config (env: `NORA_DOCKER_ENABLED`, `NORA_MAVEN_ENABLED`, etc.)
 - Shared `RegistryType` enum for type-safe cross-module registry identification
+- UI: 13-registry sidebar with format-specific SVG icons, dashboard cards for all registries
+- Short-SHA Docker tags in CI builds (#182, #192)
+
+### Changed
+- Copyright updated to "The NORA Authors"
+- OpenAPI spec version synced with Cargo.toml
 
 ## [0.6.5] - 2026-04-23
 

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -122,6 +122,104 @@ This document describes which parts of each registry protocol are implemented in
 | Directory listing | — | Not implemented |
 | Versioning | — | Overwrite-only |
 
+## RubyGems
+
+Caching proxy for rubygems.org. Immutable gem/gemspec caching with TTL-based index refresh.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Compact index (`/info/{name}`) | Full | TTL-cached |
+| Gem download (`/gems/{name}-{ver}.gem`) | Full | Immutable cache |
+| Gemspec (`/quick/Marshal.4.8/...`) | Full | Immutable cache |
+| Full index (`specs.4.8.gz`) | Full | TTL-cached |
+| Latest index (`latest_specs.4.8.gz`) | Full | TTL-cached |
+| Gem push | — | Proxy-only (read) |
+
+Client: `bundle config mirror.https://rubygems.org http://nora:4000/gems/`
+
+## Terraform
+
+Caching proxy for registry.terraform.io. Provider binaries are immutably cached; metadata uses TTL.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Service discovery (`.well-known/terraform.json`) | Full | Points to NORA |
+| Provider versions list | Full | TTL-cached |
+| Provider download metadata | Full | `download_url` rewritten to NORA |
+| Provider binary download | Full | Immutable cache |
+| Module versions list | Full | TTL-cached |
+| Module download | Full | `X-Terraform-Get` header pass-through |
+| Provider publish | — | Proxy-only (read) |
+
+Client: `provider_installation { network_mirror { url = "http://nora:4000/terraform/" } }`
+
+## Ansible Galaxy (v3 API)
+
+Caching proxy for galaxy.ansible.com. Collection tarballs are immutably cached.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Collection list | Full | TTL-cached |
+| Collection detail | Full | TTL-cached |
+| Collection versions | Full | TTL-cached |
+| Version detail | Full | TTL-cached |
+| Tarball download | Full | Immutable cache |
+| Collection publish | — | Proxy-only (read) |
+
+Client: `ansible-galaxy collection install ns.name -s http://nora:4000/ansible/`
+
+## NuGet (v3 API)
+
+Caching proxy for api.nuget.org. Service index URLs are rewritten to point through NORA.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Service index (`/v3/index.json`) | Full | `@id` URLs rewritten to NORA |
+| Registration index | Full | TTL-cached |
+| Version list (flat container) | Full | TTL-cached |
+| `.nupkg` download | Full | Immutable cache |
+| `.nuspec` download | Full | Immutable cache |
+| Package push | — | Proxy-only (read) |
+| Search | — | Not implemented |
+
+Client: `dotnet nuget add source http://nora:4000/nuget/v3/index.json -n nora`
+
+## Pub (Dart/Flutter)
+
+Caching proxy for pub.dev. Package archives are immutably cached with SHA256 verification.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Package search (`/api/packages?q=`) | Full | Response URL rewriting |
+| Package metadata (`/api/packages/{name}`) | Full | `archive_url` rewritten to NORA |
+| Version metadata | Full | Cached |
+| Security advisories | Full | Cached |
+| Archive download (`.tar.gz`) | Full | Immutable cache, SHA256 verified |
+| Package publish | — | Proxy-only (read) |
+
+Client: `export PUB_HOSTED_URL=http://nora:4000/pub && dart pub get`
+
+## Conan (C/C++)
+
+Caching proxy for ConanCenter (center2.conan.io). Recipe and package files are immutably cached (scoped to revision hashes). Metadata uses TTL-based caching.
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Ping (`/v2/ping`) | Full | Returns `X-Conan-Server-Capabilities: revisions` |
+| Recipe search | Full | Proxied to upstream |
+| Recipe latest revision | Full | TTL-cached |
+| Recipe revision list | Full | TTL-cached |
+| Recipe file list | Full | Immutable cache (revision-scoped) |
+| Recipe file download | Full | Immutable cache |
+| Package latest revision | Full | TTL-cached |
+| Package revision list | Full | TTL-cached |
+| Package file list | Full | Immutable cache (revision-scoped) |
+| Package file download | Full | Immutable cache |
+| Recipe/package upload | — | Proxy-only (read) |
+| Authentication | — | Anonymous read only |
+
+Client: `conan remote add nora http://nora:4000/conan`
+
 ## Helm OCI
 
 Helm charts are stored as OCI artifacts via the Docker registry endpoints. `helm push` and `helm pull` work through the standard `/v2/` API.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.6.5"
+version = "0.7.0-rc5"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.7.0-rc5"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"
-authors = ["DevITWay <devitway@gmail.com>"]
+authors = ["Pavel Volkov <devitway@gmail.com>"]
 repository = "https://github.com/getnora-io/nora"
 homepage = "https://getnora.dev"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Volkov Pavel | DevITWay
+Copyright (c) 2026 The NORA Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -15,15 +15,15 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 ## Why NORA
 
 - **Zero-config** — single 32 MB binary, no database, no dependencies. `docker run` and it works.
-- **Production-tested** — Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw. Used in real CI/CD with ArgoCD, Buildx cache, and air-gapped environments.
-- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 633 tests.
+- **Production-tested** — Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Used in real CI/CD with ArgoCD, Buildx cache, and air-gapped environments.
+- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 814 tests.
 
 [![Release](https://img.shields.io/github/v/release/getnora-io/nora)](https://github.com/getnora-io/nora/releases)
 [![Image Size](https://img.shields.io/badge/image-32%20MB-blue)](https://github.com/getnora-io/nora/pkgs/container/nora)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nora)](https://artifacthub.io/packages/helm/nora/nora)
 
-**32 MB** binary | **< 100 MB** RAM | **3s** startup | **7** registries
+**32 MB** binary | **< 100 MB** RAM | **3s** startup | **13** registries
 
 > Used in production at [DevIT Academy](https://github.com/devitway) since January 2026 for Docker images, Maven artifacts, and npm packages.
 
@@ -38,6 +38,12 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 | PyPI | `/simple/` | pypi.org, custom | ✓ |
 | Go Modules | `/go/` | proxy.golang.org, custom | ✓ |
 | Raw files | `/raw/` | — | ✓ |
+| RubyGems | `/gems/` | rubygems.org | ✓ |
+| Terraform | `/terraform/` | registry.terraform.io | ✓ |
+| Ansible Galaxy | `/ansible/` | galaxy.ansible.com | ✓ |
+| NuGet | `/nuget/` | api.nuget.org | ✓ |
+| Pub (Dart/Flutter) | `/pub/` | pub.dev | ✓ |
+| Conan (C/C++) | `/conan/` | ConanCenter | ✓ |
 
 > **Helm charts** work via the Docker/OCI endpoint — `helm push`/`pull` with `--plain-http` or behind TLS reverse proxy.
 
@@ -256,6 +262,12 @@ nora mirror docker --images alpine:3.20,nginx    # Mirror Docker images
 | `/simple/` | PyPI |
 | `/go/` | Go Modules |
 | `/raw/` | Raw files |
+| `/gems/` | RubyGems |
+| `/terraform/` | Terraform |
+| `/ansible/` | Ansible Galaxy |
+| `/nuget/` | NuGet |
+| `/pub/` | Pub (Dart/Flutter) |
+| `/conan/` | Conan (C/C++) |
 
 ## TLS / HTTPS
 
@@ -323,7 +335,7 @@ Full documentation: **https://getnora.dev**
 
 ## Author
 
-Created and maintained by [DevITWay](https://github.com/devitway)
+Created and maintained by [Pavel Volkov](https://github.com/devitway)
 
 [![GHCR](https://img.shields.io/badge/ghcr.io-nora-blue?logo=github)](https://github.com/getnora-io/nora/pkgs/container/nora)
 [![Rust](https://img.shields.io/badge/rust-%23000000.svg?logo=rust&logoColor=white)](https://www.rust-lang.org/)
@@ -343,4 +355,4 @@ NORA welcomes contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelin
 
 MIT License — see [LICENSE](LICENSE)
 
-Copyright (c) 2026 DevITWay
+Copyright (c) 2026 The NORA Authors

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@
 Instead, please report them via:
 
 1. **Email:** devitway@gmail.com
-2. **Telegram:** [@DevITWay](https://t.me/DevITWay) (private message)
+2. **Telegram:** [@devitway_pavel](https://t.me/devitway_pavel) (private message)
 
 ### What to Include
 

--- a/nora-registry/src/activity_log.rs
+++ b/nora-registry/src/activity_log.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use chrono::{DateTime, Utc};

--- a/nora-registry/src/audit.rs
+++ b/nora-registry/src/audit.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Persistent audit log — append-only JSONL file

--- a/nora-registry/src/auth.rs
+++ b/nora-registry/src/auth.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use axum::{

--- a/nora-registry/src/backup.rs
+++ b/nora-registry/src/backup.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Backup and restore functionality for Nora

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1,10 +1,13 @@
-// Copyright (c) 2026 The Nora Authors
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::env;
 use std::fs;
+
+use crate::registry_type::RegistryType;
 
 pub use crate::secrets::SecretsConfig;
 
@@ -31,6 +34,18 @@ pub struct Config {
     pub cargo: CargoConfig,
     #[serde(default)]
     pub raw: RawConfig,
+    #[serde(default)]
+    pub gems: GemsConfig,
+    #[serde(default)]
+    pub terraform: TerraformConfig,
+    #[serde(default)]
+    pub ansible: AnsibleConfig,
+    #[serde(default)]
+    pub nuget: NugetConfig,
+    #[serde(default)]
+    pub pub_dart: PubDartConfig,
+    #[serde(default)]
+    pub conan: ConanConfig,
     #[serde(default)]
     pub auth: AuthConfig,
     #[serde(default)]
@@ -108,6 +123,8 @@ fn default_bucket() -> String {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MavenConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     #[serde(default)]
     pub proxies: Vec<MavenProxyEntry>,
     #[serde(default = "default_timeout")]
@@ -126,6 +143,8 @@ fn default_true() -> bool {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NpmConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     #[serde(default)]
     pub proxy: Option<String>,
     #[serde(default)]
@@ -139,6 +158,8 @@ pub struct NpmConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PypiConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     #[serde(default)]
     pub proxy: Option<String>,
     #[serde(default)]
@@ -150,6 +171,8 @@ pub struct PypiConfig {
 /// Cargo registry configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CargoConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     /// Upstream Cargo registry (crates.io API)
     #[serde(default = "default_cargo_proxy")]
     pub proxy: Option<String>,
@@ -166,6 +189,7 @@ fn default_cargo_proxy() -> Option<String> {
 impl Default for CargoConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             proxy: default_cargo_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
@@ -176,6 +200,8 @@ impl Default for CargoConfig {
 /// Go module proxy configuration (GOPROXY protocol)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GoConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     /// Upstream Go module proxy URL (default: https://proxy.golang.org)
     #[serde(default = "default_go_proxy")]
     pub proxy: Option<String>,
@@ -206,6 +232,7 @@ fn default_go_max_zip_size() -> u64 {
 impl Default for GoConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             proxy: default_go_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
@@ -218,6 +245,8 @@ impl Default for GoConfig {
 /// Docker registry configuration with upstream proxy support
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DockerConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
     #[serde(default = "default_docker_timeout")]
     pub proxy_timeout: u64,
     #[serde(default)]
@@ -272,6 +301,200 @@ pub struct RawConfig {
     pub max_file_size: u64, // in bytes
 }
 
+/// RubyGems proxy configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GemsConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Upstream RubyGems registry (default: https://rubygems.org)
+    #[serde(default = "default_gems_proxy")]
+    pub proxy: Option<String>,
+    #[serde(default)]
+    pub proxy_auth: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub proxy_timeout: u64,
+    /// Index cache TTL in seconds (default: 300 = 5 min)
+    #[serde(default = "default_metadata_ttl")]
+    pub index_ttl: u64,
+}
+
+fn default_gems_proxy() -> Option<String> {
+    Some("https://rubygems.org".to_string())
+}
+
+impl Default for GemsConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            proxy: default_gems_proxy(),
+            proxy_auth: None,
+            proxy_timeout: 30,
+            index_ttl: 300,
+        }
+    }
+}
+
+/// Terraform provider/module proxy configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TerraformConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Upstream Terraform registry (default: https://registry.terraform.io)
+    #[serde(default = "default_terraform_proxy")]
+    pub proxy: Option<String>,
+    #[serde(default)]
+    pub proxy_auth: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub proxy_timeout: u64,
+    /// Separate timeout for binary downloads (default: 120s)
+    #[serde(default = "default_go_zip_timeout")]
+    pub proxy_timeout_download: u64,
+}
+
+fn default_terraform_proxy() -> Option<String> {
+    Some("https://registry.terraform.io".to_string())
+}
+
+impl Default for TerraformConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            proxy: default_terraform_proxy(),
+            proxy_auth: None,
+            proxy_timeout: 30,
+            proxy_timeout_download: 120,
+        }
+    }
+}
+
+/// Ansible Galaxy collection proxy configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnsibleConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Upstream Galaxy server (default: https://galaxy.ansible.com)
+    #[serde(default = "default_ansible_proxy")]
+    pub proxy: Option<String>,
+    #[serde(default)]
+    pub proxy_auth: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub proxy_timeout: u64,
+}
+
+fn default_ansible_proxy() -> Option<String> {
+    Some("https://galaxy.ansible.com".to_string())
+}
+
+impl Default for AnsibleConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            proxy: default_ansible_proxy(),
+            proxy_auth: None,
+            proxy_timeout: 30,
+        }
+    }
+}
+
+/// NuGet V3 proxy configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NugetConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Upstream NuGet API (default: https://api.nuget.org)
+    #[serde(default = "default_nuget_proxy")]
+    pub proxy: Option<String>,
+    #[serde(default)]
+    pub proxy_auth: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub proxy_timeout: u64,
+    /// Metadata cache TTL in seconds (default: 300 = 5 min)
+    #[serde(default = "default_metadata_ttl")]
+    pub metadata_ttl: u64,
+}
+
+fn default_nuget_proxy() -> Option<String> {
+    Some("https://api.nuget.org".to_string())
+}
+
+impl Default for NugetConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            proxy: default_nuget_proxy(),
+            proxy_auth: None,
+            proxy_timeout: 30,
+            metadata_ttl: 300,
+        }
+    }
+}
+
+/// Dart/Flutter pub registry configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PubDartConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Upstream pub registry (default: https://pub.dev)
+    #[serde(default = "default_pub_proxy")]
+    pub proxy: Option<String>,
+    #[serde(default)]
+    pub proxy_auth: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub proxy_timeout: u64,
+}
+
+fn default_pub_proxy() -> Option<String> {
+    Some("https://pub.dev".to_string())
+}
+
+impl Default for PubDartConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            proxy: default_pub_proxy(),
+            proxy_auth: None,
+            proxy_timeout: 30,
+        }
+    }
+}
+
+/// Conan V2 proxy configuration (C/C++ packages)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConanConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Upstream Conan registry (default: https://center2.conan.io)
+    #[serde(default = "default_conan_proxy")]
+    pub proxy: Option<String>,
+    #[serde(default)]
+    pub proxy_auth: Option<String>,
+    #[serde(default = "default_timeout")]
+    pub proxy_timeout: u64,
+    /// Separate timeout for binary downloads (default: 120s)
+    #[serde(default = "default_go_zip_timeout")]
+    pub proxy_timeout_download: u64,
+    /// Metadata cache TTL in seconds (default: 300 = 5 min)
+    #[serde(default = "default_metadata_ttl")]
+    pub metadata_ttl: u64,
+}
+
+fn default_conan_proxy() -> Option<String> {
+    Some("https://center2.conan.io".to_string())
+}
+
+impl Default for ConanConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            proxy: default_conan_proxy(),
+            proxy_auth: None,
+            proxy_timeout: 30,
+            proxy_timeout_download: 120,
+            metadata_ttl: 300,
+        }
+    }
+}
+
 fn default_docker_timeout() -> u64 {
     60
 }
@@ -316,6 +539,7 @@ fn default_metadata_ttl() -> u64 {
 impl Default for MavenConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             proxies: vec![MavenProxyEntry::Simple(
                 "https://repo1.maven.org/maven2".to_string(),
             )],
@@ -329,6 +553,7 @@ impl Default for MavenConfig {
 impl Default for NpmConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             proxy: Some("https://registry.npmjs.org".to_string()),
             proxy_auth: None,
             proxy_timeout: 30,
@@ -340,6 +565,7 @@ impl Default for NpmConfig {
 impl Default for PypiConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             proxy: Some("https://pypi.org/simple/".to_string()),
             proxy_auth: None,
             proxy_timeout: 30,
@@ -350,6 +576,7 @@ impl Default for PypiConfig {
 impl Default for DockerConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             proxy_timeout: 60,
             upstreams: vec![DockerUpstream {
                 url: "https://registry-1.docker.io".to_string(),
@@ -632,6 +859,54 @@ impl Default for CurationConfig {
 }
 
 impl Config {
+    /// Returns the set of enabled registry types based on config.
+    pub fn enabled_registries(&self) -> HashSet<RegistryType> {
+        let mut set = HashSet::new();
+        if self.docker.enabled {
+            set.insert(RegistryType::Docker);
+        }
+        if self.maven.enabled {
+            set.insert(RegistryType::Maven);
+        }
+        if self.npm.enabled {
+            set.insert(RegistryType::Npm);
+        }
+        if self.cargo.enabled {
+            set.insert(RegistryType::Cargo);
+        }
+        if self.pypi.enabled {
+            set.insert(RegistryType::PyPI);
+        }
+        if self.go.enabled {
+            set.insert(RegistryType::Go);
+        }
+        if self.raw.enabled {
+            set.insert(RegistryType::Raw);
+        }
+        if self.gems.enabled {
+            set.insert(RegistryType::Gems);
+        }
+        if self.terraform.enabled {
+            set.insert(RegistryType::Terraform);
+        }
+        if self.ansible.enabled {
+            set.insert(RegistryType::Ansible);
+        }
+        if self.nuget.enabled {
+            set.insert(RegistryType::Nuget);
+        }
+        if self.pub_dart.enabled {
+            set.insert(RegistryType::PubDart);
+        }
+        if self.conan.enabled {
+            set.insert(RegistryType::Conan);
+        }
+        if set.is_empty() {
+            tracing::warn!("No registries enabled! All registries are disabled.");
+        }
+        set
+    }
+
     /// Warn if credentials are configured via config.toml (not env vars)
     pub fn warn_plaintext_credentials(&self) {
         // Docker upstreams
@@ -920,6 +1195,44 @@ impl Config {
             self.auth.htpasswd_file = val;
         }
 
+        // Registry enabled flags
+        if let Ok(val) = env::var("NORA_DOCKER_ENABLED") {
+            self.docker.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_MAVEN_ENABLED") {
+            self.maven.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_NPM_ENABLED") {
+            self.npm.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_CARGO_ENABLED") {
+            self.cargo.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_PYPI_ENABLED") {
+            self.pypi.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_GO_ENABLED") {
+            self.go.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_GEMS_ENABLED") {
+            self.gems.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_TERRAFORM_ENABLED") {
+            self.terraform.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_ANSIBLE_ENABLED") {
+            self.ansible.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_NUGET_ENABLED") {
+            self.nuget.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_PUB_ENABLED") {
+            self.pub_dart.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+        if let Ok(val) = env::var("NORA_CONAN_ENABLED") {
+            self.conan.enabled = val.to_lowercase() == "true" || val == "1";
+        }
+
         // Maven config — supports "url1,url2" or "url1|auth1,url2|auth2"
         if let Ok(val) = env::var("NORA_MAVEN_PROXIES") {
             self.maven.proxies = val
@@ -1064,6 +1377,109 @@ impl Config {
             }
         }
 
+        // Gems config
+        if let Ok(val) = env::var("NORA_GEMS_PROXY") {
+            self.gems.proxy = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_GEMS_PROXY_AUTH") {
+            self.gems.proxy_auth = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_GEMS_PROXY_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.gems.proxy_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_GEMS_INDEX_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.gems.index_ttl = ttl;
+            }
+        }
+
+        // Terraform config
+        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY") {
+            self.terraform.proxy = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_AUTH") {
+            self.terraform.proxy_auth = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.terraform.proxy_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_TIMEOUT_DOWNLOAD") {
+            if let Ok(timeout) = val.parse() {
+                self.terraform.proxy_timeout_download = timeout;
+            }
+        }
+
+        // Ansible Galaxy config
+        if let Ok(val) = env::var("NORA_ANSIBLE_PROXY") {
+            self.ansible.proxy = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_ANSIBLE_PROXY_AUTH") {
+            self.ansible.proxy_auth = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_ANSIBLE_PROXY_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.ansible.proxy_timeout = timeout;
+            }
+        }
+
+        // NuGet config
+        if let Ok(val) = env::var("NORA_NUGET_PROXY") {
+            self.nuget.proxy = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_NUGET_PROXY_AUTH") {
+            self.nuget.proxy_auth = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_NUGET_PROXY_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.nuget.proxy_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_NUGET_METADATA_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.nuget.metadata_ttl = ttl;
+            }
+        }
+
+        // pub.dev config
+        if let Ok(val) = env::var("NORA_PUB_PROXY") {
+            self.pub_dart.proxy = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_PUB_PROXY_AUTH") {
+            self.pub_dart.proxy_auth = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_PUB_PROXY_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.pub_dart.proxy_timeout = timeout;
+            }
+        }
+
+        // Conan proxy config
+        if let Ok(val) = env::var("NORA_CONAN_PROXY") {
+            self.conan.proxy = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_CONAN_PROXY_AUTH") {
+            self.conan.proxy_auth = if val.is_empty() { None } else { Some(val) };
+        }
+        if let Ok(val) = env::var("NORA_CONAN_PROXY_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.conan.proxy_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_CONAN_PROXY_TIMEOUT_DOWNLOAD") {
+            if let Ok(timeout) = val.parse() {
+                self.conan.proxy_timeout_download = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_CONAN_METADATA_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.conan.metadata_ttl = ttl;
+            }
+        }
+
         // Token storage
         if let Ok(val) = env::var("NORA_AUTH_TOKEN_STORAGE") {
             self.auth.token_storage = val;
@@ -1199,6 +1615,12 @@ impl Default for Config {
             cargo: CargoConfig::default(),
             docker: DockerConfig::default(),
             raw: RawConfig::default(),
+            gems: GemsConfig::default(),
+            terraform: TerraformConfig::default(),
+            ansible: AnsibleConfig::default(),
+            nuget: NugetConfig::default(),
+            pub_dart: PubDartConfig::default(),
+            conan: ConanConfig::default(),
             auth: AuthConfig::default(),
             rate_limit: RateLimitConfig::default(),
             secrets: SecretsConfig::default(),

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 The Nora Authors
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Curation layer — package access control for proxy registries.
@@ -16,38 +16,13 @@ use crate::config::{CurationConfig, CurationMode};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
-use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 // ============================================================================
-// Registry Type
+// Registry Type (re-export from shared module)
 // ============================================================================
 
-/// Supported registry formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum RegistryType {
-    Npm,
-    PyPI,
-    Maven,
-    Cargo,
-    Go,
-    Docker,
-    Raw,
-}
-
-impl fmt::Display for RegistryType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RegistryType::Npm => write!(f, "npm"),
-            RegistryType::PyPI => write!(f, "pypi"),
-            RegistryType::Maven => write!(f, "maven"),
-            RegistryType::Cargo => write!(f, "cargo"),
-            RegistryType::Go => write!(f, "go"),
-            RegistryType::Docker => write!(f, "docker"),
-            RegistryType::Raw => write!(f, "raw"),
-        }
-    }
-}
+pub use crate::registry_type::RegistryType;
 
 // ============================================================================
 // Filter Request

--- a/nora-registry/src/dashboard_metrics.rs
+++ b/nora-registry/src/dashboard_metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use serde::{Deserialize, Serialize};

--- a/nora-registry/src/error.rs
+++ b/nora-registry/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Application error handling with HTTP response conversion

--- a/nora-registry/src/health.rs
+++ b/nora-registry/src/health.rs
@@ -1,8 +1,9 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use axum::{extract::State, http::StatusCode, response::Json, routing::get, Router};
 use serde::Serialize;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::AppState;
@@ -13,7 +14,7 @@ pub struct HealthStatus {
     pub version: String,
     pub uptime_seconds: u64,
     pub storage: StorageHealth,
-    pub registries: RegistriesHealth,
+    pub registries: HashMap<String, String>,
 }
 
 #[derive(Serialize)]
@@ -22,17 +23,6 @@ pub struct StorageHealth {
     pub reachable: bool,
     pub endpoint: String,
     pub total_size_bytes: u64,
-}
-
-#[derive(Serialize)]
-pub struct RegistriesHealth {
-    pub docker: String,
-    pub maven: String,
-    pub npm: String,
-    pub cargo: String,
-    pub pypi: String,
-    pub go: String,
-    pub raw: String,
 }
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -53,6 +43,12 @@ async fn health_check(State(state): State<Arc<AppState>>) -> (StatusCode, Json<H
 
     let uptime = state.start_time.elapsed().as_secs();
 
+    // Build registries map from enabled registries
+    let mut registries = HashMap::new();
+    for reg in &state.enabled_registries {
+        registries.insert(reg.as_str().to_string(), "ok".to_string());
+    }
+
     let health = HealthStatus {
         status: status.to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -66,15 +62,7 @@ async fn health_check(State(state): State<Arc<AppState>>) -> (StatusCode, Json<H
             },
             total_size_bytes: total_size,
         },
-        registries: RegistriesHealth {
-            docker: "ok".to_string(),
-            maven: "ok".to_string(),
-            npm: "ok".to_string(),
-            cargo: "ok".to_string(),
-            pypi: "ok".to_string(),
-            go: "ok".to_string(),
-            raw: "ok".to_string(),
-        },
+        registries,
     };
 
     let status_code = if storage_reachable {
@@ -101,7 +89,9 @@ async fn check_storage_reachable(state: &AppState) -> bool {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
-    use crate::test_helpers::{body_bytes, create_test_context, send};
+    use crate::test_helpers::{
+        body_bytes, create_test_context, create_test_context_with_config, send,
+    };
     use axum::http::{Method, StatusCode};
 
     #[tokio::test]
@@ -164,5 +154,39 @@ mod tests {
         let ctx = create_test_context();
         let response = send(&ctx.app, Method::GET, "/ready", "").await;
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_health_registries_dynamic() {
+        // Default context has all 7 v1 registries enabled
+        let ctx = create_test_context();
+        let response = send(&ctx.app, Method::GET, "/health", "").await;
+        let body = body_bytes(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let registries = json.get("registries").unwrap().as_object().unwrap();
+        assert!(registries.contains_key("docker"));
+        assert!(registries.contains_key("maven"));
+        assert!(registries.contains_key("npm"));
+        assert!(registries.contains_key("cargo"));
+        assert!(registries.contains_key("pypi"));
+        assert!(registries.contains_key("go"));
+        assert!(registries.contains_key("raw"));
+    }
+
+    #[tokio::test]
+    async fn test_health_disabled_registry_absent() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.docker.enabled = false;
+        });
+        let response = send(&ctx.app, Method::GET, "/health", "").await;
+        let body = body_bytes(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let registries = json.get("registries").unwrap().as_object().unwrap();
+        assert!(
+            !registries.contains_key("docker"),
+            "disabled docker should not appear in health"
+        );
+        // Others should still be present
+        assert!(registries.contains_key("maven"));
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 The Nora Authors
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 #![deny(clippy::unwrap_used)]
 #![forbid(unsafe_code)]
@@ -18,6 +18,7 @@ mod mirror;
 mod openapi;
 mod rate_limit;
 mod registry;
+mod registry_type;
 mod repo_index;
 mod request_id;
 mod retention;
@@ -44,6 +45,7 @@ use audit::AuditLog;
 use auth::HtpasswdAuth;
 use config::{Config, CurationMode, StorageMode};
 use dashboard_metrics::DashboardMetrics;
+use registry_type::RegistryType;
 use repo_index::RepoIndex;
 pub use storage::Storage;
 use tokens::TokenStore;
@@ -138,6 +140,7 @@ enum CurationCommand {
 pub struct AppState {
     pub storage: Storage,
     pub config: Config,
+    pub enabled_registries: HashSet<RegistryType>,
     pub start_time: Instant,
     pub auth: Option<HtpasswdAuth>,
     pub tokens: Option<TokenStore>,
@@ -469,17 +472,17 @@ fn run_curation_explain(config: &Config, package_spec: &str) {
         None => (rest.to_string(), None),
     };
 
-    let registry = match registry_str {
-        "npm" => curation::RegistryType::Npm,
-        "pypi" => curation::RegistryType::PyPI,
-        "maven" => curation::RegistryType::Maven,
-        "cargo" => curation::RegistryType::Cargo,
-        "go" => curation::RegistryType::Go,
-        "docker" => curation::RegistryType::Docker,
-        other => {
+    let registry = match RegistryType::from_str_opt(registry_str) {
+        Some(rt) => rt,
+        None => {
             eprintln!(
-                "ERROR: Unknown registry '{}'. Use: npm, pypi, maven, cargo, go, docker",
-                other
+                "ERROR: Unknown registry '{}'. Use: {}",
+                registry_str,
+                RegistryType::all()
+                    .iter()
+                    .map(|r| r.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
             );
             std::process::exit(1);
         }
@@ -668,15 +671,44 @@ async fn run_server(config: Config, storage: Storage) {
         info!(patterns = count, "Namespace isolation filter loaded");
     }
 
-    // Registry routes (shared between rate-limited and non-limited paths)
-    let registry_routes = Router::new()
-        .merge(registry::docker_routes())
-        .merge(registry::maven_routes())
-        .merge(registry::npm_routes())
-        .merge(registry::cargo_routes())
-        .merge(registry::pypi_routes())
-        .merge(registry::raw_routes())
-        .merge(registry::go_routes());
+    // Determine enabled registries from config
+    let enabled_registries = config.enabled_registries();
+
+    // Registry routes — only merge enabled registries
+    let mut registry_routes = Router::new();
+    for reg in &enabled_registries {
+        match reg {
+            RegistryType::Docker => {
+                registry_routes = registry_routes.merge(registry::docker_routes())
+            }
+            RegistryType::Maven => {
+                registry_routes = registry_routes.merge(registry::maven_routes())
+            }
+            RegistryType::Npm => registry_routes = registry_routes.merge(registry::npm_routes()),
+            RegistryType::Cargo => {
+                registry_routes = registry_routes.merge(registry::cargo_routes())
+            }
+            RegistryType::PyPI => registry_routes = registry_routes.merge(registry::pypi_routes()),
+            RegistryType::Raw => registry_routes = registry_routes.merge(registry::raw_routes()),
+            RegistryType::Go => registry_routes = registry_routes.merge(registry::go_routes()),
+            RegistryType::Gems => registry_routes = registry_routes.merge(registry::gems_routes()),
+            RegistryType::Terraform => {
+                registry_routes = registry_routes.merge(registry::terraform_routes())
+            }
+            RegistryType::Ansible => {
+                registry_routes = registry_routes.merge(registry::ansible_routes())
+            }
+            RegistryType::Nuget => {
+                registry_routes = registry_routes.merge(registry::nuget_routes())
+            }
+            RegistryType::PubDart => {
+                registry_routes = registry_routes.merge(registry::pub_dart_routes())
+            }
+            RegistryType::Conan => {
+                registry_routes = registry_routes.merge(registry::conan_routes())
+            }
+        }
+    }
 
     // Routes WITHOUT rate limiting (health, metrics, UI)
     let public_routes = Router::new()
@@ -708,6 +740,7 @@ async fn run_server(config: Config, storage: Storage) {
     let state = Arc::new(AppState {
         storage,
         config,
+        enabled_registries,
         start_time,
         auth,
         tokens,
@@ -802,20 +835,25 @@ async fn run_server(config: Config, storage: Storage) {
         "Nora started"
     );
 
+    // Log enabled registries and their mount points
+    let enabled_names: Vec<String> = state
+        .enabled_registries
+        .iter()
+        .map(|r| format!("{} ({})", r.display_name(), r.mount_point()))
+        .collect();
+    info!(
+        registries = ?enabled_names,
+        count = state.enabled_registries.len(),
+        "Enabled registries"
+    );
+
     info!(
         health = "/health",
         ready = "/ready",
         metrics = "/metrics",
         ui = "/ui/",
         api_docs = "/api-docs",
-        docker = "/v2/",
-        maven = "/maven2/",
-        npm = "/npm/",
-        cargo = "/cargo/",
-        pypi = "/simple/",
-        go = "/go/",
-        raw = "/raw/",
-        "Available endpoints"
+        "System endpoints"
     );
 
     // Background task: persist metrics and flush token last_used every 30 seconds
@@ -885,7 +923,10 @@ async fn print_retention_coverage(storage: &Storage, rules: &[config::RetentionR
     if covered.contains("*") {
         return;
     }
-    let all_registries = ["docker", "maven", "npm", "pypi", "cargo", "go", "raw"];
+    let all_registries = RegistryType::all_v1()
+        .iter()
+        .map(|r| r.as_str())
+        .collect::<Vec<_>>();
     let mut uncovered = Vec::new();
     for name in &all_registries {
         if !covered.contains(name) {

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use axum::{
@@ -125,6 +125,18 @@ fn detect_registry(path: &str) -> String {
         "go".to_string()
     } else if path.starts_with("/raw/") {
         "raw".to_string()
+    } else if path.starts_with("/gems/") {
+        "gems".to_string()
+    } else if path.starts_with("/terraform/") {
+        "terraform".to_string()
+    } else if path.starts_with("/ansible/") {
+        "ansible".to_string()
+    } else if path.starts_with("/nuget/") {
+        "nuget".to_string()
+    } else if path.starts_with("/pub/") {
+        "pub".to_string()
+    } else if path.starts_with("/conan/") {
+        "conan".to_string()
     } else if path.starts_with("/ui") {
         "ui".to_string()
     } else {

--- a/nora-registry/src/migrate.rs
+++ b/nora-registry/src/migrate.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Migration between storage backends

--- a/nora-registry/src/mirror/docker.rs
+++ b/nora-registry/src/mirror/docker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Docker image mirroring — fetch images from upstream registries and push to NORA.

--- a/nora-registry/src/mirror/mod.rs
+++ b/nora-registry/src/mirror/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! `nora mirror` — pre-fetch dependencies through NORA proxy cache.

--- a/nora-registry/src/mirror/npm.rs
+++ b/nora-registry/src/mirror/npm.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! npm lockfile parser + mirror logic.

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! OpenAPI documentation and Swagger UI
@@ -18,10 +18,10 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.6.5",
-        description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, and Raw",
+        version = "0.7.0-rc5",
+        description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
-        contact(name = "DevITWay", url = "https://getnora.dev")
+        contact(name = "The NORA Authors", url = "https://getnora.dev")
     ),
     servers(
         (url = "/", description = "Current server")
@@ -37,6 +37,12 @@ use crate::AppState;
         (name = "pypi", description = "PyPI Simple API"),
         (name = "go", description = "Go Module Proxy API"),
         (name = "raw", description = "Raw File Storage API"),
+        (name = "gems", description = "RubyGems Proxy API"),
+        (name = "terraform", description = "Terraform Registry Proxy API"),
+        (name = "ansible", description = "Ansible Galaxy Proxy API"),
+        (name = "nuget", description = "NuGet v3 Registry Proxy API"),
+        (name = "pub", description = "Dart/Flutter Pub Registry Proxy API"),
+        (name = "conan", description = "Conan V2 Registry Proxy API (C/C++)"),
         (name = "auth", description = "Authentication & API Tokens")
     ),
     paths(
@@ -84,6 +90,24 @@ use crate::AppState;
         // Raw
         crate::openapi::raw_file_get,
         crate::openapi::raw_file_put,
+        // RubyGems
+        crate::openapi::gems_info,
+        crate::openapi::gems_download,
+        // Terraform
+        crate::openapi::terraform_service_discovery,
+        crate::openapi::terraform_provider_versions,
+        // Ansible Galaxy
+        crate::openapi::ansible_collection_list,
+        crate::openapi::ansible_download,
+        // NuGet
+        crate::openapi::nuget_service_index,
+        crate::openapi::nuget_download,
+        // Pub (Dart/Flutter)
+        crate::openapi::pub_package_list,
+        crate::openapi::pub_archive_download,
+        // Conan (C/C++)
+        crate::openapi::conan_ping,
+        crate::openapi::conan_recipe_file,
         // Tokens
         crate::openapi::create_token,
         crate::openapi::list_tokens,
@@ -808,6 +832,190 @@ pub async fn raw_file_get() {}
     )
 )]
 pub async fn raw_file_put() {}
+
+// -------------------- RubyGems --------------------
+
+/// Get gem compact index
+#[utoipa::path(
+    get,
+    path = "/gems/info/{name}",
+    tag = "gems",
+    params(
+        ("name" = String, Path, description = "Gem name (e.g., 'rails')")
+    ),
+    responses(
+        (status = 200, description = "Compact index for gem"),
+        (status = 404, description = "Gem not found")
+    )
+)]
+pub async fn gems_info() {}
+
+/// Download gem file
+#[utoipa::path(
+    get,
+    path = "/gems/gems/{filename}",
+    tag = "gems",
+    params(
+        ("filename" = String, Path, description = "Gem file (e.g., 'rails-7.0.0.gem')")
+    ),
+    responses(
+        (status = 200, description = "Gem binary"),
+        (status = 404, description = "Gem not found")
+    )
+)]
+pub async fn gems_download() {}
+
+// -------------------- Terraform --------------------
+
+/// Terraform service discovery
+#[utoipa::path(
+    get,
+    path = "/terraform/.well-known/terraform.json",
+    tag = "terraform",
+    responses(
+        (status = 200, description = "Service discovery JSON")
+    )
+)]
+pub async fn terraform_service_discovery() {}
+
+/// List Terraform provider versions
+#[utoipa::path(
+    get,
+    path = "/terraform/v1/providers/{ns}/{ptype}/versions",
+    tag = "terraform",
+    params(
+        ("ns" = String, Path, description = "Provider namespace"),
+        ("ptype" = String, Path, description = "Provider type")
+    ),
+    responses(
+        (status = 200, description = "Version list"),
+        (status = 404, description = "Provider not found")
+    )
+)]
+pub async fn terraform_provider_versions() {}
+
+// -------------------- Ansible Galaxy --------------------
+
+/// List Ansible Galaxy collections
+#[utoipa::path(
+    get,
+    path = "/ansible/api/v3/plugin/ansible/content/published/collections/index/",
+    tag = "ansible",
+    responses(
+        (status = 200, description = "Collection list"),
+        (status = 502, description = "Upstream unreachable")
+    )
+)]
+pub async fn ansible_collection_list() {}
+
+/// Download Ansible collection tarball
+#[utoipa::path(
+    get,
+    path = "/ansible/download/{filename}",
+    tag = "ansible",
+    params(
+        ("filename" = String, Path, description = "Collection tarball (e.g., 'community-general-7.0.0.tar.gz')")
+    ),
+    responses(
+        (status = 200, description = "Collection tarball"),
+        (status = 404, description = "Collection not found")
+    )
+)]
+pub async fn ansible_download() {}
+
+// -------------------- NuGet --------------------
+
+/// NuGet v3 service index
+#[utoipa::path(
+    get,
+    path = "/nuget/v3/index.json",
+    tag = "nuget",
+    responses(
+        (status = 200, description = "Service index JSON with @id URLs rewritten")
+    )
+)]
+pub async fn nuget_service_index() {}
+
+/// Download NuGet package
+#[utoipa::path(
+    get,
+    path = "/nuget/v3/flatcontainer/{path}",
+    tag = "nuget",
+    params(
+        ("path" = String, Path, description = "Package path (e.g., 'newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg')")
+    ),
+    responses(
+        (status = 200, description = "Package file (.nupkg or .nuspec)"),
+        (status = 404, description = "Package not found")
+    )
+)]
+pub async fn nuget_download() {}
+
+// -------------------- Pub (Dart/Flutter) --------------------
+
+/// List or search pub packages
+#[utoipa::path(
+    get,
+    path = "/pub/api/packages/{package}",
+    tag = "pub",
+    params(
+        ("package" = String, Path, description = "Package name")
+    ),
+    responses(
+        (status = 200, description = "Package metadata with versions"),
+        (status = 404, description = "Package not found")
+    )
+)]
+pub async fn pub_package_list() {}
+
+/// Download pub package archive
+#[utoipa::path(
+    get,
+    path = "/pub/packages/{package}/versions/{archive}",
+    tag = "pub",
+    params(
+        ("package" = String, Path, description = "Package name"),
+        ("archive" = String, Path, description = "Version archive (e.g., '1.2.0.tar.gz')")
+    ),
+    responses(
+        (status = 200, description = "Package archive (.tar.gz)"),
+        (status = 404, description = "Package not found")
+    )
+)]
+pub async fn pub_archive_download() {}
+
+// -------------------- Conan --------------------
+
+/// Conan v2 ping (capabilities check)
+#[utoipa::path(
+    get,
+    path = "/conan/v2/ping",
+    tag = "conan",
+    responses(
+        (status = 200, description = "Ping response with X-Conan-Server-Capabilities header")
+    )
+)]
+pub async fn conan_ping() {}
+
+/// Download a Conan recipe or package file
+#[utoipa::path(
+    get,
+    path = "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/files/{filename}",
+    tag = "conan",
+    params(
+        ("name" = String, Path, description = "Package name"),
+        ("ver" = String, Path, description = "Package version"),
+        ("user" = String, Path, description = "User (or _ for default)"),
+        ("chan" = String, Path, description = "Channel (or _ for default)"),
+        ("rrev" = String, Path, description = "Recipe revision hash"),
+        ("filename" = String, Path, description = "File name (e.g., conanfile.py)")
+    ),
+    responses(
+        (status = 200, description = "File content"),
+        (status = 404, description = "File not found")
+    )
+)]
+pub async fn conan_recipe_file() {}
 
 // -------------------- Auth / Tokens --------------------
 

--- a/nora-registry/src/rate_limit.rs
+++ b/nora-registry/src/rate_limit.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Rate limiting configuration and middleware

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -1,0 +1,447 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! Ansible Galaxy collection proxy (API v3).
+//!
+//! Implements a caching proxy for galaxy.ansible.com:
+//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/
+//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/
+//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/versions/
+//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/versions/{ver}/
+//!   GET /ansible/download/{ns}-{name}-{ver}.tar.gz — collection tarball (immutable)
+//!
+//! Client config:
+//!   ansible-galaxy collection install community.general -s http://nora:4000/ansible/
+
+use crate::activity_log::{ActionType, ActivityEntry};
+use crate::audit::AuditEntry;
+use crate::registry::{proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::AppState;
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::sync::Arc;
+
+const UPSTREAM_DEFAULT: &str = "https://galaxy.ansible.com";
+const API_PREFIX: &str = "/api/v3/plugin/ansible/content/published/collections/index";
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        // Collection listing
+        .route(
+            "/ansible/api/v3/plugin/ansible/content/published/collections/index/",
+            get(collection_list),
+        )
+        // Collection detail
+        .route(
+            "/ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/",
+            get(collection_detail),
+        )
+        // Version listing
+        .route(
+            "/ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/versions/",
+            get(version_list),
+        )
+        // Version detail
+        .route(
+            "/ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/versions/{ver}/",
+            get(version_detail),
+        )
+        // Collection tarball download (immutable)
+        .route("/ansible/download/{filename}", get(download_tarball))
+}
+
+// ── Collection list ────────────────────────────────────────────────────
+
+async fn collection_list(State(state): State<Arc<AppState>>) -> Response {
+    let proxy_url = upstream_url(&state);
+    let url = format!("{}{}/", proxy_url.trim_end_matches('/'), API_PREFIX);
+
+    proxy_json(&state, &url, "ansible-collections").await
+}
+
+// ── Collection detail ──────────────────────────────────────────────────
+
+async fn collection_detail(
+    State(state): State<Arc<AppState>>,
+    Path((ns, name)): Path<(String, String)>,
+) -> Response {
+    if !is_valid_name(&ns) || !is_valid_name(&name) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}{}/{}/{}/",
+        proxy_url.trim_end_matches('/'),
+        API_PREFIX,
+        ns,
+        name
+    );
+
+    proxy_json(&state, &url, &format!("{}.{}", ns, name)).await
+}
+
+// ── Version listing ────────────────────────────────────────────────────
+
+async fn version_list(
+    State(state): State<Arc<AppState>>,
+    Path((ns, name)): Path<(String, String)>,
+) -> Response {
+    if !is_valid_name(&ns) || !is_valid_name(&name) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}{}/{}/{}/versions/",
+        proxy_url.trim_end_matches('/'),
+        API_PREFIX,
+        ns,
+        name
+    );
+
+    proxy_json(&state, &url, &format!("{}.{}/versions", ns, name)).await
+}
+
+// ── Version detail ─────────────────────────────────────────────────────
+
+async fn version_detail(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path((ns, name, ver)): Path<(String, String, String)>,
+) -> Response {
+    if !is_valid_name(&ns) || !is_valid_name(&name) || !is_valid_version(&ver) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Ansible,
+        &format!("{}.{}", ns, name),
+        Some(&ver),
+    ) {
+        return response;
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}{}/{}/{}/versions/{}/",
+        proxy_url.trim_end_matches('/'),
+        API_PREFIX,
+        ns,
+        name,
+        ver
+    );
+
+    proxy_json(&state, &url, &format!("{}.{} v{}", ns, name, ver)).await
+}
+
+// ── Tarball download (immutable) ───────────────────────────────────────
+
+async fn download_tarball(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(filename): Path<String>,
+) -> Response {
+    // filename = "namespace-name-version.tar.gz"
+    if !filename.ends_with(".tar.gz") || !is_safe_filename(&filename) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Parse namespace, name, version from filename
+    let stem = filename.strip_suffix(".tar.gz").unwrap_or(&filename);
+    let parts: Vec<&str> = stem.splitn(3, '-').collect();
+    if parts.len() < 3 {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+    let (ns, name, ver) = (parts[0], parts[1], parts[2]);
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Ansible,
+        &format!("{}.{}", ns, name),
+        Some(ver),
+    ) {
+        return response;
+    }
+
+    let storage_key = format!("ansible/download/{}", filename);
+
+    // Immutable cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        // Integrity check
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Ansible,
+            &format!("{}.{}", ns, name),
+            Some(ver),
+            &data,
+        ) {
+            return response;
+        }
+
+        state.metrics.record_download("ansible");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            filename,
+            "ansible",
+            "CACHE",
+        ));
+        return with_binary(data.to_vec());
+    }
+
+    // Fetch from upstream
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/download/{}-{}-{}.tar.gz",
+        proxy_url.trim_end_matches('/'),
+        ns,
+        name,
+        ver
+    );
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.ansible.proxy_timeout,
+        state.config.ansible.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("ansible");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                filename,
+                "ansible",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "ansible", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("ansible");
+            with_binary(bytes)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Ansible Galaxy download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Generic JSON proxy ─────────────────────────────────────────────────
+
+async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Response {
+    match proxy_fetch_text(
+        &state.http_client,
+        url,
+        state.config.ansible.proxy_timeout,
+        state.config.ansible.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("ansible");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact_name.to_string(),
+                "ansible",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "ansible", ""));
+
+            state.repo_index.invalidate("ansible");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Ansible Galaxy upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn upstream_url(state: &AppState) -> String {
+    state
+        .config
+        .ansible
+        .proxy
+        .clone()
+        .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
+}
+
+fn with_json(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+fn with_binary(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/gzip"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 256
+        && !name.contains('/')
+        && !name.contains('\0')
+        && !name.contains("..")
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+fn is_valid_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 128
+        && !version.contains('/')
+        && !version.contains('\0')
+        && !version.contains("..")
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+}
+
+fn is_safe_filename(name: &str) -> bool {
+    !name.contains("..")
+        && !name.contains('/')
+        && !name.contains('\0')
+        && !name.is_empty()
+        && name.len() <= 512
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_names() {
+        assert!(is_valid_name("community"));
+        assert!(is_valid_name("ansible"));
+        assert!(is_valid_name("cloud-common"));
+    }
+
+    #[test]
+    fn test_invalid_names() {
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("../evil"));
+        assert!(!is_valid_name("foo/bar"));
+    }
+
+    #[test]
+    fn test_safe_filename() {
+        assert!(is_safe_filename("community-general-7.0.0.tar.gz"));
+        assert!(!is_safe_filename("../evil.tar.gz"));
+        assert!(!is_safe_filename("evil/path.tar.gz"));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod integration_tests {
+    use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+    use axum::http::{Method, StatusCode};
+
+    #[tokio::test]
+    async fn test_ansible_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = false;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/api/v3/plugin/ansible/content/published/collections/index/",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_ansible_cached_tarball() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "ansible/download/community-general-7.0.0.tar.gz",
+                b"tarball-data",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/download/community-general-7.0.0.tar.gz",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"tarball-data");
+    }
+
+    #[tokio::test]
+    async fn test_ansible_unreachable_proxy() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+            cfg.ansible.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.ansible.proxy_timeout = 1;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/api/v3/plugin/ansible/content/published/collections/index/",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+}

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Cargo registry with sparse index (RFC 2789).

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -1,0 +1,1161 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! Conan V2 proxy registry (C/C++ packages).
+//!
+//! Implements a caching proxy for ConanCenter (center2.conan.io):
+//!
+//! ## Endpoints
+//!   GET /conan/v2/ping                             — health + capabilities
+//!   GET /conan/v2/conans/search                    — search recipes
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/latest — latest recipe revision
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions — list recipe revisions
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/files — list recipe files
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/files/{filename} — download recipe file (immutable)
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/latest — latest package revision
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/revisions — list package revisions
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/revisions/{prev}/files — list package files
+//!   GET /conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/revisions/{prev}/files/{filename} — download package file (immutable)
+//!
+//! ## Client config
+//!   conan remote add nora http://nora:4000/conan
+//!
+//! ## Design
+//! - All revision-scoped files are immutably cached (revisions never change)
+//! - Metadata endpoints (latest, revisions, search) use TTL-based caching
+//! - Uses a single wildcard route + dispatcher pattern (deep URL hierarchy)
+
+use crate::activity_log::{ActionType, ActivityEntry};
+use crate::audit::AuditEntry;
+use crate::registry::{proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::AppState;
+use axum::{
+    extract::{Path, Query, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const UPSTREAM_DEFAULT: &str = "https://center2.conan.io";
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        // Ping — must come before the wildcard
+        .route("/conan/v2/ping", get(ping))
+        // Search
+        .route("/conan/v2/conans/search", get(search))
+        // Recipe file download (deepest, most specific — must be before shorter patterns)
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/revisions/{prev}/files/{filename}",
+            get(package_file_download),
+        )
+        // Package file listing
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/revisions/{prev}/files",
+            get(package_file_list),
+        )
+        // Package revision list
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/revisions",
+            get(package_revisions),
+        )
+        // Package latest revision
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/packages/{pkg_id}/latest",
+            get(package_latest),
+        )
+        // Recipe file download
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/files/{filename}",
+            get(recipe_file_download),
+        )
+        // Recipe file listing
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rrev}/files",
+            get(recipe_file_list),
+        )
+        // Recipe revision list
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions",
+            get(recipe_revisions),
+        )
+        // Recipe latest revision
+        .route(
+            "/conan/v2/conans/{name}/{ver}/{user}/{chan}/latest",
+            get(recipe_latest),
+        )
+}
+
+// ── Ping ──────────────────────────────────────────────────────────────
+
+async fn ping() -> Response {
+    (
+        StatusCode::OK,
+        [
+            ("X-Conan-Server-Capabilities", "revisions"),
+            ("Content-Type", "text/plain"),
+        ],
+        "",
+    )
+        .into_response()
+}
+
+// ── Search ────────────────────────────────────────────────────────────
+
+async fn search(
+    State(state): State<Arc<AppState>>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Response {
+    let query = params.get("q").cloned().unwrap_or_default();
+    if query.len() > 256 {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let proxy_url = upstream_url(&state);
+    // Percent-encode query for upstream
+    let encoded_query: String = query
+        .bytes()
+        .flat_map(|b| {
+            if b.is_ascii_alphanumeric()
+                || b == b'-'
+                || b == b'_'
+                || b == b'.'
+                || b == b'*'
+                || b == b'/'
+            {
+                vec![b as char]
+            } else if b == b' ' {
+                vec!['+']
+            } else {
+                format!("%{:02X}", b).chars().collect()
+            }
+        })
+        .collect();
+    let url = format!(
+        "{}/v2/conans/search?q={}",
+        proxy_url.trim_end_matches('/'),
+        encoded_query
+    );
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.conan.proxy_timeout,
+        state.config.conan.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("conan");
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                format!("search:{}", query),
+                "conan",
+                "PROXY",
+            ));
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Conan search error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Recipe latest revision (TTL cached) ───────────────────────────────
+
+async fn recipe_latest(
+    State(state): State<Arc<AppState>>,
+    Path((name, ver, user, chan)): Path<(String, String, String, String)>,
+) -> Response {
+    if !is_valid_ref(&name) || !is_valid_ref(&ver) || !is_valid_ref(&user) || !is_valid_ref(&chan) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let storage_key = format!("conan/{}/latest.json", ref_str);
+
+    // TTL cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
+                state.metrics.record_download("conan");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/latest",
+        proxy_url.trim_end_matches('/'),
+        ref_str
+    );
+
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+}
+
+// ── Recipe revisions (TTL cached) ─────────────────────────────────────
+
+async fn recipe_revisions(
+    State(state): State<Arc<AppState>>,
+    Path((name, ver, user, chan)): Path<(String, String, String, String)>,
+) -> Response {
+    if !is_valid_ref(&name) || !is_valid_ref(&ver) || !is_valid_ref(&user) || !is_valid_ref(&chan) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let storage_key = format!("conan/{}/revisions.json", ref_str);
+
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
+                state.metrics.record_download("conan");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions",
+        proxy_url.trim_end_matches('/'),
+        ref_str
+    );
+
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+}
+
+// ── Recipe file listing (immutable — scoped to revision) ──────────────
+
+async fn recipe_file_list(
+    State(state): State<Arc<AppState>>,
+    Path((name, ver, user, chan, rrev)): Path<(String, String, String, String, String)>,
+) -> Response {
+    if !is_valid_ref(&name)
+        || !is_valid_ref(&ver)
+        || !is_valid_ref(&user)
+        || !is_valid_ref(&chan)
+        || !is_valid_revision(&rrev)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let storage_key = format!("conan/{}/revisions/{}/files.json", ref_str, rrev);
+
+    // Immutable: if cached, serve directly
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        state.metrics.record_download("conan");
+        state.metrics.record_cache_hit();
+        return with_json(data.to_vec());
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions/{}/files",
+        proxy_url.trim_end_matches('/'),
+        ref_str,
+        rrev
+    );
+
+    fetch_and_cache_immutable_json(&state, &url, &storage_key, &ref_str).await
+}
+
+// ── Recipe file download (immutable) ──────────────────────────────────
+
+async fn recipe_file_download(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path((name, ver, user, chan, rrev, filename)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Response {
+    if !is_valid_ref(&name)
+        || !is_valid_ref(&ver)
+        || !is_valid_ref(&user)
+        || !is_valid_ref(&chan)
+        || !is_valid_revision(&rrev)
+        || !is_valid_filename(&filename)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let artifact = format!("{} rrev={} {}", ref_str, rrev, filename);
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Conan,
+        &name,
+        Some(&ver),
+    ) {
+        return response;
+    }
+
+    let storage_key = format!("conan/{}/revisions/{}/files/{}", ref_str, rrev, filename);
+
+    // Immutable cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        // Curation integrity
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Conan,
+            &name,
+            Some(&ver),
+            &data,
+        ) {
+            return response;
+        }
+
+        state.metrics.record_download("conan");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            artifact,
+            "conan",
+            "CACHE",
+        ));
+        return with_binary(data.to_vec());
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions/{}/files/{}",
+        proxy_url.trim_end_matches('/'),
+        ref_str,
+        rrev,
+        filename
+    );
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.conan.proxy_timeout,
+        state.config.conan.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact,
+                "conan",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
+
+            // Immutable cache: put_if_absent
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("conan");
+            with_binary(bytes)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Conan recipe file download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Package latest revision (TTL cached) ──────────────────────────────
+
+async fn package_latest(
+    State(state): State<Arc<AppState>>,
+    Path((name, ver, user, chan, rrev, pkg_id)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Response {
+    if !is_valid_ref(&name)
+        || !is_valid_ref(&ver)
+        || !is_valid_ref(&user)
+        || !is_valid_ref(&chan)
+        || !is_valid_revision(&rrev)
+        || !is_valid_revision(&pkg_id)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let storage_key = format!(
+        "conan/{}/revisions/{}/packages/{}/latest.json",
+        ref_str, rrev, pkg_id
+    );
+
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
+                state.metrics.record_download("conan");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions/{}/packages/{}/latest",
+        proxy_url.trim_end_matches('/'),
+        ref_str,
+        rrev,
+        pkg_id
+    );
+
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+}
+
+// ── Package revisions (TTL cached) ────────────────────────────────────
+
+async fn package_revisions(
+    State(state): State<Arc<AppState>>,
+    Path((name, ver, user, chan, rrev, pkg_id)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Response {
+    if !is_valid_ref(&name)
+        || !is_valid_ref(&ver)
+        || !is_valid_ref(&user)
+        || !is_valid_ref(&chan)
+        || !is_valid_revision(&rrev)
+        || !is_valid_revision(&pkg_id)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let storage_key = format!(
+        "conan/{}/revisions/{}/packages/{}/revisions.json",
+        ref_str, rrev, pkg_id
+    );
+
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
+                state.metrics.record_download("conan");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions/{}/packages/{}/revisions",
+        proxy_url.trim_end_matches('/'),
+        ref_str,
+        rrev,
+        pkg_id
+    );
+
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+}
+
+// ── Package file listing (immutable — scoped to PREV) ─────────────────
+
+async fn package_file_list(
+    State(state): State<Arc<AppState>>,
+    Path((name, ver, user, chan, rrev, pkg_id, prev)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Response {
+    if !is_valid_ref(&name)
+        || !is_valid_ref(&ver)
+        || !is_valid_ref(&user)
+        || !is_valid_ref(&chan)
+        || !is_valid_revision(&rrev)
+        || !is_valid_revision(&pkg_id)
+        || !is_valid_revision(&prev)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let storage_key = format!(
+        "conan/{}/revisions/{}/packages/{}/revisions/{}/files.json",
+        ref_str, rrev, pkg_id, prev
+    );
+
+    // Immutable
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        state.metrics.record_download("conan");
+        state.metrics.record_cache_hit();
+        return with_json(data.to_vec());
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions/{}/packages/{}/revisions/{}/files",
+        proxy_url.trim_end_matches('/'),
+        ref_str,
+        rrev,
+        pkg_id,
+        prev
+    );
+
+    fetch_and_cache_immutable_json(&state, &url, &storage_key, &ref_str).await
+}
+
+// ── Package file download (immutable) ─────────────────────────────────
+
+async fn package_file_download(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Path((name, ver, user, chan, rrev, pkg_id, prev, filename)): Path<(
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+        String,
+    )>,
+) -> Response {
+    if !is_valid_ref(&name)
+        || !is_valid_ref(&ver)
+        || !is_valid_ref(&user)
+        || !is_valid_ref(&chan)
+        || !is_valid_revision(&rrev)
+        || !is_valid_revision(&pkg_id)
+        || !is_valid_revision(&prev)
+        || !is_valid_filename(&filename)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let artifact = format!("{}#{}:{}#{} {}", ref_str, rrev, pkg_id, prev, filename);
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Conan,
+        &name,
+        Some(&ver),
+    ) {
+        return response;
+    }
+
+    let storage_key = format!(
+        "conan/{}/revisions/{}/packages/{}/revisions/{}/files/{}",
+        ref_str, rrev, pkg_id, prev, filename
+    );
+
+    // Immutable cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        // Curation integrity
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Conan,
+            &name,
+            Some(&ver),
+            &data,
+        ) {
+            return response;
+        }
+
+        state.metrics.record_download("conan");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            artifact,
+            "conan",
+            "CACHE",
+        ));
+        return with_binary(data.to_vec());
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v2/conans/{}/revisions/{}/packages/{}/revisions/{}/files/{}",
+        proxy_url.trim_end_matches('/'),
+        ref_str,
+        rrev,
+        pkg_id,
+        prev,
+        filename
+    );
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.conan.proxy_timeout_download,
+        state.config.conan.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact,
+                "conan",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
+
+            // Immutable cache
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("conan");
+            with_binary(bytes)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Conan package file download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Shared fetch helpers ──────────────────────────────────────────────
+
+/// Fetch JSON from upstream, cache with TTL (mutable content).
+async fn fetch_and_cache_json(
+    state: &AppState,
+    url: &str,
+    storage_key: &str,
+    artifact: &str,
+) -> Response {
+    match proxy_fetch_text(
+        &state.http_client,
+        url,
+        state.config.conan.proxy_timeout,
+        state.config.conan.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact.to_string(),
+                "conan",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key.to_string();
+            let data = text.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("conan");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(url, error = ?e, "Conan upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+/// Fetch JSON from upstream, cache immutably (content scoped to revision, never changes).
+async fn fetch_and_cache_immutable_json(
+    state: &AppState,
+    url: &str,
+    storage_key: &str,
+    artifact: &str,
+) -> Response {
+    match proxy_fetch_text(
+        &state.http_client,
+        url,
+        state.config.conan.proxy_timeout,
+        state.config.conan.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact.to_string(),
+                "conan",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key.to_string();
+            let data = text.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, data.as_bytes()).await;
+                }
+            });
+
+            state.repo_index.invalidate("conan");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(url, error = ?e, "Conan upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+fn upstream_url(state: &AppState) -> String {
+    state
+        .config
+        .conan
+        .proxy
+        .clone()
+        .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
+}
+
+fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(modified_unix) < ttl_secs
+}
+
+fn with_json(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+fn with_binary(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/octet-stream"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+/// Validate a Conan reference component (name, version, user, channel).
+/// Allows alphanumeric, hyphens, underscores, dots, and `_` (for `_/_` pattern).
+fn is_valid_ref(s: &str) -> bool {
+    !s.is_empty()
+        && s.len() <= 256
+        && !s.contains('/')
+        && !s.contains('\0')
+        && !s.contains("..")
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '+')
+}
+
+/// Validate a revision hash (SHA-256 hex or short hash).
+fn is_valid_revision(rev: &str) -> bool {
+    !rev.is_empty()
+        && rev.len() <= 128
+        && rev
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() || c.is_ascii_alphanumeric())
+}
+
+/// Validate a filename in the Conan file listing.
+fn is_valid_filename(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 256
+        && !name.contains('/')
+        && !name.contains('\0')
+        && !name.contains("..")
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '+')
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_refs() {
+        assert!(is_valid_ref("zlib"));
+        assert!(is_valid_ref("1.2.13"));
+        assert!(is_valid_ref("_")); // user/channel can be _
+        assert!(is_valid_ref("my-org"));
+        assert!(is_valid_ref("boost"));
+        assert!(is_valid_ref("1.0.0+build1"));
+    }
+
+    #[test]
+    fn test_invalid_refs() {
+        assert!(!is_valid_ref(""));
+        assert!(!is_valid_ref("../evil"));
+        assert!(!is_valid_ref("foo/bar"));
+        assert!(!is_valid_ref("foo\0bar"));
+        assert!(!is_valid_ref("foo bar"));
+    }
+
+    #[test]
+    fn test_valid_revisions() {
+        assert!(is_valid_revision("abc123"));
+        assert!(is_valid_revision(
+            "e4f7c8d90ab1234567890abcdef1234567890abc"
+        ));
+        assert!(is_valid_revision("0"));
+    }
+
+    #[test]
+    fn test_invalid_revisions() {
+        assert!(!is_valid_revision(""));
+        assert!(!is_valid_revision("abc/def"));
+        assert!(!is_valid_revision("abc def"));
+    }
+
+    #[test]
+    fn test_valid_filenames() {
+        assert!(is_valid_filename("conanfile.py"));
+        assert!(is_valid_filename("conanmanifest.txt"));
+        assert!(is_valid_filename("conan_package.tgz"));
+        assert!(is_valid_filename("conan_sources.tgz"));
+        assert!(is_valid_filename("conaninfo.txt"));
+        assert!(is_valid_filename("conan_export.tgz"));
+    }
+
+    #[test]
+    fn test_invalid_filenames() {
+        assert!(!is_valid_filename(""));
+        assert!(!is_valid_filename("../evil.txt"));
+        assert!(!is_valid_filename("path/to/file"));
+        assert!(!is_valid_filename("file\0name"));
+    }
+
+    #[test]
+    fn test_ttl_fresh() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(is_within_ttl(now - 10, 3600));
+    }
+
+    #[test]
+    fn test_ttl_expired() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(!is_within_ttl(now - 7200, 3600));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod integration_tests {
+    use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+    use axum::http::{Method, StatusCode};
+
+    #[tokio::test]
+    async fn test_conan_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.conan.enabled = false;
+        });
+        let resp = send(&ctx.app, Method::GET, "/conan/v2/ping", "").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_conan_ping() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.conan.enabled = true;
+        });
+        let resp = send(&ctx.app, Method::GET, "/conan/v2/ping", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers()
+                .get("X-Conan-Server-Capabilities")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "revisions"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conan_cached_recipe_file() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.conan.enabled = true;
+        });
+
+        // Pre-populate cache with immutable recipe file
+        ctx.state
+            .storage
+            .put(
+                "conan/zlib/1.2.13/_/_/revisions/abc123/files/conanfile.py",
+                b"class ZlibConan(ConanFile):\n    pass",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/zlib/1.2.13/_/_/revisions/abc123/files/conanfile.py",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert!(body.starts_with(b"class Zlib"));
+    }
+
+    #[tokio::test]
+    async fn test_conan_cached_package_file() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.conan.enabled = true;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "conan/zlib/1.2.13/_/_/revisions/abc123/packages/deadbeef/revisions/cafe42/files/conan_package.tgz",
+                b"fake-tgz-data",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/zlib/1.2.13/_/_/revisions/abc123/packages/deadbeef/revisions/cafe42/files/conan_package.tgz",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"fake-tgz-data");
+    }
+
+    #[tokio::test]
+    async fn test_conan_unreachable_proxy() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.conan.enabled = true;
+            cfg.conan.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.conan.proxy_timeout = 1;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/zlib/1.2.13/_/_/latest",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn test_conan_invalid_ref_rejected() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.conan.enabled = true;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/../evil/_/_/latest",
+            "",
+        )
+        .await;
+        assert!(resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_conan_curation_enforce_blocks() {
+        use crate::test_helpers::send_with_headers;
+
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "conan", "name": "evil-lib", "version": "*", "reason": "supply chain attack"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.conan.enabled = true;
+            cfg.curation.mode = crate::config::CurationMode::Enforce;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "conan/evil-lib/1.0/_/_/revisions/abc123/files/conanfile.py",
+                b"evil recipe",
+            )
+            .await
+            .unwrap();
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/evil-lib/1.0/_/_/revisions/abc123/files/conanfile.py",
+            vec![],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers()
+                .get("x-nora-decision")
+                .and_then(|v| v.to_str().ok()),
+            Some("blocked")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conan_curation_audit_passes() {
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "conan", "name": "evil-lib", "version": "*", "reason": "supply chain attack"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.conan.enabled = true;
+            cfg.curation.mode = crate::config::CurationMode::Audit;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "conan/evil-lib/1.0/_/_/revisions/abc123/files/conanfile.py",
+                b"evil recipe",
+            )
+            .await
+            .unwrap();
+
+        // Audit mode: logs but passes through
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/evil-lib/1.0/_/_/revisions/abc123/files/conanfile.py",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"evil recipe");
+    }
+
+    #[tokio::test]
+    async fn test_conan_curation_enforce_allows_safe() {
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "conan", "name": "evil-lib", "version": "*", "reason": "supply chain attack"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.conan.enabled = true;
+            cfg.curation.mode = crate::config::CurationMode::Enforce;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "conan/zlib/1.2.13/_/_/revisions/abc123/files/conanfile.py",
+                b"safe recipe",
+            )
+            .await
+            .unwrap();
+
+        // zlib is NOT blocked — should pass
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/conan/v2/conans/zlib/1.2.13/_/_/revisions/abc123/files/conanfile.py",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"safe recipe");
+    }
+}

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use crate::activity_log::{ActionType, ActivityEntry};

--- a/nora-registry/src/registry/docker_auth.rs
+++ b/nora-registry/src/registry/docker_auth.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use crate::config::basic_auth_header;

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -1,0 +1,794 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! RubyGems proxy registry.
+//!
+//! Implements a caching proxy for rubygems.org:
+//!   GET /gems/specs.4.8.gz             — full gem index (binary, mutable, TTL cache)
+//!   GET /gems/latest_specs.4.8.gz      — latest gem index (binary, mutable, TTL cache)
+//!   GET /gems/prerelease_specs.4.8.gz  — prerelease index (binary, mutable, TTL cache)
+//!   GET /gems/info/{name}              — compact index (text, mutable, TTL cache)
+//!   GET /gems/gems/{name}-{version}.gem — gem download (binary, immutable cache)
+//!   GET /gems/quick/Marshal.4.8/{name}-{version}.gemspec.rz — gemspec (binary, immutable cache)
+//!
+//! Client config:
+//!   bundle config mirror.https://rubygems.org http://nora:4000/gems/
+
+use crate::activity_log::{ActionType, ActivityEntry};
+use crate::audit::AuditEntry;
+use crate::registry::{proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::AppState;
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const UPSTREAM_DEFAULT: &str = "https://rubygems.org";
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        // Index files (mutable)
+        .route("/gems/specs.4.8.gz", get(specs_index))
+        .route("/gems/latest_specs.4.8.gz", get(latest_specs_index))
+        .route("/gems/prerelease_specs.4.8.gz", get(prerelease_specs_index))
+        // Compact index (mutable)
+        .route("/gems/info/{name}", get(compact_index))
+        // Gem download (immutable) — wildcard because axum forbids two params per segment
+        .route("/gems/gems/{filename}", get(download_gem))
+        // Gemspec (immutable)
+        .route("/gems/quick/Marshal.4.8/{filename}", get(download_gemspec))
+}
+
+/// Check if a cached entry is within TTL based on unix timestamp
+fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(modified_unix) < ttl_secs
+}
+
+// ── Index endpoints (mutable, TTL cached) ─────────────────────────────
+
+async fn specs_index(State(state): State<Arc<AppState>>) -> Response {
+    fetch_index(&state, "specs.4.8.gz").await
+}
+
+async fn latest_specs_index(State(state): State<Arc<AppState>>) -> Response {
+    fetch_index(&state, "latest_specs.4.8.gz").await
+}
+
+async fn prerelease_specs_index(State(state): State<Arc<AppState>>) -> Response {
+    fetch_index(&state, "prerelease_specs.4.8.gz").await
+}
+
+async fn fetch_index(state: &AppState, filename: &str) -> Response {
+    let storage_key = format!("gems/{}", filename);
+
+    // Check TTL: if cached and fresh, serve from cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.gems.index_ttl) {
+                state.metrics.record_download("gems");
+                state.metrics.record_cache_hit();
+                state.activity.push(ActivityEntry::new(
+                    ActionType::CacheHit,
+                    filename.to_string(),
+                    "gems",
+                    "CACHE",
+                ));
+                return with_binary(data.to_vec(), "application/gzip");
+            }
+        }
+    }
+
+    // Fetch from upstream
+    let proxy_url = upstream_url(state);
+    let url = format!("{}/{}", proxy_url.trim_end_matches('/'), filename);
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.gems.proxy_timeout,
+        state.config.gems.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("gems");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                filename.to_string(),
+                "gems",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
+
+            // Cache in background (overwrite — mutable content)
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, &data).await;
+            });
+
+            state.repo_index.invalidate("gems");
+            with_binary(bytes, "application/gzip")
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(filename, error = ?e, "RubyGems upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Compact index ──────────────────────────────────────────────────────
+
+async fn compact_index(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(name): Path<String>,
+) -> Response {
+    if !is_valid_gem_name(&name) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Gems,
+        &name,
+        None,
+    ) {
+        return response;
+    }
+
+    let storage_key = format!("gems/info/{}", name);
+
+    // Check TTL cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.gems.index_ttl) {
+                state.metrics.record_download("gems");
+                state.metrics.record_cache_hit();
+                state.activity.push(ActivityEntry::new(
+                    ActionType::CacheHit,
+                    name.clone(),
+                    "gems",
+                    "CACHE",
+                ));
+                return with_text(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!("{}/info/{}", proxy_url.trim_end_matches('/'), name);
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.gems.proxy_timeout,
+        state.config.gems.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("gems");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                name,
+                "gems",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = text.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("gems");
+            with_text(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "RubyGems compact index error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Gem download (immutable) ───────────────────────────────────────────
+
+async fn download_gem(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(filename): Path<String>,
+) -> Response {
+    // filename = "name-version.gem" — strip .gem suffix and split
+    let stem = match filename.strip_suffix(".gem") {
+        Some(s) => s,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let (name, version) = match split_gem_filename(stem) {
+        Some(nv) => nv,
+        None => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    if !is_valid_gem_name(&name) || !is_valid_version(&version) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let artifact = format!("{}-{}", name, version);
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Gems,
+        &name,
+        Some(&version),
+    ) {
+        return response;
+    }
+
+    let storage_key = format!("gems/gems/{}.gem", artifact);
+
+    // Immutable: if cached, serve directly
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        // Curation integrity
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::Gems,
+            &name,
+            Some(&version),
+            &data,
+        ) {
+            return response;
+        }
+
+        state.metrics.record_download("gems");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            artifact,
+            "gems",
+            "CACHE",
+        ));
+        return with_binary(data.to_vec(), "application/octet-stream");
+    }
+
+    // Fetch from upstream
+    let proxy_url = upstream_url(&state);
+    let url = format!("{}/gems/{}.gem", proxy_url.trim_end_matches('/'), artifact);
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.gems.proxy_timeout,
+        state.config.gems.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("gems");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact,
+                "gems",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
+
+            // Immutable cache: put_if_absent
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("gems");
+            with_binary(bytes, "application/octet-stream")
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "RubyGems download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Gemspec download (immutable) ───────────────────────────────────────
+
+async fn download_gemspec(
+    State(state): State<Arc<AppState>>,
+    Path(filename): Path<String>,
+) -> Response {
+    // filename = "name-version.gemspec.rz" — strip suffix and split
+    let stem = match filename.strip_suffix(".gemspec.rz") {
+        Some(s) => s,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    let (name, version) = match split_gem_filename(stem) {
+        Some(nv) => nv,
+        None => return StatusCode::BAD_REQUEST.into_response(),
+    };
+    if !is_valid_gem_name(&name) || !is_valid_version(&version) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let artifact = format!("{}-{}", name, version);
+    let storage_key = format!("gems/quick/Marshal.4.8/{}.gemspec.rz", artifact);
+
+    // Immutable cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        state.metrics.record_download("gems");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            artifact,
+            "gems",
+            "CACHE",
+        ));
+        return with_binary(data.to_vec(), "application/octet-stream");
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/quick/Marshal.4.8/{}.gemspec.rz",
+        proxy_url.trim_end_matches('/'),
+        artifact
+    );
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.gems.proxy_timeout,
+        state.config.gems.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("gems");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact,
+                "gems",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("gems");
+            with_binary(bytes, "application/octet-stream")
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "RubyGems gemspec error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn upstream_url(state: &AppState) -> String {
+    state
+        .config
+        .gems
+        .proxy
+        .clone()
+        .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
+}
+
+fn with_binary(data: Vec<u8>, content_type: &'static str) -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, HeaderValue::from_static(content_type))],
+        data,
+    )
+        .into_response()
+}
+
+fn with_text(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; charset=utf-8"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+/// Split gem filename "name-version" into (name, version).
+/// The version starts at the last hyphen followed by a digit.
+/// Examples:
+///   "rails-7.0.0"      → ("rails", "7.0.0")
+///   "rack-test-1.0.0"  → ("rack-test", "1.0.0")
+///   "rspec-core-3.12"  → ("rspec-core", "3.12")
+fn split_gem_filename(stem: &str) -> Option<(String, String)> {
+    // Find the last '-' that is followed by a digit (start of version)
+    let mut split_pos = None;
+    for (i, c) in stem.char_indices() {
+        if c == '-' {
+            if let Some(next) = stem[i + 1..].chars().next() {
+                if next.is_ascii_digit() {
+                    split_pos = Some(i);
+                }
+            }
+        }
+    }
+    let pos = split_pos?;
+    let name = &stem[..pos];
+    let version = &stem[pos + 1..];
+    if name.is_empty() || version.is_empty() {
+        return None;
+    }
+    Some((name.to_string(), version.to_string()))
+}
+
+/// Validate gem name: alphanumeric, hyphens, underscores, dots.
+/// No path traversal, no slashes, no null bytes.
+fn is_valid_gem_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 256
+        && !name.contains('/')
+        && !name.contains('\0')
+        && !name.contains("..")
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+/// Validate version string: digits, dots, hyphens, alphanumeric, ".pre", ".beta", etc.
+fn is_valid_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 128
+        && !version.contains('/')
+        && !version.contains('\0')
+        && !version.contains("..")
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_gem_names() {
+        assert!(is_valid_gem_name("rails"));
+        assert!(is_valid_gem_name("activerecord"));
+        assert!(is_valid_gem_name("rack-test"));
+        assert!(is_valid_gem_name("ruby_parser"));
+        assert!(is_valid_gem_name("nokogiri"));
+        assert!(is_valid_gem_name("rspec-core"));
+    }
+
+    #[test]
+    fn test_invalid_gem_names() {
+        assert!(!is_valid_gem_name(""));
+        assert!(!is_valid_gem_name("../evil"));
+        assert!(!is_valid_gem_name("foo/bar"));
+        assert!(!is_valid_gem_name("foo\0bar"));
+        assert!(!is_valid_gem_name("foo bar"));
+    }
+
+    #[test]
+    fn test_valid_versions() {
+        assert!(is_valid_version("1.0.0"));
+        assert!(is_valid_version("3.2.1"));
+        assert!(is_valid_version("1.0.0.pre"));
+        assert!(is_valid_version("2.0.0.beta1"));
+        assert!(is_valid_version("1.0.0-rc1"));
+    }
+
+    #[test]
+    fn test_invalid_versions() {
+        assert!(!is_valid_version(""));
+        assert!(!is_valid_version("../1.0"));
+        assert!(!is_valid_version("1.0/evil"));
+        assert!(!is_valid_version("1.0\0evil"));
+    }
+
+    #[test]
+    fn test_split_gem_filename_simple() {
+        let (name, ver) = split_gem_filename("rails-7.0.0").unwrap();
+        assert_eq!(name, "rails");
+        assert_eq!(ver, "7.0.0");
+    }
+
+    #[test]
+    fn test_split_gem_filename_with_hyphens() {
+        let (name, ver) = split_gem_filename("rack-test-1.0.0").unwrap();
+        assert_eq!(name, "rack-test");
+        assert_eq!(ver, "1.0.0");
+    }
+
+    #[test]
+    fn test_split_gem_filename_complex() {
+        let (name, ver) = split_gem_filename("rspec-core-3.12.0").unwrap();
+        assert_eq!(name, "rspec-core");
+        assert_eq!(ver, "3.12.0");
+    }
+
+    #[test]
+    fn test_split_gem_filename_pre_release() {
+        let (name, ver) = split_gem_filename("rails-7.0.0.pre").unwrap();
+        assert_eq!(name, "rails");
+        assert_eq!(ver, "7.0.0.pre");
+    }
+
+    #[test]
+    fn test_split_gem_filename_no_version() {
+        assert!(split_gem_filename("noversion").is_none());
+    }
+
+    #[test]
+    fn test_split_gem_filename_empty() {
+        assert!(split_gem_filename("").is_none());
+    }
+
+    #[test]
+    fn test_ttl_fresh() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(is_within_ttl(now - 10, 3600)); // 10s ago, TTL 1h
+    }
+
+    #[test]
+    fn test_ttl_expired() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(!is_within_ttl(now - 7200, 3600)); // 2h ago, TTL 1h
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod integration_tests {
+    use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+    use axum::http::{Method, StatusCode};
+
+    #[tokio::test]
+    async fn test_gems_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.gems.enabled = false;
+        });
+        // Gems routes are not mounted when disabled, so 404
+        let resp = send(&ctx.app, Method::GET, "/gems/info/rails", "").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_gems_invalid_name_rejected() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.gems.enabled = true;
+        });
+        let resp = send(&ctx.app, Method::GET, "/gems/info/../evil", "").await;
+        // Route won't match since .. is not a valid {name} segment
+        assert!(resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_gems_unreachable_proxy_returns_error() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.gems.enabled = true;
+            // Point to unreachable host to force error path
+            cfg.gems.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.gems.proxy_timeout = 1;
+        });
+        let resp = send(&ctx.app, Method::GET, "/gems/gems/rails-7.0.0.gem", "").await;
+        // Unreachable proxy → BAD_GATEWAY
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn test_gems_cached_gem_served() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.gems.enabled = true;
+        });
+
+        // Pre-populate cache
+        ctx.state
+            .storage
+            .put("gems/gems/test-gem-1.0.0.gem", b"gem-binary-data")
+            .await
+            .unwrap();
+
+        let resp = send(&ctx.app, Method::GET, "/gems/gems/test-gem-1.0.0.gem", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"gem-binary-data");
+    }
+
+    #[tokio::test]
+    async fn test_gems_cached_gemspec_served() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.gems.enabled = true;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "gems/quick/Marshal.4.8/test-gem-1.0.0.gemspec.rz",
+                b"gemspec-data",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/gems/quick/Marshal.4.8/test-gem-1.0.0.gemspec.rz",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"gemspec-data");
+    }
+
+    #[tokio::test]
+    async fn test_gems_cached_compact_index() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.gems.enabled = true;
+            cfg.gems.index_ttl = 3600; // 1 hour
+        });
+
+        ctx.state
+            .storage
+            .put("gems/info/rails", b"---\n1.0.0 |checksum:abc123")
+            .await
+            .unwrap();
+
+        let resp = send(&ctx.app, Method::GET, "/gems/info/rails", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert!(body.starts_with(b"---"));
+    }
+
+    #[tokio::test]
+    async fn test_gems_curation_enforce_blocks() {
+        use crate::test_helpers::send_with_headers;
+
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "gems", "name": "evil-gem", "version": "*", "reason": "malware"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.gems.enabled = true;
+            cfg.curation.mode = crate::config::CurationMode::Enforce;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        ctx.state
+            .storage
+            .put("gems/gems/evil-gem-1.0.0.gem", b"evil-data")
+            .await
+            .unwrap();
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/gems/gems/evil-gem-1.0.0.gem",
+            vec![],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            resp.headers()
+                .get("x-nora-decision")
+                .and_then(|v| v.to_str().ok()),
+            Some("blocked")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_gems_curation_audit_passes() {
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "gems", "name": "evil-gem", "version": "*", "reason": "malware"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.gems.enabled = true;
+            cfg.curation.mode = crate::config::CurationMode::Audit;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        ctx.state
+            .storage
+            .put("gems/gems/evil-gem-1.0.0.gem", b"evil-data")
+            .await
+            .unwrap();
+
+        // Audit mode: logs but does NOT block
+        let resp = send(&ctx.app, Method::GET, "/gems/gems/evil-gem-1.0.0.gem", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"evil-data");
+    }
+
+    #[tokio::test]
+    async fn test_gems_curation_off_passes() {
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "gems", "name": "evil-gem", "version": "*", "reason": "malware"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.gems.enabled = true;
+            cfg.curation.mode = crate::config::CurationMode::Off;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        ctx.state
+            .storage
+            .put("gems/gems/evil-gem-1.0.0.gem", b"evil-data")
+            .await
+            .unwrap();
+
+        // Off mode: no filtering
+        let resp = send(&ctx.app, Method::GET, "/gems/gems/evil-gem-1.0.0.gem", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Go module proxy (GOPROXY protocol).

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Maven registry — Maven 2 repository layout with checksums, immutability,

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -1,23 +1,35 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
+mod ansible;
 mod cargo_registry;
+mod conan;
 pub mod docker;
 pub mod docker_auth;
+mod gems;
 mod go;
 mod maven;
 mod npm;
+mod nuget;
+mod pub_dart;
 mod pypi;
 mod raw;
+mod terraform;
 
+pub use ansible::routes as ansible_routes;
 pub use cargo_registry::routes as cargo_routes;
+pub use conan::routes as conan_routes;
 pub use docker::routes as docker_routes;
 pub use docker_auth::DockerAuth;
+pub use gems::routes as gems_routes;
 pub use go::routes as go_routes;
 pub use maven::routes as maven_routes;
 pub use npm::routes as npm_routes;
+pub use nuget::routes as nuget_routes;
+pub use pub_dart::routes as pub_dart_routes;
 pub use pypi::routes as pypi_routes;
 pub use raw::routes as raw_routes;
+pub use terraform::routes as terraform_routes;
 
 use crate::config::basic_auth_header;
 use std::time::Duration;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use crate::activity_log::{ActionType, ActivityEntry};

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -1,0 +1,555 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! NuGet v3 registry proxy.
+//!
+//! Implements a caching proxy for api.nuget.org:
+//!   GET /nuget/v3/index.json — service index (JSON, rewrite @id URLs)
+//!   GET /nuget/v3/registration/{id}/index.json — package registration
+//!   GET /nuget/v3/flatcontainer/{id}/index.json — version list
+//!   GET /nuget/v3/flatcontainer/{id}/{ver}/{filename}.nupkg — package download (immutable)
+//!   GET /nuget/v3/flatcontainer/{id}/{ver}/{filename}.nuspec — package spec (immutable)
+//!
+//! Client config:
+//!   dotnet nuget add source http://nora:4000/nuget/v3/index.json -n nora
+
+use crate::activity_log::{ActionType, ActivityEntry};
+use crate::audit::AuditEntry;
+use crate::registry::{proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::AppState;
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::sync::Arc;
+
+const UPSTREAM_DEFAULT: &str = "https://api.nuget.org";
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        // Service index
+        .route("/nuget/v3/index.json", get(service_index))
+        // Registration index
+        .route(
+            "/nuget/v3/registration/{id}/index.json",
+            get(registration_index),
+        )
+        // Flat container: version list + package download (single wildcard)
+        .route(
+            "/nuget/v3/flatcontainer/{*path}",
+            get(flatcontainer_handler),
+        )
+}
+
+// ── Service index ──────────────────────────────────────────────────────
+
+async fn service_index(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    let host = extract_host(&state, &headers);
+    let proxy_url = upstream_url(&state);
+    let url = format!("{}/v3/index.json", proxy_url.trim_end_matches('/'));
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.nuget.proxy_timeout,
+        state.config.nuget.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            // Rewrite @id URLs to point through NORA
+            let rewritten = rewrite_service_index(&text, &host);
+
+            state.metrics.record_download("nuget");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                "service-index".to_string(),
+                "nuget",
+                "PROXY",
+            ));
+
+            with_json(rewritten.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "NuGet service index error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Registration index ─────────────────────────────────────────────────
+
+async fn registration_index(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(id): Path<String>,
+) -> Response {
+    let id_lower = id.to_lowercase();
+    if !is_valid_package_id(&id_lower) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Nuget,
+        &id_lower,
+        None,
+    ) {
+        return response;
+    }
+
+    let storage_key = format!("nuget/registration/{}/index.json", id_lower);
+
+    // TTL cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
+                state.metrics.record_download("nuget");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v3/registration5-gz-semver2/{}/index.json",
+        proxy_url.trim_end_matches('/'),
+        id_lower
+    );
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.nuget.proxy_timeout,
+        state.config.nuget.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("nuget");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                id_lower.clone(),
+                "nuget",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "nuget", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = text.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("nuget");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "NuGet registration error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Flat container dispatcher ───────────────────────────────────────────
+
+async fn flatcontainer_handler(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(path): Path<String>,
+) -> Response {
+    // Path patterns:
+    //   {id}/index.json              → version list
+    //   {id}/{ver}/{filename}.nupkg  → package download
+    //   {id}/{ver}/{filename}.nuspec → package spec
+    let parts: Vec<&str> = path.splitn(3, '/').collect();
+    match parts.len() {
+        2 if parts[1] == "index.json" => version_list(state, parts[0]).await,
+        3 => flatcontainer_download(state, headers, &path, parts[0], parts[1], parts[2]).await,
+        _ => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+// ── Version list ───────────────────────────────────────────────────────
+
+async fn version_list(state: Arc<AppState>, id: &str) -> Response {
+    let id = id.to_string();
+    let id_lower = id.to_lowercase();
+    if !is_valid_package_id(&id_lower) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let storage_key = format!("nuget/flatcontainer/{}/index.json", id_lower);
+
+    // TTL cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
+                state.metrics.record_download("nuget");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v3-flatcontainer/{}/index.json",
+        proxy_url.trim_end_matches('/'),
+        id_lower
+    );
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.nuget.proxy_timeout,
+        state.config.nuget.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("nuget");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                format!("{}/versions", id_lower),
+                "nuget",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "nuget", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = text.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("nuget");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "NuGet version list error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Flatcontainer download (nupkg/nuspec, immutable) ───────────────────
+
+async fn flatcontainer_download(
+    state: Arc<AppState>,
+    headers: axum::http::HeaderMap,
+    path: &str,
+    id: &str,
+    ver: &str,
+    filename: &str,
+) -> Response {
+    if !is_safe_path(path) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Only serve .nupkg and .nuspec files
+    if !filename.ends_with(".nupkg") && !filename.ends_with(".nuspec") {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let id_lower = id.to_lowercase();
+
+    // Curation check for .nupkg downloads
+    if filename.ends_with(".nupkg") {
+        if let Some(response) = crate::curation::check_download(
+            &state.curation,
+            state.config.curation.bypass_token.as_deref(),
+            &headers,
+            crate::curation::RegistryType::Nuget,
+            &id_lower,
+            Some(ver),
+        ) {
+            return response;
+        }
+    }
+
+    let storage_key = format!("nuget/flatcontainer/{}", path.to_lowercase());
+    let content_type = if filename.ends_with(".nuspec") {
+        "application/xml"
+    } else {
+        "application/octet-stream"
+    };
+
+    // Immutable cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if filename.ends_with(".nupkg") {
+            if let Some(response) = crate::curation::verify_integrity(
+                &state.curation,
+                crate::curation::RegistryType::Nuget,
+                &id_lower,
+                Some(ver),
+                &data,
+            ) {
+                return response;
+            }
+        }
+
+        state.metrics.record_download("nuget");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            format!("{}/{}", id_lower, filename),
+            "nuget",
+            "CACHE",
+        ));
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, content_type)],
+            data.to_vec(),
+        )
+            .into_response();
+    }
+
+    // Fetch from upstream
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v3-flatcontainer/{}/{}/{}",
+        proxy_url.trim_end_matches('/'),
+        id_lower,
+        ver.to_lowercase(),
+        filename.to_lowercase()
+    );
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.nuget.proxy_timeout,
+        state.config.nuget.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("nuget");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                format!("{}/{}", id_lower, filename),
+                "nuget",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "nuget", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("nuget");
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, content_type)],
+                bytes.to_vec(),
+            )
+                .into_response()
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "NuGet download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+fn extract_host(state: &AppState, headers: &HeaderMap) -> String {
+    if let Some(public_url) = &state.config.server.public_url {
+        return public_url
+            .trim_start_matches("http://")
+            .trim_start_matches("https://")
+            .to_string();
+    }
+    headers
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("localhost:4000")
+        .to_string()
+}
+
+fn upstream_url(state: &AppState) -> String {
+    state
+        .config
+        .nuget
+        .proxy
+        .clone()
+        .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
+}
+
+fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(modified_unix) < ttl_secs
+}
+
+fn with_json(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+/// Rewrite NuGet service index: replace upstream @id URLs with NORA URLs.
+/// This is a simplified rewrite — full NuGet v3 has many @id fields.
+fn rewrite_service_index(json_text: &str, host: &str) -> String {
+    let nora_base = format!("http://{}/nuget", host);
+
+    // Simple string replacement approach for the major services
+    json_text
+        .replace(
+            "https://api.nuget.org/v3-flatcontainer/",
+            &format!("{}/v3/flatcontainer/", nora_base),
+        )
+        .replace(
+            "https://api.nuget.org/v3/registration5-gz-semver2/",
+            &format!("{}/v3/registration/", nora_base),
+        )
+}
+
+fn is_valid_package_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 256
+        && !id.contains('/')
+        && !id.contains('\0')
+        && !id.contains("..")
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_')
+}
+
+fn is_safe_path(path: &str) -> bool {
+    !path.contains("..")
+        && !path.starts_with('/')
+        && !path.contains("//")
+        && !path.contains('\0')
+        && !path.is_empty()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_package_ids() {
+        assert!(is_valid_package_id("newtonsoft.json"));
+        assert!(is_valid_package_id("system.text.json"));
+        assert!(is_valid_package_id("microsoft.extensions.logging"));
+        assert!(is_valid_package_id("xunit"));
+    }
+
+    #[test]
+    fn test_invalid_package_ids() {
+        assert!(!is_valid_package_id(""));
+        assert!(!is_valid_package_id("../evil"));
+        assert!(!is_valid_package_id("foo/bar"));
+    }
+
+    #[test]
+    fn test_rewrite_service_index() {
+        let input = r#"{"resources":[{"@id":"https://api.nuget.org/v3-flatcontainer/","@type":"PackageBaseAddress/3.0.0"}]}"#;
+        let result = rewrite_service_index(input, "nora:4000");
+        assert!(result.contains("http://nora:4000/nuget/v3/flatcontainer/"));
+        assert!(!result.contains("api.nuget.org/v3-flatcontainer/"));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod integration_tests {
+    use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+    use axum::http::{Method, StatusCode};
+
+    #[tokio::test]
+    async fn test_nuget_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = false;
+        });
+        let resp = send(&ctx.app, Method::GET, "/nuget/v3/index.json", "").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_nuget_cached_nupkg() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "nuget/flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+                b"nupkg-data",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/flatcontainer/newtonsoft.json/13.0.1/newtonsoft.json.13.0.1.nupkg",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"nupkg-data");
+    }
+
+    #[tokio::test]
+    async fn test_nuget_unreachable_proxy() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.nuget.proxy_timeout = 1;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/flatcontainer/test-package/index.json",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+}

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -1,0 +1,840 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! Dart/Flutter pub registry proxy.
+//!
+//! Implements hosted pub repository endpoints from repository spec v2:
+//!   GET /pub/api/packages?q={term}&page={page}         — package search
+//!   GET /pub/api/packages/{package}                    — package metadata with versions
+//!   GET /pub/api/packages/{package}/versions/{version} — version metadata
+//!   GET /pub/api/packages/{package}/advisories         — security advisories
+//!   GET /pub/packages/{package}/versions/{version}.tar.gz — package archive
+//!
+//! Client config:
+//!   export PUB_HOSTED_URL=http://nora:4000/pub
+//!   dart pub get
+
+use crate::activity_log::{ActionType, ActivityEntry};
+use crate::audit::AuditEntry;
+use crate::registry::{proxy_fetch, ProxyError};
+use crate::validation::validate_storage_key;
+use crate::AppState;
+use axum::{
+    extract::{Path, RawQuery, State},
+    http::{header, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use serde_json::{Map, Value};
+use sha2::Digest;
+use std::sync::Arc;
+
+const PUB_CONTENT_TYPE: &str = "application/vnd.pub.v2+json";
+const PUB_ARCHIVE_CONTENT_TYPE: &str = "application/octet-stream";
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'#')
+    .add(b'%')
+    .add(b'/')
+    .add(b'<')
+    .add(b'>')
+    .add(b'?')
+    .add(b'[')
+    .add(b'\\')
+    .add(b']')
+    .add(b'^')
+    .add(b'`')
+    .add(b'{')
+    .add(b'|')
+    .add(b'}');
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/pub/api/packages", get(search_packages))
+        .route(
+            "/pub/api/packages/{package}/advisories",
+            get(package_advisories),
+        )
+        .route(
+            "/pub/api/packages/{package}/versions/{version}",
+            get(version_metadata),
+        )
+        .route("/pub/api/packages/{package}", get(package_listing))
+        .route(
+            "/pub/packages/{package}/versions/{archive}",
+            get(download_archive),
+        )
+}
+
+async fn search_packages(
+    State(state): State<Arc<AppState>>,
+    RawQuery(raw_query): RawQuery,
+) -> Response {
+    let raw_query = raw_query.unwrap_or_default();
+    let key = format!(
+        "pub/search/{}.json",
+        hex::encode(sha2::Sha256::digest(raw_query.as_bytes()))
+    );
+
+    if let Ok(data) = state.storage.get(&key).await {
+        return pub_json_response(data.to_vec());
+    }
+
+    let Some(proxy_url) = &state.config.pub_dart.proxy else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let url = if raw_query.is_empty() {
+        format!("{}/api/packages", proxy_url.trim_end_matches('/'))
+    } else {
+        format!(
+            "{}/api/packages?{}",
+            proxy_url.trim_end_matches('/'),
+            raw_query
+        )
+    };
+
+    match fetch_pub_api(&state, &url).await {
+        Ok(data) => {
+            let nora_base = nora_base_url(&state);
+            let rewritten = rewrite_search_response(&data, &nora_base, proxy_url).unwrap_or(data);
+            cache_bytes(&state, key, rewritten.clone()).await;
+            pub_json_response(rewritten)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, query = raw_query, "pub search upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn package_listing(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path(package): Path<String>,
+) -> Response {
+    if !is_valid_pub_package_name(&package) {
+        return pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_package",
+            "Invalid pub package name",
+        );
+    }
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::PubDart,
+        &package,
+        None,
+    ) {
+        return response;
+    }
+
+    let key = format!("pub/api/packages/{}.json", package);
+    if let Ok(data) = state.storage.get(&key).await {
+        return pub_json_response(data.to_vec());
+    }
+
+    let Some(proxy_url) = &state.config.pub_dart.proxy else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let url = format!(
+        "{}/api/packages/{}",
+        proxy_url.trim_end_matches('/'),
+        encode_segment(&package)
+    );
+
+    match fetch_pub_api(&state, &url).await {
+        Ok(data) => {
+            let nora_base = nora_base_url(&state);
+            let rewritten = rewrite_package_response(&data, &nora_base, &package).unwrap_or(data);
+            cache_bytes(&state, key, rewritten.clone()).await;
+            state.repo_index.invalidate("pub");
+            pub_json_response(rewritten)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, package, "pub package upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn version_metadata(
+    State(state): State<Arc<AppState>>,
+    Path((package, version)): Path<(String, String)>,
+) -> Response {
+    if !is_valid_pub_package_name(&package) || !is_valid_pub_version(&version) {
+        return pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_version",
+            "Invalid package name or version",
+        );
+    }
+
+    let key = format!("pub/api/packages/{}/versions/{}.json", package, version);
+    if let Ok(data) = state.storage.get(&key).await {
+        return pub_json_response(data.to_vec());
+    }
+
+    let Some(proxy_url) = &state.config.pub_dart.proxy else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let url = format!(
+        "{}/api/packages/{}/versions/{}",
+        proxy_url.trim_end_matches('/'),
+        encode_segment(&package),
+        encode_segment(&version)
+    );
+
+    match fetch_pub_api(&state, &url).await {
+        Ok(data) => {
+            let nora_base = nora_base_url(&state);
+            let rewritten = rewrite_version_response(&data, &nora_base, &package).unwrap_or(data);
+            cache_bytes(&state, key, rewritten.clone()).await;
+            pub_json_response(rewritten)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, package, version, "pub version upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn package_advisories(
+    State(state): State<Arc<AppState>>,
+    Path(package): Path<String>,
+) -> Response {
+    if !is_valid_pub_package_name(&package) {
+        return pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_package",
+            "Invalid pub package name",
+        );
+    }
+
+    let key = format!("pub/api/packages/{}/advisories.json", package);
+    if let Ok(data) = state.storage.get(&key).await {
+        return pub_json_response(data.to_vec());
+    }
+
+    let Some(proxy_url) = &state.config.pub_dart.proxy else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let url = format!(
+        "{}/api/packages/{}/advisories",
+        proxy_url.trim_end_matches('/'),
+        encode_segment(&package)
+    );
+
+    match fetch_pub_api(&state, &url).await {
+        Ok(data) => {
+            cache_bytes(&state, key, data.clone()).await;
+            pub_json_response(data)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, package, "pub advisories upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn download_archive(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path((package, archive)): Path<(String, String)>,
+) -> Response {
+    let Some(version) = archive.strip_suffix(".tar.gz") else {
+        return pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_version",
+            "Invalid package archive name",
+        );
+    };
+
+    if !is_valid_pub_package_name(&package) || !is_valid_pub_version(version) {
+        return pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_version",
+            "Invalid package name or version",
+        );
+    }
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::PubDart,
+        &package,
+        Some(version),
+    ) {
+        return response;
+    }
+
+    let key = format!("pub/packages/{}/versions/{}.tar.gz", package, version);
+
+    if let Ok(data) = state.storage.get(&key).await {
+        // Integrity verification (curation allowlist)
+        if let Some(response) = crate::curation::verify_integrity(
+            &state.curation,
+            crate::curation::RegistryType::PubDart,
+            &package,
+            Some(version),
+            &data,
+        ) {
+            return response;
+        }
+
+        if let Ok(stored_hash) = state.storage.get(&format!("{}.sha256", key)).await {
+            let expected = String::from_utf8_lossy(&stored_hash);
+            let computed = hex::encode(sha2::Sha256::digest(&data));
+            if computed != expected.as_ref() {
+                tracing::error!(package, version, "pub archive integrity check failed");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        }
+
+        state.metrics.record_download("pub");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::Pull,
+            format!("{}@{}", package, version),
+            "pub",
+            "LOCAL",
+        ));
+        state
+            .audit
+            .log(AuditEntry::new("pull", "api", "", "pub", ""));
+
+        return archive_response(data.to_vec());
+    }
+
+    let Some(proxy_url) = &state.config.pub_dart.proxy else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+
+    let encoded_version = encode_segment(version);
+    let url = if proxy_url.contains("pub.dev") {
+        format!(
+            "{}/api/archives/{}-{}.tar.gz",
+            proxy_url.trim_end_matches('/'),
+            encode_segment(&package),
+            encoded_version
+        )
+    } else {
+        format!(
+            "{}/packages/{}/versions/{}.tar.gz",
+            proxy_url.trim_end_matches('/'),
+            encode_segment(&package),
+            encoded_version
+        )
+    };
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.pub_dart.proxy_timeout,
+        state.config.pub_dart.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(data) => {
+            let hash = hex::encode(sha2::Sha256::digest(&data));
+            cache_bytes(&state, key.clone(), data.clone()).await;
+            cache_bytes(&state, format!("{}.sha256", key), hash.into_bytes()).await;
+            state.repo_index.invalidate("pub");
+
+            state.metrics.record_download("pub");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::Pull,
+                format!("{}@{}", package, version),
+                "pub",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "pub", ""));
+
+            archive_response(data)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, package, version, "pub archive upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+async fn fetch_pub_api(state: &AppState, url: &str) -> Result<Vec<u8>, ProxyError> {
+    super::proxy_fetch_core(
+        &state.http_client,
+        url,
+        state.config.pub_dart.proxy_timeout,
+        state.config.pub_dart.proxy_auth.as_deref(),
+        Some(("Accept", PUB_CONTENT_TYPE)),
+        |response| async { response.bytes().await.map(|b| b.to_vec()) },
+    )
+    .await
+}
+
+async fn cache_bytes(state: &Arc<AppState>, key: String, data: Vec<u8>) {
+    let _ = state.storage.put(&key, &data).await;
+}
+
+fn pub_json_response(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(PUB_CONTENT_TYPE),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=300"),
+            ),
+        ],
+        data,
+    )
+        .into_response()
+}
+
+fn archive_response(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(PUB_ARCHIVE_CONTENT_TYPE),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=31536000, immutable"),
+            ),
+        ],
+        data,
+    )
+        .into_response()
+}
+
+fn pub_error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    let body = serde_json::json!({
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    });
+    (
+        status,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static(PUB_CONTENT_TYPE),
+        )],
+        serde_json::to_vec(&body).unwrap_or_default(),
+    )
+        .into_response()
+}
+
+fn rewrite_package_response(data: &[u8], nora_base: &str, package: &str) -> Result<Vec<u8>, ()> {
+    let mut json: Value = serde_json::from_slice(data).map_err(|_| ())?;
+
+    if let Some(latest) = json.get_mut("latest").and_then(|v| v.as_object_mut()) {
+        rewrite_version_object(latest, nora_base, package, false);
+    }
+    if let Some(versions) = json.get_mut("versions").and_then(|v| v.as_array_mut()) {
+        for version in versions {
+            if let Some(obj) = version.as_object_mut() {
+                rewrite_version_object(obj, nora_base, package, false);
+            }
+        }
+    }
+
+    serde_json::to_vec(&json).map_err(|_| ())
+}
+
+fn rewrite_version_response(data: &[u8], nora_base: &str, package: &str) -> Result<Vec<u8>, ()> {
+    let mut json: Value = serde_json::from_slice(data).map_err(|_| ())?;
+    let Some(obj) = json.as_object_mut() else {
+        return Err(());
+    };
+    rewrite_version_object(obj, nora_base, package, false);
+    serde_json::to_vec(&json).map_err(|_| ())
+}
+
+fn rewrite_search_response(data: &[u8], nora_base: &str, proxy_url: &str) -> Result<Vec<u8>, ()> {
+    let mut json: Value = serde_json::from_slice(data).map_err(|_| ())?;
+
+    if let Some(packages) = json.get_mut("packages").and_then(|v| v.as_array_mut()) {
+        for package in packages {
+            let Some(name) = package
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_owned)
+            else {
+                continue;
+            };
+            if let Some(latest) = package.get_mut("latest").and_then(|v| v.as_object_mut()) {
+                rewrite_version_object(latest, nora_base, &name, true);
+            }
+        }
+    }
+
+    if let Some(next_url) = json.get("next_url").and_then(|v| v.as_str()) {
+        let rewritten = rewrite_next_url(next_url, nora_base, proxy_url);
+        json["next_url"] = Value::String(rewritten);
+    }
+
+    serde_json::to_vec(&json).map_err(|_| ())
+}
+
+fn rewrite_version_object(
+    object: &mut Map<String, Value>,
+    nora_base: &str,
+    package: &str,
+    include_search_urls: bool,
+) {
+    let Some(version) = object
+        .get("version")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned)
+    else {
+        return;
+    };
+    let version = version.as_str();
+
+    object.insert(
+        "archive_url".to_string(),
+        Value::String(nora_archive_url(nora_base, package, version)),
+    );
+
+    if include_search_urls && object.contains_key("package_url") {
+        object.insert(
+            "package_url".to_string(),
+            Value::String(nora_package_url(nora_base, package)),
+        );
+    }
+    if include_search_urls && object.contains_key("url") {
+        object.insert(
+            "url".to_string(),
+            Value::String(nora_version_url(nora_base, package, version)),
+        );
+    }
+}
+
+fn rewrite_next_url(next_url: &str, nora_base: &str, proxy_url: &str) -> String {
+    let upstream_prefix = format!("{}/api/packages", proxy_url.trim_end_matches('/'));
+    let nora_prefix = format!("{}/api/packages", nora_base.trim_end_matches('/'));
+
+    next_url
+        .strip_prefix(&upstream_prefix)
+        .map(|suffix| format!("{}{}", nora_prefix, suffix))
+        .unwrap_or_else(|| next_url.to_string())
+}
+
+fn nora_archive_url(nora_base: &str, package: &str, version: &str) -> String {
+    format!(
+        "{}/packages/{}/versions/{}.tar.gz",
+        nora_base.trim_end_matches('/'),
+        encode_segment(package),
+        encode_segment(version)
+    )
+}
+
+fn nora_package_url(nora_base: &str, package: &str) -> String {
+    format!(
+        "{}/api/packages/{}",
+        nora_base.trim_end_matches('/'),
+        encode_segment(package)
+    )
+}
+
+fn nora_version_url(nora_base: &str, package: &str, version: &str) -> String {
+    format!(
+        "{}/api/packages/{}/versions/{}",
+        nora_base.trim_end_matches('/'),
+        encode_segment(package),
+        encode_segment(version)
+    )
+}
+
+/// Build NORA base URL with /pub prefix for URL rewriting.
+fn nora_base_url(state: &AppState) -> String {
+    if let Some(url) = &state.config.server.public_url {
+        return format!("{}/pub", url.trim_end_matches('/'));
+    }
+    format!(
+        "http://{}:{}/pub",
+        state.config.server.host, state.config.server.port
+    )
+}
+
+fn encode_segment(value: &str) -> String {
+    utf8_percent_encode(value, PATH_SEGMENT_ENCODE_SET).to_string()
+}
+
+fn is_valid_pub_package_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 64 {
+        return false;
+    }
+
+    let Some(first) = name.chars().next() else {
+        return false;
+    };
+    if !first.is_ascii_lowercase() && first != '_' {
+        return false;
+    }
+
+    name.chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
+}
+
+fn is_valid_pub_version(version: &str) -> bool {
+    validate_storage_key(version).is_ok()
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '+' | '-' | '_'))
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::{body_bytes, create_test_context_with_config, send, TestContext};
+    use axum::http::{Method, StatusCode};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn create_pub_proxy_test_context(proxy_url: String) -> TestContext {
+        create_test_context_with_config(move |cfg| {
+            cfg.pub_dart.enabled = true;
+            cfg.pub_dart.proxy = Some(proxy_url);
+        })
+    }
+
+    #[test]
+    fn test_valid_pub_package_names() {
+        assert!(is_valid_pub_package_name("http"));
+        assert!(is_valid_pub_package_name("flutter_test"));
+        assert!(is_valid_pub_package_name("a1_b2"));
+        assert!(is_valid_pub_package_name("_private_pkg"));
+    }
+
+    #[test]
+    fn test_invalid_pub_package_names() {
+        assert!(!is_valid_pub_package_name(""));
+        assert!(!is_valid_pub_package_name("Http"));
+        assert!(!is_valid_pub_package_name("with-dash"));
+        assert!(!is_valid_pub_package_name("1starts_with_digit"));
+        assert!(!is_valid_pub_package_name("with/slash"));
+    }
+
+    #[test]
+    fn test_rewrite_package_response_rewrites_archive_urls() {
+        let source = serde_json::json!({
+            "name": "http",
+            "latest": {
+                "version": "1.2.0",
+                "archive_url": "https://pub.dev/api/archives/http-1.2.0.tar.gz"
+            },
+            "versions": [{
+                "version": "1.2.0",
+                "archive_url": "https://pub.dev/api/archives/http-1.2.0.tar.gz"
+            }]
+        });
+
+        let rewritten = rewrite_package_response(
+            &serde_json::to_vec(&source).unwrap(),
+            "http://127.0.0.1:4000/pub",
+            "http",
+        )
+        .unwrap();
+        let json: Value = serde_json::from_slice(&rewritten).unwrap();
+
+        assert_eq!(
+            json["latest"]["archive_url"],
+            "http://127.0.0.1:4000/pub/packages/http/versions/1.2.0.tar.gz"
+        );
+        assert_eq!(
+            json["versions"][0]["archive_url"],
+            "http://127.0.0.1:4000/pub/packages/http/versions/1.2.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_search_response_rewrites_next_and_package_urls() {
+        let source = serde_json::json!({
+            "next_url": "https://pub.dev/api/packages?page=2&q=http",
+            "packages": [{
+                "name": "http",
+                "latest": {
+                    "version": "1.2.0",
+                    "archive_url": "https://pub.dev/api/archives/http-1.2.0.tar.gz",
+                    "package_url": "https://pub.dev/api/packages/http",
+                    "url": "https://pub.dev/api/packages/http/versions/1.2.0"
+                }
+            }]
+        });
+
+        let rewritten = rewrite_search_response(
+            &serde_json::to_vec(&source).unwrap(),
+            "http://127.0.0.1:4000/pub",
+            "https://pub.dev",
+        )
+        .unwrap();
+        let json: Value = serde_json::from_slice(&rewritten).unwrap();
+
+        assert_eq!(
+            json["next_url"],
+            "http://127.0.0.1:4000/pub/api/packages?page=2&q=http"
+        );
+        assert_eq!(
+            json["packages"][0]["latest"]["package_url"],
+            "http://127.0.0.1:4000/pub/api/packages/http"
+        );
+        assert_eq!(
+            json["packages"][0]["latest"]["url"],
+            "http://127.0.0.1:4000/pub/api/packages/http/versions/1.2.0"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pub_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.pub_dart.enabled = false;
+        });
+        let resp = send(&ctx.app, Method::GET, "/pub/api/packages/http", "").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_pub_package_metadata_proxy_and_cache() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/packages/http"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", PUB_CONTENT_TYPE)
+                    .set_body_json(serde_json::json!({
+                        "name": "http",
+                        "latest": {
+                            "version": "1.2.0",
+                            "archive_url": format!("{}/api/archives/http-1.2.0.tar.gz", server.uri()),
+                            "archive_sha256": "abc123",
+                            "pubspec": {"name": "http", "version": "1.2.0"}
+                        },
+                        "versions": [{
+                            "version": "1.2.0",
+                            "archive_url": format!("{}/api/archives/http-1.2.0.tar.gz", server.uri()),
+                            "archive_sha256": "abc123",
+                            "pubspec": {"name": "http", "version": "1.2.0"}
+                        }]
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let ctx = create_pub_proxy_test_context(server.uri());
+
+        let resp = send(&ctx.app, Method::GET, "/pub/api/packages/http", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = body_bytes(resp).await;
+        let json: Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["latest"]["archive_url"]
+            .as_str()
+            .unwrap()
+            .contains("/pub/packages/http/versions/1.2.0.tar.gz"));
+
+        let cached = ctx
+            .state
+            .storage
+            .get("pub/api/packages/http.json")
+            .await
+            .unwrap();
+        let cached_json: Value = serde_json::from_slice(&cached).unwrap();
+        assert_eq!(cached_json["name"], "http");
+    }
+
+    #[tokio::test]
+    async fn test_pub_archive_from_storage() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.pub_dart.enabled = true;
+        });
+        ctx.state
+            .storage
+            .put("pub/packages/http/versions/1.2.0.tar.gz", b"archive-data")
+            .await
+            .unwrap();
+        ctx.state
+            .storage
+            .put(
+                "pub/packages/http/versions/1.2.0.tar.gz.sha256",
+                hex::encode(sha2::Sha256::digest(b"archive-data")).as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/pub/packages/http/versions/1.2.0.tar.gz",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"archive-data");
+    }
+
+    #[tokio::test]
+    async fn test_pub_advisories_proxy_and_cache() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/packages/http/advisories"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", PUB_CONTENT_TYPE)
+                    .set_body_json(serde_json::json!({
+                        "advisories": [],
+                        "advisoriesUpdated": "2024-04-28T09:27:57.869544Z"
+                    })),
+            )
+            .mount(&server)
+            .await;
+
+        let ctx = create_pub_proxy_test_context(server.uri());
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/pub/api/packages/http/advisories",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let cached = ctx
+            .state
+            .storage
+            .get("pub/api/packages/http/advisories.json")
+            .await
+            .unwrap();
+        let json: Value = serde_json::from_slice(&cached).unwrap();
+        assert!(json["advisories"].as_array().unwrap().is_empty());
+    }
+}

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! PyPI registry — PEP 503 (Simple HTML) + PEP 691 (JSON) + twine upload.

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use crate::activity_log::{ActionType, ActivityEntry};

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -1,0 +1,790 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! Terraform provider/module registry proxy.
+//!
+//! Implements a caching proxy for registry.terraform.io:
+//!   GET /terraform/.well-known/terraform.json     — service discovery
+//!   GET /terraform/v1/providers/{ns}/{type}/versions — list provider versions
+//!   GET /terraform/v1/providers/{ns}/{type}/{ver}/download/{os}/{arch} — download metadata
+//!   GET /terraform/v1/providers/download/{ns}/{type}/{ver}/{filename}  — binary download
+//!   GET /terraform/v1/modules/{ns}/{name}/{provider}/versions — list module versions
+//!   GET /terraform/v1/modules/{ns}/{name}/{provider}/{ver}/download — module download
+//!
+//! Client config:
+//!   In ~/.terraformrc:
+//!     provider_installation {
+//!       network_mirror { url = "http://nora:4000/terraform/" }
+//!     }
+
+use crate::activity_log::{ActionType, ActivityEntry};
+use crate::audit::AuditEntry;
+use crate::registry::{proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::AppState;
+use axum::{
+    extract::{Path, State},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use std::sync::Arc;
+
+const UPSTREAM_DEFAULT: &str = "https://registry.terraform.io";
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        // Service discovery
+        .route(
+            "/terraform/.well-known/terraform.json",
+            get(service_discovery),
+        )
+        // Provider versions
+        .route(
+            "/terraform/v1/providers/{ns}/{ptype}/versions",
+            get(provider_versions),
+        )
+        // Provider download metadata (returns JSON with download_url)
+        .route(
+            "/terraform/v1/providers/{ns}/{ptype}/{ver}/download/{os}/{arch}",
+            get(provider_download_meta),
+        )
+        // Provider binary download (cached, immutable)
+        .route(
+            "/terraform/v1/providers/download/{*path}",
+            get(provider_download_binary),
+        )
+        // Module versions
+        .route(
+            "/terraform/v1/modules/{ns}/{name}/{provider}/versions",
+            get(module_versions),
+        )
+        // Module download (returns X-Terraform-Get header)
+        .route(
+            "/terraform/v1/modules/{ns}/{name}/{provider}/{ver}/download",
+            get(module_download),
+        )
+}
+
+// ── Service discovery ──────────────────────────────────────────────────
+
+async fn service_discovery(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    let host = extract_host(&state, &headers);
+    let base = format!("http://{}", host);
+    let json = serde_json::json!({
+        "providers.v1": format!("{}/terraform/v1/providers/", base),
+        "modules.v1": format!("{}/terraform/v1/modules/", base)
+    });
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        serde_json::to_vec(&json).unwrap_or_default(),
+    )
+        .into_response()
+}
+
+// ── Provider versions (mutable, TTL cached) ────────────────────────────
+
+async fn provider_versions(
+    State(state): State<Arc<AppState>>,
+    Path((ns, ptype)): Path<(String, String)>,
+) -> Response {
+    if !is_valid_name(&ns) || !is_valid_name(&ptype) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let storage_key = format!("terraform/providers/{}/{}/versions.json", ns, ptype);
+
+    // TTL cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, 300) {
+                state.metrics.record_download("terraform");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v1/providers/{}/{}/versions",
+        proxy_url.trim_end_matches('/'),
+        ns,
+        ptype
+    );
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.terraform.proxy_timeout,
+        state.config.terraform.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("terraform");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                format!("{}/{}", ns, ptype),
+                "terraform",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = text.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("terraform");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(provider = format!("{}/{}", ns, ptype), error = ?e, "Terraform upstream error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Provider download metadata ─────────────────────────────────────────
+
+async fn provider_download_meta(
+    State(state): State<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
+    Path((ns, ptype, ver, os, arch)): Path<(String, String, String, String, String)>,
+) -> Response {
+    if !is_valid_name(&ns)
+        || !is_valid_name(&ptype)
+        || !is_valid_version(&ver)
+        || !is_valid_name(&os)
+        || !is_valid_name(&arch)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let host = extract_host(&state, &headers);
+    let artifact = format!("{}/{} v{} {}/{}", ns, ptype, ver, os, arch);
+
+    // Curation check
+    if let Some(response) = crate::curation::check_download(
+        &state.curation,
+        state.config.curation.bypass_token.as_deref(),
+        &headers,
+        crate::curation::RegistryType::Terraform,
+        &format!("{}/{}", ns, ptype),
+        Some(&ver),
+    ) {
+        return response;
+    }
+
+    let storage_key = format!(
+        "terraform/providers/{}/{}/{}/{}_{}.json",
+        ns, ptype, ver, os, arch
+    );
+
+    // TTL cache for metadata
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, 300) {
+                state.metrics.record_download("terraform");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v1/providers/{}/{}/{}/download/{}/{}",
+        proxy_url.trim_end_matches('/'),
+        ns,
+        ptype,
+        ver,
+        os,
+        arch
+    );
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.terraform.proxy_timeout,
+        state.config.terraform.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            // Rewrite download_url to point through NORA
+            let rewritten = rewrite_download_url(&text, &host, &ns, &ptype, &ver);
+
+            state.metrics.record_download("terraform");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                artifact,
+                "terraform",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = rewritten.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("terraform");
+            with_json(rewritten.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Terraform download metadata error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Provider binary download (immutable) ───────────────────────────────
+
+async fn provider_download_binary(
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<String>,
+) -> Response {
+    if !is_safe_path(&path) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let storage_key = format!("terraform/download/{}", path);
+
+    // Immutable: if cached, serve directly
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        state.metrics.record_download("terraform");
+        state.metrics.record_cache_hit();
+        state.activity.push(ActivityEntry::new(
+            ActionType::CacheHit,
+            path.clone(),
+            "terraform",
+            "CACHE",
+        ));
+        return with_binary(data.to_vec());
+    }
+
+    // Try upstream — reconstruct original URL from path
+    // Path format: {ns}/{type}/{ver}/{filename}
+    let parts: Vec<&str> = path.splitn(4, '/').collect();
+    if parts.len() < 4 {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let proxy_url = upstream_url(&state);
+    // The download URL from registry.terraform.io is typically a direct URL
+    // We proxy the binary from releases.hashicorp.com or similar
+    let url = format!(
+        "{}/v1/providers/download/{}",
+        proxy_url.trim_end_matches('/'),
+        path
+    );
+
+    match proxy_fetch(
+        &state.http_client,
+        &url,
+        state.config.terraform.proxy_timeout_download,
+        state.config.terraform.proxy_auth.as_deref(),
+    )
+    .await
+    {
+        Ok(bytes) => {
+            state.metrics.record_download("terraform");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                path,
+                "terraform",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
+
+            // Immutable cache
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = bytes.clone();
+            tokio::spawn(async move {
+                if storage.stat(&key).await.is_none() {
+                    let _ = storage.put(&key, &data).await;
+                }
+            });
+
+            state.repo_index.invalidate("terraform");
+            with_binary(bytes)
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Terraform binary download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Module versions ────────────────────────────────────────────────────
+
+async fn module_versions(
+    State(state): State<Arc<AppState>>,
+    Path((ns, name, provider)): Path<(String, String, String)>,
+) -> Response {
+    if !is_valid_name(&ns) || !is_valid_name(&name) || !is_valid_name(&provider) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let storage_key = format!(
+        "terraform/modules/{}/{}/{}/versions.json",
+        ns, name, provider
+    );
+
+    // TTL cache
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Some(meta) = state.storage.stat(&storage_key).await {
+            if is_within_ttl(meta.modified, 300) {
+                state.metrics.record_download("terraform");
+                state.metrics.record_cache_hit();
+                return with_json(data.to_vec());
+            }
+        }
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v1/modules/{}/{}/{}/versions",
+        proxy_url.trim_end_matches('/'),
+        ns,
+        name,
+        provider
+    );
+
+    match proxy_fetch_text(
+        &state.http_client,
+        &url,
+        state.config.terraform.proxy_timeout,
+        state.config.terraform.proxy_auth.as_deref(),
+        None,
+    )
+    .await
+    {
+        Ok(text) => {
+            state.metrics.record_download("terraform");
+            state.metrics.record_cache_miss();
+            state.activity.push(ActivityEntry::new(
+                ActionType::ProxyFetch,
+                format!("{}/{}/{}", ns, name, provider),
+                "terraform",
+                "PROXY",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
+
+            let storage = state.storage.clone();
+            let key = storage_key;
+            let data = text.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key, data.as_bytes()).await;
+            });
+
+            state.repo_index.invalidate("terraform");
+            with_json(text.into_bytes())
+        }
+        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, "Terraform module versions error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Module download ────────────────────────────────────────────────────
+
+async fn module_download(
+    State(state): State<Arc<AppState>>,
+    Path((ns, name, provider, ver)): Path<(String, String, String, String)>,
+) -> Response {
+    if !is_valid_name(&ns)
+        || !is_valid_name(&name)
+        || !is_valid_name(&provider)
+        || !is_valid_version(&ver)
+    {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    let proxy_url = upstream_url(&state);
+    let url = format!(
+        "{}/v1/modules/{}/{}/{}/{}/download",
+        proxy_url.trim_end_matches('/'),
+        ns,
+        name,
+        provider,
+        ver
+    );
+
+    // Module download returns 204 with X-Terraform-Get header pointing to source
+    let client = &state.http_client;
+    let timeout = state.config.terraform.proxy_timeout;
+
+    let mut request = client
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(timeout));
+    if let Some(auth) = state.config.terraform.proxy_auth.as_deref() {
+        request = request.header("Authorization", crate::config::basic_auth_header(auth));
+    }
+
+    match request.send().await {
+        Ok(response) => {
+            if let Some(tf_get) = response.headers().get("x-terraform-get") {
+                state.metrics.record_download("terraform");
+                state.activity.push(ActivityEntry::new(
+                    ActionType::ProxyFetch,
+                    format!("{}/{}/{} v{}", ns, name, provider, ver),
+                    "terraform",
+                    "PROXY",
+                ));
+
+                // Pass through the X-Terraform-Get header
+                return (
+                    StatusCode::NO_CONTENT,
+                    [("x-terraform-get", tf_get.to_str().unwrap_or(""))],
+                )
+                    .into_response();
+            }
+            StatusCode::NOT_FOUND.into_response()
+        }
+        Err(e) => {
+            tracing::debug!(error = ?e, "Terraform module download error");
+            StatusCode::BAD_GATEWAY.into_response()
+        }
+    }
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/// Extract Host from request headers, fallback to config or default
+fn extract_host(state: &AppState, headers: &HeaderMap) -> String {
+    if let Some(public_url) = &state.config.server.public_url {
+        // Strip protocol prefix
+        return public_url
+            .trim_start_matches("http://")
+            .trim_start_matches("https://")
+            .to_string();
+    }
+    headers
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("localhost:4000")
+        .to_string()
+}
+
+fn upstream_url(state: &AppState) -> String {
+    state
+        .config
+        .terraform
+        .proxy
+        .clone()
+        .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
+}
+
+fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    now.saturating_sub(modified_unix) < ttl_secs
+}
+
+fn with_json(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+fn with_binary(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/zip"),
+        )],
+        data,
+    )
+        .into_response()
+}
+
+/// Rewrite download_url in provider metadata JSON to point through NORA.
+fn rewrite_download_url(json_text: &str, host: &str, ns: &str, ptype: &str, ver: &str) -> String {
+    // Parse JSON, find download_url, rewrite it
+    if let Ok(mut json) = serde_json::from_str::<serde_json::Value>(json_text) {
+        if let Some(obj) = json.as_object_mut() {
+            if let Some(download_url) = obj.get("download_url") {
+                if let Some(url_str) = download_url.as_str() {
+                    // Extract filename from original URL
+                    let filename = url_str.rsplit('/').next().unwrap_or("provider.zip");
+                    let new_url = format!(
+                        "http://{}/terraform/v1/providers/download/{}/{}/{}/{}",
+                        host, ns, ptype, ver, filename
+                    );
+                    obj.insert(
+                        "download_url".to_string(),
+                        serde_json::Value::String(new_url),
+                    );
+                }
+            }
+        }
+        serde_json::to_string(&json).unwrap_or_else(|_| json_text.to_string())
+    } else {
+        json_text.to_string()
+    }
+}
+
+/// Validate namespace/type/provider names
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 256
+        && !name.contains('/')
+        && !name.contains('\0')
+        && !name.contains("..")
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+/// Validate version string
+fn is_valid_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 128
+        && !version.contains('/')
+        && !version.contains('\0')
+        && !version.contains("..")
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' || c == '+')
+}
+
+/// Path safety validation
+fn is_safe_path(path: &str) -> bool {
+    !path.contains("..")
+        && !path.starts_with('/')
+        && !path.contains("//")
+        && !path.contains('\0')
+        && !path.is_empty()
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_names() {
+        assert!(is_valid_name("hashicorp"));
+        assert!(is_valid_name("aws"));
+        assert!(is_valid_name("google-beta"));
+        assert!(is_valid_name("terraform-provider-azurerm"));
+    }
+
+    #[test]
+    fn test_invalid_names() {
+        assert!(!is_valid_name(""));
+        assert!(!is_valid_name("../evil"));
+        assert!(!is_valid_name("foo/bar"));
+        assert!(!is_valid_name("foo\0bar"));
+    }
+
+    #[test]
+    fn test_valid_versions() {
+        assert!(is_valid_version("5.0.0"));
+        assert!(is_valid_version("3.67.0"));
+        assert!(is_valid_version("1.0.0-beta1"));
+    }
+
+    #[test]
+    fn test_rewrite_download_url() {
+        let input = r#"{"download_url":"https://releases.hashicorp.com/terraform-provider-aws/5.0.0/terraform-provider-aws_5.0.0_linux_amd64.zip","shasum":"abc123"}"#;
+        let result = rewrite_download_url(input, "nora:4000", "hashicorp", "aws", "5.0.0");
+        assert!(result.contains("http://nora:4000/terraform/v1/providers/download/hashicorp/aws/5.0.0/terraform-provider-aws_5.0.0_linux_amd64.zip"));
+        // Other fields preserved
+        assert!(result.contains("abc123"));
+    }
+
+    #[test]
+    fn test_rewrite_download_url_no_url() {
+        let input = r#"{"shasum":"abc123"}"#;
+        let result = rewrite_download_url(input, "nora:4000", "hashicorp", "aws", "5.0.0");
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_rewrite_download_url_invalid_json() {
+        let input = "not json";
+        let result = rewrite_download_url(input, "nora:4000", "hashicorp", "aws", "5.0.0");
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_safe_path() {
+        assert!(is_safe_path("hashicorp/aws/5.0.0/provider.zip"));
+        assert!(!is_safe_path("../../etc/passwd"));
+        assert!(!is_safe_path("/absolute/path"));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod integration_tests {
+    use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+    use axum::http::{Method, StatusCode};
+
+    #[tokio::test]
+    async fn test_terraform_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = false;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/.well-known/terraform.json",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_terraform_service_discovery() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/.well-known/terraform.json",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("providers.v1").is_some());
+        assert!(json.get("modules.v1").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_terraform_cached_binary() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "terraform/download/hashicorp/aws/5.0.0/provider.zip",
+                b"zip-binary",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/download/hashicorp/aws/5.0.0/provider.zip",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"zip-binary");
+    }
+
+    #[tokio::test]
+    async fn test_terraform_unreachable_proxy() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+            cfg.terraform.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.terraform.proxy_timeout = 1;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/hashicorp/aws/versions",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn test_terraform_invalid_name_rejected() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/../evil/versions",
+            "",
+        )
+        .await;
+        assert!(resp.status() == StatusCode::NOT_FOUND || resp.status() == StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_terraform_curation_enforce_blocks() {
+        use crate::test_helpers::send_with_headers;
+
+        let blocklist_dir = tempfile::TempDir::new().unwrap();
+        let blocklist_path = blocklist_dir.path().join("blocklist.json");
+        let blocklist = serde_json::json!({
+            "version": 1,
+            "rules": [{"registry": "terraform", "name": "evilcorp/backdoor", "version": "*", "reason": "compromised"}]
+        });
+        std::fs::write(&blocklist_path, serde_json::to_string(&blocklist).unwrap()).unwrap();
+
+        let bl_path = blocklist_path.to_str().unwrap().to_string();
+        let ctx = create_test_context_with_config(move |cfg| {
+            cfg.terraform.enabled = true;
+            cfg.terraform.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.terraform.proxy_timeout = 1;
+            cfg.curation.mode = crate::config::CurationMode::Enforce;
+            cfg.curation.blocklist_path = Some(bl_path);
+        });
+
+        // Curation check happens before proxy fetch, so it should block even without upstream
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/evilcorp/backdoor/1.0.0/download/linux/amd64",
+            vec![],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/nora-registry/src/registry_type.rs
+++ b/nora-registry/src/registry_type.rs
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 The Nora Authors
+// SPDX-License-Identifier: MIT
+
+//! Shared registry type enum used across config, curation, metrics, and UI.
+
+use serde::Serialize;
+use std::fmt;
+
+/// All supported registry formats.
+///
+/// This is the single source of truth for registry types. Other modules
+/// (curation, config, metrics, UI) reference this enum.
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize)]
+pub enum RegistryType {
+    Docker,
+    Maven,
+    Npm,
+    Cargo,
+    #[serde(rename = "pypi")]
+    PyPI,
+    Go,
+    Raw,
+    // New formats (v0.7):
+    #[serde(rename = "gems")]
+    Gems,
+    #[serde(rename = "terraform")]
+    Terraform,
+    #[serde(rename = "ansible")]
+    Ansible,
+    #[serde(rename = "nuget")]
+    Nuget,
+    #[serde(rename = "pub")]
+    PubDart,
+    #[serde(rename = "conan")]
+    Conan,
+}
+
+impl RegistryType {
+    /// Lowercase string identifier used in storage keys, metrics, and config.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Docker => "docker",
+            Self::Maven => "maven",
+            Self::Npm => "npm",
+            Self::Cargo => "cargo",
+            Self::PyPI => "pypi",
+            Self::Go => "go",
+            Self::Raw => "raw",
+            Self::Gems => "gems",
+            Self::Terraform => "terraform",
+            Self::Ansible => "ansible",
+            Self::Nuget => "nuget",
+            Self::PubDart => "pub",
+            Self::Conan => "conan",
+        }
+    }
+
+    /// URL mount point for this registry's routes.
+    pub fn mount_point(&self) -> &'static str {
+        match self {
+            Self::Docker => "/v2/",
+            Self::Maven => "/maven2/",
+            Self::Npm => "/npm/",
+            Self::Cargo => "/cargo/",
+            Self::PyPI => "/simple/",
+            Self::Go => "/go/",
+            Self::Raw => "/raw/",
+            Self::Gems => "/gems/",
+            Self::Terraform => "/terraform/",
+            Self::Ansible => "/ansible/",
+            Self::Nuget => "/nuget/",
+            Self::PubDart => "/pub/",
+            Self::Conan => "/conan/",
+        }
+    }
+
+    /// Display name for UI (capitalized).
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Self::Docker => "Docker",
+            Self::Maven => "Maven",
+            Self::Npm => "npm",
+            Self::Cargo => "Cargo",
+            Self::PyPI => "PyPI",
+            Self::Go => "Go",
+            Self::Raw => "Raw",
+            Self::Gems => "RubyGems",
+            Self::Terraform => "Terraform",
+            Self::Ansible => "Ansible",
+            Self::Nuget => "NuGet",
+            Self::PubDart => "Pub (Dart)",
+            Self::Conan => "Conan",
+        }
+    }
+
+    /// All registry types (original 7).
+    pub fn all_v1() -> &'static [RegistryType] {
+        &[
+            Self::Docker,
+            Self::Maven,
+            Self::Npm,
+            Self::Cargo,
+            Self::PyPI,
+            Self::Go,
+            Self::Raw,
+        ]
+    }
+
+    /// All registry types including new formats.
+    pub fn all() -> &'static [RegistryType] {
+        &[
+            Self::Docker,
+            Self::Maven,
+            Self::Npm,
+            Self::Cargo,
+            Self::PyPI,
+            Self::Go,
+            Self::Raw,
+            Self::Gems,
+            Self::Terraform,
+            Self::Ansible,
+            Self::Nuget,
+            Self::PubDart,
+            Self::Conan,
+        ]
+    }
+
+    /// Parse from string (case-insensitive).
+    pub fn from_str_opt(s: &str) -> Option<Self> {
+        match s.to_lowercase().as_str() {
+            "docker" => Some(Self::Docker),
+            "maven" => Some(Self::Maven),
+            "npm" => Some(Self::Npm),
+            "cargo" => Some(Self::Cargo),
+            "pypi" => Some(Self::PyPI),
+            "go" => Some(Self::Go),
+            "raw" => Some(Self::Raw),
+            "gems" | "rubygems" => Some(Self::Gems),
+            "terraform" => Some(Self::Terraform),
+            "ansible" => Some(Self::Ansible),
+            "nuget" => Some(Self::Nuget),
+            "pub" | "pub_dart" | "dart" => Some(Self::PubDart),
+            "conan" => Some(Self::Conan),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for RegistryType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_as_str_roundtrip() {
+        for rt in RegistryType::all() {
+            let s = rt.as_str();
+            let parsed = RegistryType::from_str_opt(s);
+            assert_eq!(parsed, Some(*rt), "roundtrip failed for {}", s);
+        }
+    }
+
+    #[test]
+    fn test_mount_points_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for rt in RegistryType::all() {
+            assert!(
+                seen.insert(rt.mount_point()),
+                "duplicate mount point: {}",
+                rt.mount_point()
+            );
+        }
+    }
+
+    #[test]
+    fn test_display() {
+        assert_eq!(RegistryType::Docker.to_string(), "docker");
+        assert_eq!(RegistryType::PyPI.to_string(), "pypi");
+        assert_eq!(RegistryType::Gems.to_string(), "gems");
+        assert_eq!(RegistryType::Nuget.to_string(), "nuget");
+    }
+
+    #[test]
+    fn test_from_str_case_insensitive() {
+        assert_eq!(
+            RegistryType::from_str_opt("DOCKER"),
+            Some(RegistryType::Docker)
+        );
+        assert_eq!(
+            RegistryType::from_str_opt("RubyGems"),
+            Some(RegistryType::Gems)
+        );
+        assert_eq!(RegistryType::from_str_opt("unknown"), None);
+    }
+
+    #[test]
+    fn test_all_contains_v1() {
+        for rt in RegistryType::all_v1() {
+            assert!(
+                RegistryType::all().contains(rt),
+                "{} in v1 but not in all",
+                rt
+            );
+        }
+    }
+}

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! In-memory repository index with lazy rebuild on invalidation.

--- a/nora-registry/src/request_id.rs
+++ b/nora-registry/src/request_id.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Request ID middleware for request tracking and correlation

--- a/nora-registry/src/secrets/env.rs
+++ b/nora-registry/src/secrets/env.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Environment variables secrets provider

--- a/nora-registry/src/secrets/mod.rs
+++ b/nora-registry/src/secrets/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Secrets management for NORA

--- a/nora-registry/src/secrets/protected.rs
+++ b/nora-registry/src/secrets/protected.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Protected secret types with memory safety

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use async_trait::async_trait;

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 mod local;

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use async_trait::async_trait;

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 The Nora Authors
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Shared test infrastructure for integration tests.
@@ -87,23 +87,27 @@ fn build_context(
             s3_region: String::new(),
         },
         maven: MavenConfig {
+            enabled: true,
             proxies: vec![],
             proxy_timeout: 5,
             checksum_verify: true,
             immutable_releases: true,
         },
         npm: NpmConfig {
+            enabled: true,
             proxy: None,
             proxy_auth: None,
             proxy_timeout: 5,
             metadata_ttl: 0,
         },
         pypi: PypiConfig {
+            enabled: true,
             proxy: None,
             proxy_auth: None,
             proxy_timeout: 5,
         },
         go: GoConfig {
+            enabled: true,
             proxy: None,
             proxy_auth: None,
             proxy_timeout: 5,
@@ -111,11 +115,13 @@ fn build_context(
             max_zip_size: 10_485_760,
         },
         cargo: CargoConfig {
+            enabled: true,
             proxy: None,
             proxy_auth: None,
             proxy_timeout: 5,
         },
         docker: DockerConfig {
+            enabled: true,
             proxy_timeout: 5,
             upstreams: vec![],
         },
@@ -123,6 +129,12 @@ fn build_context(
             enabled: true,
             max_file_size: 1_048_576, // 1 MB
         },
+        gems: GemsConfig::default(),
+        terraform: TerraformConfig::default(),
+        ansible: AnsibleConfig::default(),
+        nuget: NugetConfig::default(),
+        pub_dart: crate::config::PubDartConfig::default(),
+        conan: crate::config::ConanConfig::default(),
         auth: AuthConfig {
             enabled: auth_enabled,
             anonymous_read,
@@ -186,9 +198,12 @@ fn build_context(
         curation_engine.set_namespace_filter(Box::new(ns_filter));
     }
 
+    let enabled_registries = config.enabled_registries();
+
     let state = Arc::new(AppState {
         storage,
         config,
+        enabled_registries: enabled_registries.clone(),
         start_time: Instant::now(),
         auth,
         tokens,
@@ -204,14 +219,51 @@ fn build_context(
     });
 
     // Build router identical to run_server() but without TcpListener / rate-limiting
-    let registry_routes = Router::new()
-        .merge(registry::docker_routes())
-        .merge(registry::maven_routes())
-        .merge(registry::npm_routes())
-        .merge(registry::cargo_routes())
-        .merge(registry::pypi_routes())
-        .merge(registry::raw_routes())
-        .merge(registry::go_routes());
+    // Dynamic route merging based on enabled registries
+    let mut registry_routes = Router::new();
+    for reg in &enabled_registries {
+        match reg {
+            crate::registry_type::RegistryType::Docker => {
+                registry_routes = registry_routes.merge(registry::docker_routes());
+            }
+            crate::registry_type::RegistryType::Maven => {
+                registry_routes = registry_routes.merge(registry::maven_routes());
+            }
+            crate::registry_type::RegistryType::Npm => {
+                registry_routes = registry_routes.merge(registry::npm_routes());
+            }
+            crate::registry_type::RegistryType::Cargo => {
+                registry_routes = registry_routes.merge(registry::cargo_routes());
+            }
+            crate::registry_type::RegistryType::PyPI => {
+                registry_routes = registry_routes.merge(registry::pypi_routes());
+            }
+            crate::registry_type::RegistryType::Raw => {
+                registry_routes = registry_routes.merge(registry::raw_routes());
+            }
+            crate::registry_type::RegistryType::Go => {
+                registry_routes = registry_routes.merge(registry::go_routes());
+            }
+            crate::registry_type::RegistryType::Gems => {
+                registry_routes = registry_routes.merge(registry::gems_routes());
+            }
+            crate::registry_type::RegistryType::Terraform => {
+                registry_routes = registry_routes.merge(registry::terraform_routes());
+            }
+            crate::registry_type::RegistryType::Ansible => {
+                registry_routes = registry_routes.merge(registry::ansible_routes());
+            }
+            crate::registry_type::RegistryType::Nuget => {
+                registry_routes = registry_routes.merge(registry::nuget_routes());
+            }
+            crate::registry_type::RegistryType::PubDart => {
+                registry_routes = registry_routes.merge(registry::pub_dart_routes());
+            }
+            crate::registry_type::RegistryType::Conan => {
+                registry_routes = registry_routes.merge(registry::conan_routes());
+            }
+        }
+    }
 
     let public_routes = Router::new().merge(crate::health::routes());
 

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use argon2::{

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use super::components::{format_size, format_timestamp, html_escape};
@@ -111,13 +111,9 @@ pub struct MountPoint {
 
 pub async fn api_stats(State(state): State<Arc<AppState>>) -> Json<RegistryStats> {
     // Trigger index rebuild if needed, then get counts
-    let _ = state.repo_index.get("docker", &state.storage).await;
-    let _ = state.repo_index.get("maven", &state.storage).await;
-    let _ = state.repo_index.get("npm", &state.storage).await;
-    let _ = state.repo_index.get("cargo", &state.storage).await;
-    let _ = state.repo_index.get("pypi", &state.storage).await;
-    let _ = state.repo_index.get("go", &state.storage).await;
-    let _ = state.repo_index.get("raw", &state.storage).await;
+    for reg in &state.enabled_registries {
+        let _ = state.repo_index.get(reg.as_str(), &state.storage).await;
+    }
 
     let (docker, maven, npm, cargo, pypi, go, raw) = state.repo_index.counts();
     Json(RegistryStats {
@@ -132,41 +128,104 @@ pub async fn api_stats(State(state): State<Arc<AppState>>) -> Json<RegistryStats
 }
 
 pub async fn api_dashboard(State(state): State<Arc<AppState>>) -> Json<DashboardResponse> {
-    // Get indexes (will rebuild if dirty)
-    let docker_repos = state.repo_index.get("docker", &state.storage).await;
-    let maven_repos = state.repo_index.get("maven", &state.storage).await;
-    let npm_repos = state.repo_index.get("npm", &state.storage).await;
-    let cargo_repos = state.repo_index.get("cargo", &state.storage).await;
-    let pypi_repos = state.repo_index.get("pypi", &state.storage).await;
-    let go_repos = state.repo_index.get("go", &state.storage).await;
-    let raw_repos = state.repo_index.get("raw", &state.storage).await;
+    use crate::registry_type::RegistryType;
 
-    // Calculate sizes from cached index
-    let docker_size: u64 = docker_repos.iter().map(|r| r.size).sum();
-    let maven_size: u64 = maven_repos.iter().map(|r| r.size).sum();
-    let npm_size: u64 = npm_repos.iter().map(|r| r.size).sum();
-    let cargo_size: u64 = cargo_repos.iter().map(|r| r.size).sum();
-    let pypi_size: u64 = pypi_repos.iter().map(|r| r.size).sum();
-    let go_size: u64 = go_repos.iter().map(|r| r.size).sum();
-    let raw_size: u64 = raw_repos.iter().map(|r| r.size).sum();
-    let total_storage =
-        docker_size + maven_size + npm_size + cargo_size + pypi_size + go_size + raw_size;
+    let mut total_storage: u64 = 0;
+    let mut total_artifacts: usize = 0;
+    let mut registry_card_stats = Vec::new();
+    let mut mount_points = Vec::new();
 
-    // Count total versions/tags, not just repositories
-    let docker_versions: usize = docker_repos.iter().map(|r| r.versions).sum();
-    let maven_versions: usize = maven_repos.iter().map(|r| r.versions).sum();
-    let npm_versions: usize = npm_repos.iter().map(|r| r.versions).sum();
-    let cargo_versions: usize = cargo_repos.iter().map(|r| r.versions).sum();
-    let pypi_versions: usize = pypi_repos.iter().map(|r| r.versions).sum();
-    let go_versions: usize = go_repos.iter().map(|r| r.versions).sum();
-    let raw_versions: usize = raw_repos.iter().map(|r| r.versions).sum();
-    let total_artifacts = docker_versions
-        + maven_versions
-        + npm_versions
-        + cargo_versions
-        + pypi_versions
-        + go_versions
-        + raw_versions;
+    for reg in RegistryType::all_v1() {
+        if !state.enabled_registries.contains(reg) {
+            continue;
+        }
+
+        let name = reg.as_str();
+        let repos = state.repo_index.get(name, &state.storage).await;
+        let size: u64 = repos.iter().map(|r| r.size).sum();
+        let versions: usize = repos.iter().map(|r| r.versions).sum();
+
+        total_storage += size;
+        total_artifacts += versions;
+
+        registry_card_stats.push(RegistryCardStats {
+            name: name.to_string(),
+            artifact_count: versions,
+            downloads: state.metrics.get_registry_downloads(name),
+            uploads: state.metrics.get_registry_uploads(name),
+            size_bytes: size,
+        });
+
+        let proxy_upstream = match reg {
+            RegistryType::Docker => state.config.docker.upstreams.first().map(|u| u.url.clone()),
+            RegistryType::Maven => state
+                .config
+                .maven
+                .proxies
+                .first()
+                .map(|p| p.url().to_string()),
+            RegistryType::Npm => state.config.npm.proxy.clone(),
+            RegistryType::PyPI => state.config.pypi.proxy.clone(),
+            RegistryType::Go => state.config.go.proxy.clone(),
+            RegistryType::Gems => state.config.gems.proxy.clone(),
+            RegistryType::Terraform => state.config.terraform.proxy.clone(),
+            RegistryType::Ansible => state.config.ansible.proxy.clone(),
+            RegistryType::Nuget => state.config.nuget.proxy.clone(),
+            _ => None,
+        };
+
+        mount_points.push(MountPoint {
+            registry: reg.display_name().to_string(),
+            mount_path: reg.mount_point().to_string(),
+            proxy_upstream,
+        });
+    }
+
+    // Also include new format registries if enabled
+    for reg in &[
+        RegistryType::Gems,
+        RegistryType::Terraform,
+        RegistryType::Ansible,
+        RegistryType::Nuget,
+        RegistryType::PubDart,
+        RegistryType::Conan,
+    ] {
+        if !state.enabled_registries.contains(reg) {
+            continue;
+        }
+
+        let name = reg.as_str();
+        let repos = state.repo_index.get(name, &state.storage).await;
+        let size: u64 = repos.iter().map(|r| r.size).sum();
+        let versions: usize = repos.iter().map(|r| r.versions).sum();
+
+        total_storage += size;
+        total_artifacts += versions;
+
+        registry_card_stats.push(RegistryCardStats {
+            name: name.to_string(),
+            artifact_count: versions,
+            downloads: state.metrics.get_registry_downloads(name),
+            uploads: state.metrics.get_registry_uploads(name),
+            size_bytes: size,
+        });
+
+        let proxy_upstream = match reg {
+            RegistryType::Gems => state.config.gems.proxy.clone(),
+            RegistryType::Terraform => state.config.terraform.proxy.clone(),
+            RegistryType::Ansible => state.config.ansible.proxy.clone(),
+            RegistryType::Nuget => state.config.nuget.proxy.clone(),
+            RegistryType::PubDart => state.config.pub_dart.proxy.clone(),
+            RegistryType::Conan => state.config.conan.proxy.clone(),
+            _ => None,
+        };
+
+        mount_points.push(MountPoint {
+            registry: reg.display_name().to_string(),
+            mount_path: reg.mount_point().to_string(),
+            proxy_upstream,
+        });
+    }
 
     let global_stats = GlobalStats {
         downloads: state.metrics.downloads.load(Ordering::Relaxed),
@@ -175,101 +234,6 @@ pub async fn api_dashboard(State(state): State<Arc<AppState>>) -> Json<Dashboard
         cache_hit_percent: state.metrics.cache_hit_rate(),
         storage_bytes: total_storage,
     };
-
-    let registry_card_stats = vec![
-        RegistryCardStats {
-            name: "docker".to_string(),
-            artifact_count: docker_versions,
-            downloads: state.metrics.get_registry_downloads("docker"),
-            uploads: state.metrics.get_registry_uploads("docker"),
-            size_bytes: docker_size,
-        },
-        RegistryCardStats {
-            name: "maven".to_string(),
-            artifact_count: maven_versions,
-            downloads: state.metrics.get_registry_downloads("maven"),
-            uploads: state.metrics.get_registry_uploads("maven"),
-            size_bytes: maven_size,
-        },
-        RegistryCardStats {
-            name: "npm".to_string(),
-            artifact_count: npm_versions,
-            downloads: state.metrics.get_registry_downloads("npm"),
-            uploads: 0,
-            size_bytes: npm_size,
-        },
-        RegistryCardStats {
-            name: "cargo".to_string(),
-            artifact_count: cargo_versions,
-            downloads: state.metrics.get_registry_downloads("cargo"),
-            uploads: 0,
-            size_bytes: cargo_size,
-        },
-        RegistryCardStats {
-            name: "pypi".to_string(),
-            artifact_count: pypi_versions,
-            downloads: state.metrics.get_registry_downloads("pypi"),
-            uploads: 0,
-            size_bytes: pypi_size,
-        },
-        RegistryCardStats {
-            name: "go".to_string(),
-            artifact_count: go_versions,
-            downloads: state.metrics.get_registry_downloads("go"),
-            uploads: 0,
-            size_bytes: go_size,
-        },
-        RegistryCardStats {
-            name: "raw".to_string(),
-            artifact_count: raw_versions,
-            downloads: state.metrics.get_registry_downloads("raw"),
-            uploads: state.metrics.get_registry_uploads("raw"),
-            size_bytes: raw_size,
-        },
-    ];
-
-    let mount_points = vec![
-        MountPoint {
-            registry: "Docker".to_string(),
-            mount_path: "/v2/".to_string(),
-            proxy_upstream: state.config.docker.upstreams.first().map(|u| u.url.clone()),
-        },
-        MountPoint {
-            registry: "Maven".to_string(),
-            mount_path: "/maven2/".to_string(),
-            proxy_upstream: state
-                .config
-                .maven
-                .proxies
-                .first()
-                .map(|p| p.url().to_string()),
-        },
-        MountPoint {
-            registry: "npm".to_string(),
-            mount_path: "/npm/".to_string(),
-            proxy_upstream: state.config.npm.proxy.clone(),
-        },
-        MountPoint {
-            registry: "Cargo".to_string(),
-            mount_path: "/cargo/".to_string(),
-            proxy_upstream: None,
-        },
-        MountPoint {
-            registry: "PyPI".to_string(),
-            mount_path: "/simple/".to_string(),
-            proxy_upstream: state.config.pypi.proxy.clone(),
-        },
-        MountPoint {
-            registry: "Go".to_string(),
-            mount_path: "/go/".to_string(),
-            proxy_upstream: state.config.go.proxy.clone(),
-        },
-        MountPoint {
-            registry: "Raw".to_string(),
-            mount_path: "/raw/".to_string(),
-            proxy_upstream: None,
-        },
-    ];
 
     let activity = state.activity.recent(20);
     let uptime_seconds = state.start_time.elapsed().as_secs();

--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use super::i18n::{get_translations, Lang, Translations};
@@ -14,6 +14,27 @@ pub fn layout_dark(
     extra_scripts: &str,
     lang: Lang,
     auth_enabled: bool,
+) -> String {
+    layout_dark_filtered(
+        title,
+        content,
+        active_page,
+        extra_scripts,
+        lang,
+        auth_enabled,
+        None,
+    )
+}
+
+/// Dark theme layout wrapper with optional registry filter
+pub fn layout_dark_filtered(
+    title: &str,
+    content: &str,
+    active_page: Option<&str>,
+    extra_scripts: &str,
+    lang: Lang,
+    auth_enabled: bool,
+    enabled_registries: Option<&std::collections::HashSet<crate::registry_type::RegistryType>>,
 ) -> String {
     let t = get_translations(lang);
     format!(
@@ -77,15 +98,20 @@ pub fn layout_dark(
 </html>"##,
         lang.code(),
         html_escape(title),
-        sidebar_dark(active_page, t, auth_enabled),
+        sidebar_dark_with_registries(active_page, t, auth_enabled, enabled_registries),
         header_dark(lang),
         content,
         extra_scripts
     )
 }
 
-/// Dark theme sidebar
-fn sidebar_dark(active_page: Option<&str>, t: &Translations, auth_enabled: bool) -> String {
+/// Dark theme sidebar with optional registry filter
+pub fn sidebar_dark_with_registries(
+    active_page: Option<&str>,
+    t: &Translations,
+    auth_enabled: bool,
+    enabled: Option<&std::collections::HashSet<crate::registry_type::RegistryType>>,
+) -> String {
     let active = active_page.unwrap_or("");
 
     let docker_icon = r#"<path fill="currentColor" d="M13.983 11.078h2.119a.186.186 0 00.186-.185V9.006a.186.186 0 00-.186-.186h-2.119a.185.185 0 00-.185.185v1.888c0 .102.083.185.185.185m-2.954-5.43h2.118a.186.186 0 00.186-.186V3.574a.186.186 0 00-.186-.185h-2.118a.185.185 0 00-.185.185v1.888c0 .102.082.185.185.186m0 2.716h2.118a.187.187 0 00.186-.186V6.29a.186.186 0 00-.186-.185h-2.118a.185.185 0 00-.185.185v1.887c0 .102.082.185.185.186m-2.93 0h2.12a.186.186 0 00.184-.186V6.29a.185.185 0 00-.185-.185H8.1a.185.185 0 00-.185.185v1.887c0 .102.083.185.185.186m-2.964 0h2.119a.186.186 0 00.185-.186V6.29a.185.185 0 00-.185-.185H5.136a.186.186 0 00-.186.185v1.887c0 .102.084.185.186.186m5.893 2.715h2.118a.186.186 0 00.186-.185V9.006a.186.186 0 00-.186-.186h-2.118a.185.185 0 00-.185.185v1.888c0 .102.082.185.185.185m-2.93 0h2.12a.185.185 0 00.184-.185V9.006a.185.185 0 00-.184-.186h-2.12a.185.185 0 00-.184.185v1.888c0 .102.083.185.185.185m-2.964 0h2.119a.185.185 0 00.185-.185V9.006a.185.185 0 00-.185-.186h-2.12a.186.186 0 00-.185.186v1.887c0 .102.084.185.186.185m-2.92 0h2.12a.185.185 0 00.184-.185V9.006a.185.185 0 00-.184-.186h-2.12a.185.185 0 00-.184.185v1.888c0 .102.082.185.185.185M23.763 9.89c-.065-.051-.672-.51-1.954-.51-.338.001-.676.03-1.01.087-.248-1.7-1.653-2.53-1.716-2.566l-.344-.199-.226.327c-.284.438-.49.922-.612 1.43-.23.97-.09 1.882.403 2.661-.595.332-1.55.413-1.744.42H.751a.751.751 0 00-.75.748 11.376 11.376 0 00.692 4.062c.545 1.428 1.355 2.48 2.41 3.124 1.18.723 3.1 1.137 5.275 1.137.983.003 1.963-.086 2.93-.266a12.248 12.248 0 003.823-1.389c.98-.567 1.86-1.288 2.61-2.136 1.252-1.418 1.998-2.997 2.553-4.4h.221c1.372 0 2.215-.549 2.68-1.009.309-.293.55-.65.707-1.046l.098-.288Z"/>"#;
@@ -97,20 +123,60 @@ fn sidebar_dark(active_page: Option<&str>, t: &Translations, auth_enabled: bool)
     // Dashboard label is translated, registry names stay as-is
     let dashboard_label = t.nav_dashboard;
 
-    let nav_items = [
+    use crate::registry_type::RegistryType;
+
+    // All possible nav items with their RegistryType
+    let all_nav_items: Vec<(Option<RegistryType>, &str, &str, &str, &str, bool)> = vec![
         (
+            None,
             "dashboard",
             "/ui/",
             dashboard_label,
             r#"<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"/>"#,
             true,
         ),
-        ("docker", "/ui/docker", "Docker", docker_icon, false),
-        ("maven", "/ui/maven", "Maven", maven_icon, false),
-        ("npm", "/ui/npm", "npm", npm_icon, false),
-        ("cargo", "/ui/cargo", "Cargo", cargo_icon, false),
-        ("pypi", "/ui/pypi", "PyPI", pypi_icon, false),
         (
+            Some(RegistryType::Docker),
+            "docker",
+            "/ui/docker",
+            "Docker",
+            docker_icon,
+            false,
+        ),
+        (
+            Some(RegistryType::Maven),
+            "maven",
+            "/ui/maven",
+            "Maven",
+            maven_icon,
+            false,
+        ),
+        (
+            Some(RegistryType::Npm),
+            "npm",
+            "/ui/npm",
+            "npm",
+            npm_icon,
+            false,
+        ),
+        (
+            Some(RegistryType::Cargo),
+            "cargo",
+            "/ui/cargo",
+            "Cargo",
+            cargo_icon,
+            false,
+        ),
+        (
+            Some(RegistryType::PyPI),
+            "pypi",
+            "/ui/pypi",
+            "PyPI",
+            pypi_icon,
+            false,
+        ),
+        (
+            Some(RegistryType::Raw),
             "raw",
             "/ui/raw",
             "Raw",
@@ -118,37 +184,125 @@ fn sidebar_dark(active_page: Option<&str>, t: &Translations, auth_enabled: bool)
             false,
         ),
         (
+            Some(RegistryType::Go),
             "go",
             "/ui/go",
             "Go",
             r#"<path fill="currentColor" d="M2.64 9.56s.24-.14.65-.38c.41-.24.97-.5 1.63-.7A7.85 7.85 0 017.53 8c.86 0 1.67.17 2.37.52.7.35 1.26.87 1.63 1.51.37.64.54 1.41.54 2.27v.2h-2.7v-.16c0-.47-.09-.86-.28-1.15a1.7 1.7 0 00-.77-.67 2.7 2.7 0 00-1.14-.22c-.56 0-1.06.13-1.46.4-.41.27-.72.66-.93 1.16-.21.5-.31 1.1-.31 1.8 0 .69.1 1.28.32 1.78.21.5.53.88.94 1.15.41.27.9.4 1.47.4.38 0 .73-.06 1.04-.17.31-.12.56-.29.74-.52.19-.23.29-.51.29-.84v-.14H7.15v-1.76h5.07v1.3c0 .8-.17 1.48-.52 2.04a3.46 3.46 0 01-1.5 1.3c-.66.3-1.44.45-2.35.45-.99 0-1.87-.18-2.63-.55a4.2 4.2 0 01-1.77-1.59C3.15 14.82 3 13.94 3 12.89v-.28c0-1.04.16-1.93.48-2.65a3.08 3.08 0 01-.84-.4zm12.1-1.34c.92 0 1.74.18 2.44.55a3.96 3.96 0 011.66 1.59c.4.7.6 1.54.6 2.53v.28c0 .99-.2 1.83-.6 2.53a3.96 3.96 0 01-1.66 1.59c-.7.37-1.52.55-2.44.55s-1.74-.18-2.44-.55a3.96 3.96 0 01-1.66-1.59c-.4-.7-.6-1.54-.6-2.53v-.28c0-.99.2-1.83.6-2.53a3.96 3.96 0 011.66-1.59c.7-.37 1.52-.55 2.44-.55zm0 2.12c-.44 0-.82.12-1.14.37-.32.24-.56.6-.73 1.06-.17.46-.26 1.01-.26 1.65v.28c0 .64.09 1.19.26 1.65.17.46.41.82.73 1.06.32.25.7.37 1.14.37.44 0 .82-.12 1.14-.37.32-.24.56-.6.73-1.06.17-.46.26-1.01.26-1.65v-.28c0-.64-.09-1.19-.26-1.65a2.17 2.17 0 00-.73-1.06 1.78 1.78 0 00-1.14-.37z"/>"#,
             false,
         ),
+        (
+            Some(RegistryType::Gems),
+            "gems",
+            "/ui/gems",
+            "RubyGems",
+            icons::GEMS,
+            false,
+        ),
+        (
+            Some(RegistryType::Terraform),
+            "terraform",
+            "/ui/terraform",
+            "Terraform",
+            icons::TERRAFORM,
+            false,
+        ),
+        (
+            Some(RegistryType::Ansible),
+            "ansible",
+            "/ui/ansible",
+            "Ansible",
+            icons::ANSIBLE,
+            false,
+        ),
+        (
+            Some(RegistryType::Nuget),
+            "nuget",
+            "/ui/nuget",
+            "NuGet",
+            icons::NUGET,
+            false,
+        ),
+        (
+            Some(RegistryType::PubDart),
+            "pub",
+            "/ui/pub",
+            "pub.dev",
+            icons::PUB,
+            true,
+        ),
+        (
+            Some(RegistryType::Conan),
+            "conan",
+            "/ui/conan",
+            "Conan",
+            icons::CONAN,
+            false,
+        ),
     ];
 
-    let nav_html: String = nav_items.iter().map(|(id, href, label, icon_path, is_stroke)| {
-        let is_active = active == *id;
+    // Filter to enabled registries (dashboard always shown)
+    let nav_items: Vec<_> = all_nav_items
+        .into_iter()
+        .filter(|(reg_type, _, _, _, _, _)| {
+            match reg_type {
+                None => true, // Dashboard always visible
+                Some(rt) => match enabled {
+                    Some(set) => set.contains(rt),
+                    None => true, // No filter = show all
+                },
+            }
+        })
+        .map(|(_, id, href, label, icon, is_stroke)| (id, href, label, icon, is_stroke))
+        .collect();
+
+    let render_nav_item = |id: &str,
+                           href: &str,
+                           label: &str,
+                           icon_path: &str,
+                           is_stroke: bool|
+     -> String {
+        let is_active = active == id;
         let active_class = if is_active {
             "bg-slate-700 text-white"
         } else {
             "text-slate-300 hover:bg-slate-700 hover:text-white"
         };
 
-        let (fill_attr, stroke_attr) = if *is_stroke {
+        let (fill_attr, stroke_attr) = if is_stroke {
             ("none", r#" stroke="currentColor""#)
         } else {
             ("currentColor", "")
         };
 
-        format!(r##"
+        format!(
+            r##"
             <a href="{}" class="flex items-center px-4 py-3 text-sm font-medium rounded-lg transition-colors {}">
                 <svg class="w-5 h-5 mr-3" fill="{}"{} viewBox="0 0 24 24">
                     {}
                 </svg>
                 {}
             </a>
-        "##, href, active_class, fill_attr, stroke_attr, icon_path, label)
-    }).collect();
+        "##,
+            href, active_class, fill_attr, stroke_attr, icon_path, label
+        )
+    };
+
+    let dashboard_html: String = nav_items
+        .iter()
+        .filter(|(id, _, _, _, _)| *id == "dashboard")
+        .map(|(id, href, label, icon, is_stroke)| {
+            render_nav_item(id, href, label, icon, *is_stroke)
+        })
+        .collect();
+
+    let registries_html: String = nav_items
+        .iter()
+        .filter(|(id, _, _, _, _)| *id != "dashboard")
+        .map(|(id, href, label, icon, is_stroke)| {
+            render_nav_item(id, href, label, icon, *is_stroke)
+        })
+        .collect();
     // Flat sidebar items (no umbrella category)
     let admin_section = if auth_enabled {
         let tokens_active = if active == "tokens" {
@@ -188,7 +342,10 @@ fn sidebar_dark(active_page: Option<&str>, t: &Translations, auth_enabled: bool)
             </div>
             <nav class="flex-1 px-4 py-6 space-y-1 overflow-y-auto">
                 {}
-                <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 mt-6 mb-3">
+                <div class="border-t border-slate-700 mt-4 pt-4">
+                    <div class="text-xs font-semibold text-slate-400 uppercase tracking-wider px-4 mb-3">
+                        {}
+                    </div>
                     {}
                 </div>
                 {}
@@ -200,7 +357,7 @@ fn sidebar_dark(active_page: Option<&str>, t: &Translations, auth_enabled: bool)
             </div>
         </div>
     "#,
-        nav_html, t.nav_registries, admin_section, VERSION
+        dashboard_html, t.nav_registries, registries_html, admin_section, VERSION
     )
 }
 
@@ -528,6 +685,12 @@ pub mod icons {
     pub const CARGO: &str = r#"<path fill="currentColor" d="M6 2h12a1 1 0 011 1v8a1 1 0 01-1 1H6a1 1 0 01-1-1V3a1 1 0 011-1zm0 2v2h12V4H6zm0 3v2h12V7H6zM2 14h8a1 1 0 011 1v6a1 1 0 01-1 1H2a1 1 0 01-1-1v-6a1 1 0 011-1zm0 2v1.5h8V16H2zM14 14h8a1 1 0 011 1v6a1 1 0 01-1 1h-8a1 1 0 01-1-1v-6a1 1 0 011-1zm0 2v1.5h8V16h-8z"/>"#;
     pub const GO: &str = r#"<path fill="currentColor" d="M2.64 9.56s.24-.14.65-.38c.41-.24.97-.5 1.63-.7A7.85 7.85 0 017.53 8c.86 0 1.67.17 2.37.52.7.35 1.26.87 1.63 1.51.37.64.54 1.41.54 2.27v.2h-2.7v-.16c0-.47-.09-.86-.28-1.15a1.7 1.7 0 00-.77-.67 2.7 2.7 0 00-1.14-.22c-.56 0-1.06.13-1.46.4-.41.27-.72.66-.93 1.16-.21.5-.31 1.1-.31 1.8 0 .69.1 1.28.32 1.78.21.5.53.88.94 1.15.41.27.9.4 1.47.4.38 0 .73-.06 1.04-.17.31-.12.56-.29.74-.52.19-.23.29-.51.29-.84v-.14H7.15v-1.76h5.07v1.3c0 .8-.17 1.48-.52 2.04a3.46 3.46 0 01-1.5 1.3c-.66.3-1.44.45-2.35.45-.99 0-1.87-.18-2.63-.55a4.2 4.2 0 01-1.77-1.59C3.15 14.82 3 13.94 3 12.89v-.28c0-1.04.16-1.93.48-2.65a3.08 3.08 0 01-.84-.4zm12.1-1.34c.92 0 1.74.18 2.44.55a3.96 3.96 0 011.66 1.59c.4.7.6 1.54.6 2.53v.28c0 .99-.2 1.83-.6 2.53a3.96 3.96 0 01-1.66 1.59c-.7.37-1.52.55-2.44.55s-1.74-.18-2.44-.55a3.96 3.96 0 01-1.66-1.59c-.4-.7-.6-1.54-.6-2.53v-.28c0-.99.2-1.83.6-2.53a3.96 3.96 0 011.66-1.59c.7-.37 1.52-.55 2.44-.55zm0 2.12c-.44 0-.82.12-1.14.37-.32.24-.56.6-.73 1.06-.17.46-.26 1.01-.26 1.65v.28c0 .64.09 1.19.26 1.65.17.46.41.82.73 1.06.32.25.7.37 1.14.37.44 0 .82-.12 1.14-.37.32-.24.56-.6.73-1.06.17-.46.26-1.01.26-1.65v-.28c0-.64-.09-1.19-.26-1.65a2.17 2.17 0 00-.73-1.06 1.78 1.78 0 00-1.14-.37z"/>"#;
     pub const RAW: &str = r#"<path fill="currentColor" d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zm4 18H6V4h7v5h5v11z"/>"#;
+    pub const GEMS: &str = r#"<path fill="currentColor" d="M7.81 7.9l-2.97 2.95 7.19 7.18 2.96-2.95 4.22-4.23-2.96-2.96v-.01H7.8zM12 0L1.53 6v12L12 24l10.47-6V6L12 0zm8.47 16.85L12 21.73l-8.47-4.88V7.12L12 2.24l8.47 4.88v9.73z"/>"#;
+    pub const TERRAFORM: &str = r#"<path fill="currentColor" d="M1.5 0v7.69l6.56 3.85V3.85L1.5 0zm7.94 4.62v7.69l6.56-3.84V.77L9.44 4.62zm7.94 0v7.69l6.56-3.84V.77l-6.56 3.85zM9.44 13.46v7.69l6.56-3.85v-7.69l-6.56 3.85z"/>"#;
+    pub const ANSIBLE: &str = r#"<path fill="currentColor" d="M10.617 11.473l4.686 3.695-3.102-7.662zM12 0C5.371 0 0 5.371 0 12s5.371 12 12 12 12-5.371 12-12S18.629 0 12 0zm5.797 17.305c-.011.471-.403.842-.875.83-.236 0-.416-.09-.664-.293l-6.19-5-2.079 5.203H6.191L11.438 5.44c.124-.314.427-.52.764-.506.326-.014.63.189.742.506l4.774 11.494c.045.111.08.234.08.348-.001.009-.001.009-.001.023z"/>"#;
+    pub const NUGET: &str = r#"<circle cx="7" cy="17" r="3.5" fill="currentColor"/><circle cx="16" cy="8.5" r="5" fill="currentColor"/><circle cx="4" cy="5" r="2" fill="currentColor"/>"#;
+    pub const CONAN: &str = r#"<path fill="currentColor" d="M11.709 0 0 5.534V16.76L11.984 24l4.857-2.706V9.998c.13-.084.275-.196.399-.27l.032-.017c.197-.11.329-.102.23.33v10.884l6.466-3.603V6.11L24 6.093Zm.915 2.83c.932.02 1.855.191 2.706.552 1.32.533 2.522 1.364 3.45 2.429a62.814 62.814 0 0 1-3.044 1.616c.56-.853.14-2.009-.76-2.455-.93-.648-2.093-.73-3.205-.674-1.064.175-2.258.51-2.893 1.474-.722.862-.084 2.11.914 2.408 1.2.509 2.543.38 3.806.413-.975.457-1.931.97-2.927 1.358-1.701-.176-3.585-.917-4.374-2.51-.574-1.178.215-2.572 1.319-3.14a11.426 11.426 0 0 1 3.336-1.348 9.212 9.212 0 0 1 1.672-.123Z"/>"#;
+    pub const PUB: &str = r#"<g><path fill="none" stroke="currentColor" d="M4.105 4.105v12.79c0 1.266.159 1.577.79 2.21L9.79 24h9.947v-4.263L4.105 4.105z"/><path fill="none" stroke="currentColor" d="M4.105 16.894c0 1.266.159 1.577.79 2.21l.632.632h14.21L4.105 4.105v12.79z"/><path fill="none" stroke="currentColor" d="M4.105 4.105L.316 12c-.135.287-.316.64-.316.95c0 .69.303 1.395.79 1.895l4.105 4.105c-.631-.633-.79-.944-.79-2.21V4.105z"/><path fill="none" stroke="currentColor" d="M5.053 19.263c-.631-.633-.79-.944-.79-2.21V4.263l-.158-.158v12.79c0 1.266.159 1.577.79 2.21l.632.632h0L5.053 19.263z"/><path fill="none" stroke="currentColor" d="M16.737 4.105H4.105l15.632 15.632H24V9.947l-5.053-5.053c-.711-.712-1.342-.79-2.21-.79z"/><path fill="none" stroke="currentColor" d="M18.947 4.895l-4.105-4.105C14.484.429 13.737 0 13.105 0c-.543 0-1.076.108-1.421.316L4.105 4.105h12.632c.868 0 1.499.078 2.21.79z"/><polygon fill="none" stroke="currentColor" points="23.842 9.79 23.842 19.579 19.579 19.579 19.737 19.737 24 19.737 24 9.947"/><path fill="none" stroke="currentColor" d="M18.947 4.895c-.783-.783-1.425-.79-2.368-.79H4.105l.158.158h12.316c.395 0 1.185-.079 1.895.632l.474.474z"/></g>"#;
     pub const PYPI: &str = r#"<path fill="currentColor" d="M14.25.18l.9.2.73.26.59.3.45.32.34.34.25.34.16.33.1.3.04.26.02.2-.01.13V8.5l-.05.63-.13.55-.21.46-.26.38-.3.31-.33.25-.35.19-.35.14-.33.1-.3.07-.26.04-.21.02H8.83l-.69.05-.59.14-.5.22-.41.27-.33.32-.27.35-.2.36-.15.37-.1.35-.07.32-.04.27-.02.21v3.06H3.23l-.21-.03-.28-.07-.32-.12-.35-.18-.36-.26-.36-.36-.35-.46-.32-.59-.28-.73-.21-.88-.14-1.05L0 11.97l.06-1.22.16-1.04.24-.87.32-.71.36-.57.4-.44.42-.33.42-.24.4-.16.36-.1.32-.05.24-.01h.16l.06.01h8.16v-.83H6.24l-.01-2.75-.02-.37.05-.34.11-.31.17-.28.25-.26.31-.23.38-.2.44-.18.51-.15.58-.12.64-.1.71-.06.77-.04.84-.02 1.27.05 1.07.13zm-6.3 1.98l-.23.33-.08.41.08.41.23.34.33.22.41.09.41-.09.33-.22.23-.34.08-.41-.08-.41-.23-.33-.33-.22-.41-.09-.41.09-.33.22zM21.1 6.11l.28.06.32.12.35.18.36.27.36.35.35.47.32.59.28.73.21.88.14 1.04.05 1.23-.06 1.23-.16 1.04-.24.86-.32.71-.36.57-.4.45-.42.33-.42.24-.4.16-.36.09-.32.05-.24.02-.16-.01h-8.22v.82h5.84l.01 2.76.02.36-.05.34-.11.31-.17.29-.25.25-.31.24-.38.2-.44.17-.51.15-.58.13-.64.09-.71.07-.77.04-.84.01-1.27-.04-1.07-.14-.9-.2-.73-.25-.59-.3-.45-.33-.34-.34-.25-.34-.16-.33-.1-.3-.04-.25-.02-.2.01-.13v-5.34l.05-.64.13-.54.21-.46.26-.38.3-.32.33-.24.35-.2.35-.14.33-.1.3-.06.26-.04.21-.02.13-.01h5.84l.69-.05.59-.14.5-.21.41-.28.33-.32.27-.35.2-.36.15-.36.1-.35.07-.32.04-.28.02-.21V6.07h2.09l.14.01.21.03zm-6.47 14.25l-.23.33-.08.41.08.41.23.33.33.23.41.08.41-.08.33-.23.23-.33.08-.41-.08-.41-.23-.33-.33-.23-.41-.08-.41.08-.33.23z"/>"#;
 }
 
@@ -580,7 +743,7 @@ pub fn render_bragging_footer(lang: Lang) -> String {
                 <div class="text-xs text-slate-500 mt-1">{}</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-yellow-400">7</div>
+                <div class="text-2xl font-bold text-yellow-400">13</div>
                 <div class="text-xs text-slate-500 mt-1">{}</div>
             </div>
             <div class="p-3">

--- a/nora-registry/src/ui/i18n.rs
+++ b/nora-registry/src/ui/i18n.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 /// Internationalization support for the UI

--- a/nora-registry/src/ui/logo.rs
+++ b/nora-registry/src/ui/logo.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 #[allow(dead_code)]

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 mod api;
@@ -133,6 +133,13 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/ui/go/{*name}", get(go_detail))
         .route("/ui/raw", get(raw_list))
         .route("/ui/raw/{*name}", get(raw_detail))
+        // New registries (v0.7 — generic list pages)
+        .route("/ui/gems", get(generic_registry_list))
+        .route("/ui/terraform", get(generic_registry_list))
+        .route("/ui/ansible", get(generic_registry_list))
+        .route("/ui/nuget", get(generic_registry_list))
+        .route("/ui/pub", get(generic_registry_list))
+        .route("/ui/conan", get(generic_registry_list))
         // Token management UI (protected by auth middleware)
         .route("/ui/tokens", get(tokens_page))
         // Token management API (HTMX endpoints)
@@ -492,6 +499,45 @@ async fn raw_detail(
         &detail,
         lang,
         &base_url,
+        auth_enabled,
+    ))
+}
+
+// Generic registry list handler for new formats (v0.7)
+async fn generic_registry_list(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListQuery>,
+    headers: axum::http::HeaderMap,
+    uri: axum::http::Uri,
+) -> impl IntoResponse {
+    let lang = extract_lang_from_list(&query, headers.get("cookie").and_then(|v| v.to_str().ok()));
+    let page = query.page.unwrap_or(1).max(1);
+    let limit = query.limit.unwrap_or(DEFAULT_PAGE_SIZE).min(100);
+    let auth_enabled = state.auth.is_some();
+
+    // Extract registry type from URI path: /ui/{type}
+    let registry_key = uri.path().strip_prefix("/ui/").unwrap_or("raw");
+    let title = match registry_key {
+        "gems" => "RubyGems",
+        "terraform" => "Terraform Registry",
+        "ansible" => "Ansible Galaxy",
+        "nuget" => "NuGet Gallery",
+        "pub" => "Pub (Dart/Flutter)",
+        "conan" => "Conan (C/C++)",
+        _ => registry_key,
+    };
+
+    let all_items = state.repo_index.get(registry_key, &state.storage).await;
+    let (items, total) = paginate(&all_items, page, limit);
+
+    Html(render_registry_list_paginated(
+        registry_key,
+        title,
+        &items,
+        page,
+        limit,
+        total,
+        lang,
         auth_enabled,
     ))
 }

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 use super::api::{DashboardResponse, DockerDetail, MavenDetail, PackageDetail};
@@ -1057,6 +1057,12 @@ fn get_registry_icon(registry_type: &str) -> &'static str {
         "pypi" => icons::PYPI,
         "go" => icons::GO,
         "raw" => icons::RAW,
+        "gems" => icons::GEMS,
+        "terraform" => icons::TERRAFORM,
+        "ansible" => icons::ANSIBLE,
+        "nuget" => icons::NUGET,
+        "pub" => icons::PUB,
+        "conan" => icons::CONAN,
         _ => {
             r#"<path fill="currentColor" d="M10 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2h-8l-2-2z"/>"#
         }
@@ -1072,6 +1078,12 @@ fn get_registry_title(registry_type: &str) -> &'static str {
         "pypi" => "PyPI Repository",
         "go" => "Go Modules",
         "raw" => "Raw Storage",
+        "gems" => "RubyGems",
+        "terraform" => "Terraform Registry",
+        "ansible" => "Ansible Galaxy",
+        "nuget" => "NuGet Gallery",
+        "pub" => "pub.dev",
+        "conan" => "Conan (C/C++)",
         _ => "Registry",
     }
 }

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2026 Volkov Pavel | DevITWay
+// Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
 //! Input validation for artifact registry paths and identifiers

--- a/scripts/coherence-check.sh
+++ b/scripts/coherence-check.sh
@@ -55,7 +55,7 @@ echo ""
 
 echo "--- Registry List ---"
 # Source of truth: Router mounts in main.rs or lib.rs
-EXPECTED_REGISTRIES="docker maven npm cargo pypi go raw"
+EXPECTED_REGISTRIES="docker maven npm cargo pypi go raw gems terraform ansible nuget pub conan"
 
 for reg in $EXPECTED_REGISTRIES; do
     # Check README mentions it


### PR DESCRIPTION
## Summary

- **Curation layer** — blocklist, allowlist, integrity verification, CVE blocking via OSV.dev, CLI tools (`nora curation validate/explain`). Modes: off/audit/enforce. Wired into all 13 registries.
- **6 new registries**: RubyGems, Terraform, Ansible Galaxy, NuGet, pub.dev, Conan — all with proxy upstream, curation support, dynamic enable/disable
- **Dynamic registry loading** — per-registry `enabled` flag in config + env vars (`NORA_*_ENABLED`)
- **UI** — 13-registry sidebar with SVG icons, dashboard cards for all formats
- **Copyright** updated to The NORA Authors

## Registries

| Format | Path | Issue |
|--------|------|-------|
| RubyGems | `/gems/` | Closes #141 |
| Terraform | `/terraform/` | Closes #133 |
| Ansible Galaxy | `/ansible/` | Closes #134 |
| NuGet | `/nuget/` | Closes #140 |
| pub.dev | `/pub/` | Closes #166 |
| Conan | `/conan/` | Closes #142 |

pub.dev registry based on PR #191 by @mit-73.

## Test plan

- [x] 821 unit tests passing
- [x] Coherence check passing
- [x] demo.getnora.io deployed and verified (13/13 healthy)
- [ ] CI status checks