### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.7.0-rc5"
+version = "0.7.0"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0-rc5"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -18,7 +18,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.7.0-rc5",
+        version = "0.7.0",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
Version bump to v0.7.0 for release tag.