### PR TITLE
fix: immutable SHA tags in Docker image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Get short SHA and version
+        id: sha
+        run: |
+          echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
@@ -68,7 +74,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}-{{sha}}
+            type=raw,value=${{ steps.sha.outputs.version }}-${{ steps.sha.outputs.short }}
             type=raw,value=latest
 
       - name: Build and push (alpine)
@@ -91,7 +97,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}-{{sha}}
+            type=raw,value=${{ steps.sha.outputs.version }}-${{ steps.sha.outputs.short }}
             type=raw,value=latest
 
       - name: Build and push (redos)
@@ -115,7 +121,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{version}}-{{sha}}
+            type=raw,value=${{ steps.sha.outputs.version }}-${{ steps.sha.outputs.short }}
             type=raw,value=latest
 
       - name: Build and push (astra)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-27
+
 ### Added
 - **Declarative registry selection** — `[registries] enable = ["docker","npm"]` / `"all"` / `["all","-maven"]`, env `NORA_REGISTRIES_ENABLE`, 3-tier priority (env > TOML > legacy)
 - **Curation layer** — policy engine for download filtering across all 13 registries (#184-#190)


### PR DESCRIPTION
## Summary
- `type=semver,pattern={{version}}-{{sha}}` does not work — `{{sha}}` is not a valid semver placeholder
- Result: tags like `0.7.0-` with empty SHA suffix (visible in v0.7.0 GHCR tags)
- Fix: use `type=raw` with explicit `${{ steps.sha.outputs.version }}-${{ steps.sha.outputs.short }}`
- Restores "Get short SHA" step removed in #192

## Expected tags after fix
- `0.7.1-abc1234` (alpine)
- `0.7.1-abc1234-redos` (via flavor suffix)
- `0.7.1-abc1234-astra` (via flavor suffix)

These immutable tags are what goes into Helm values / K8s manifests to avoid stale `imagePullPolicy: IfNotPresent` cache.

Fixes #174