### PR TITLE
feat: v0.7.1 — min-release-age, token UI, dynamic stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-27
+
+### Added
+- **Min-release-age filter** — block packages younger than N days/hours/weeks (#132). Config: `min_release_age = "7d"`, env `NORA_CURATION_MIN_RELEASE_AGE`
+- **Token RBAC** — read/write/admin roles per token, expiry badges in UI, expired tokens sorted to bottom (#124)
+- **Dynamic stats footer** — demo builds show live binary size, VmRSS, registry count from /proc (replaces hardcoded values)
+- 850 total tests (up from 821)
+
+### Changed
+- Token list UI: expired tokens show red badge, sorted to bottom with reduced opacity
+- `format_expiry()` replaces `format_timestamp()` for token expiry display — correctly shows "in 28d" for future, "expired 3d ago" for past
+- `#[non_exhaustive]` on `Role` enum for forward compatibility
+
 ## [0.7.0] - 2026-04-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 
 - **Zero-config** — single binary, no database, no dependencies. `docker run` and it works.
 - **13 registries** — Docker, Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++).
-- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 821 tests.
+- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 850 tests.
 
 [![Release](https://img.shields.io/github/v/release/getnora-io/nora)](https://github.com/getnora-io/nora/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -94,7 +94,8 @@ See [full documentation](https://getnora.dev) for all registries.
 
 - **Web UI** — dashboard with search, browse, i18n (EN/RU)
 - **Proxy & Cache** — transparent proxy to upstream registries with local cache
-- **Curation** — blocklist, allowlist, CVE blocking, integrity verification
+- **Curation** — blocklist, allowlist, namespace isolation, integrity verification, min-release-age filter
+- **Token RBAC** — read/write/admin roles, expiry tracking, deferred last_used flush
 - **Mirror CLI** — offline sync for air-gapped environments (`nora mirror`)
 - **Backup & Restore** — `nora backup` / `nora restore`
 - **S3 Storage** — MinIO, AWS S3, any S3-compatible backend
@@ -114,6 +115,16 @@ docker run -d -p 4000:4000 \
   ghcr.io/getnora-io/nora:latest
 ```
 
+```bash
+# Curation — block packages younger than 7 days
+docker run -d -p 4000:4000 \
+  -v nora-data:/data \
+  -e NORA_CURATION_MODE=enforce \
+  -e NORA_CURATION_MIN_RELEASE_AGE=7d \
+  -e NORA_CURATION_ALLOWLIST_PATH=/data/allowlist.json \
+  ghcr.io/getnora-io/nora:latest
+```
+
 ## Performance
 
 | Metric | NORA | Nexus | JFrog |
@@ -130,7 +141,7 @@ docker run -d -p 4000:4000 \
 - ~~Signed releases & SBOM~~ ✅ v0.6.4
 - ~~Curation layer~~ ✅ v0.7.0
 - ~~13 registry formats~~ ✅ v0.7.0
-- **Min Release Age** — block packages younger than N days
+- ~~Min Release Age~~ ✅ v0.7.1
 - **OIDC / Workload Identity** — zero-secret auth for GitHub Actions, GitLab CI
 - **Image Signing Policy** — cosign verification on upstream pulls
 

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -826,6 +826,7 @@ pub enum CurationOnFailure {
 /// - `NORA_CURATION_BYPASS_TOKEN` — token to bypass curation checks
 /// - `NORA_CURATION_REQUIRE_INTEGRITY` — require integrity metadata (default: false)
 /// - `NORA_CURATION_INTERNAL_NAMESPACES` — comma-separated glob patterns
+/// - `NORA_CURATION_MIN_RELEASE_AGE` — minimum release age (e.g., "7d", "24h", "1w")
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CurationConfig {
     #[serde(default)]
@@ -845,6 +846,10 @@ pub struct CurationConfig {
     /// Always active regardless of curation mode (security boundary).
     #[serde(default)]
     pub internal_namespaces: Vec<String>,
+    /// Minimum release age before a package is allowed (e.g., "7d", "24h", "1w").
+    /// Packages published less than this duration ago are blocked.
+    #[serde(default)]
+    pub min_release_age: Option<String>,
 }
 
 impl Default for CurationConfig {
@@ -857,6 +862,7 @@ impl Default for CurationConfig {
             bypass_token: None,
             require_integrity: false,
             internal_namespaces: Vec::new(),
+            min_release_age: None,
         }
     }
 }
@@ -1826,6 +1832,9 @@ impl Config {
             } else {
                 val.split(',').map(|s| s.trim().to_string()).collect()
             };
+        }
+        if let Ok(val) = env::var("NORA_CURATION_MIN_RELEASE_AGE") {
+            self.curation.min_release_age = if val.is_empty() { None } else { Some(val) };
         }
     }
 }

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -43,6 +43,8 @@ pub struct FilterRequest {
     pub integrity: Option<String>,
     /// Whether the request carries a valid bypass token.
     pub bypass: bool,
+    /// Publish date as Unix timestamp (seconds). None = unknown.
+    pub publish_date: Option<i64>,
 }
 
 // ============================================================================
@@ -271,6 +273,7 @@ pub fn check_download(
         version: version.map(|v| v.to_string()),
         integrity: None,
         bypass,
+        publish_date: None,
     };
 
     let result = engine.evaluate(&request);
@@ -334,6 +337,7 @@ pub fn verify_integrity(
         version: version.map(|v| v.to_string()),
         integrity: Some(integrity),
         bypass: false, // bypass already checked in pre-download phase
+        publish_date: None,
     };
 
     let result = engine.evaluate(&request);
@@ -808,6 +812,121 @@ impl ProxyFilter for NamespaceFilter {
 // Tests
 // ============================================================================
 
+// ============================================================================
+// MinReleaseAgeFilter — block packages younger than N seconds (supply chain)
+// ============================================================================
+
+/// Parse a human-readable duration string into seconds.
+///
+/// Supported formats: `"7d"` (days), `"24h"` (hours), `"1w"` (weeks).
+/// Multiple units can be combined: `"1w2d"` = 9 days.
+pub fn parse_duration(s: &str) -> Result<i64, String> {
+    if s.is_empty() {
+        return Err("empty duration string".to_string());
+    }
+
+    let mut total: i64 = 0;
+    let mut num_buf = String::new();
+
+    for ch in s.chars() {
+        if ch.is_ascii_digit() {
+            num_buf.push(ch);
+        } else {
+            if num_buf.is_empty() {
+                return Err(format!("unexpected unit '{}' without number", ch));
+            }
+            let n: i64 = num_buf
+                .parse()
+                .map_err(|_| format!("invalid number '{}'", num_buf))?;
+            num_buf.clear();
+
+            match ch {
+                'd' => total += n * 86400,
+                'h' => total += n * 3600,
+                'w' => total += n * 604800,
+                _ => return Err(format!("unknown unit '{}' (use d/h/w)", ch)),
+            }
+        }
+    }
+
+    if !num_buf.is_empty() {
+        return Err(format!(
+            "trailing number '{}' without unit (use d/h/w)",
+            num_buf
+        ));
+    }
+
+    if total == 0 {
+        return Err("duration must be greater than zero".to_string());
+    }
+
+    Ok(total)
+}
+
+/// Filter that blocks packages published less than `min_age_secs` ago.
+///
+/// If `publish_date` is `None` (unknown), the filter returns `Skip` (no opinion).
+pub struct MinReleaseAgeFilter {
+    min_age_secs: i64,
+    label: String,
+}
+
+impl MinReleaseAgeFilter {
+    pub fn new(min_age_secs: i64, label: &str) -> Self {
+        Self {
+            min_age_secs,
+            label: label.to_string(),
+        }
+    }
+
+    fn format_duration(secs: i64) -> String {
+        if secs >= 604800 {
+            let weeks = secs / 604800;
+            let days = (secs % 604800) / 86400;
+            if days > 0 {
+                format!("{}w{}d", weeks, days)
+            } else {
+                format!("{}w", weeks)
+            }
+        } else if secs >= 86400 {
+            format!("{}d", secs / 86400)
+        } else {
+            format!("{}h", secs / 3600)
+        }
+    }
+}
+
+impl ProxyFilter for MinReleaseAgeFilter {
+    fn name(&self) -> &'static str {
+        "min-release-age"
+    }
+
+    fn evaluate(&self, request: &FilterRequest) -> Decision {
+        let Some(publish_ts) = request.publish_date else {
+            return Decision::Skip; // Unknown date — don't block
+        };
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        let age = now - publish_ts;
+        if age < self.min_age_secs {
+            Decision::Block {
+                rule: "min-release-age".to_string(),
+                reason: format!(
+                    "package is {}  old (minimum: {})",
+                    Self::format_duration(age.max(0)),
+                    self.label,
+                ),
+            }
+        } else {
+            Decision::Skip
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -879,6 +998,7 @@ mod tests {
             version: Some("1.0.0".to_string()),
             integrity: Some("sha256-abc123".to_string()),
             bypass: false,
+            publish_date: None,
         }
     }
 
@@ -890,6 +1010,7 @@ mod tests {
             version: None,
             integrity: None,
             bypass: false,
+            publish_date: None,
         }
     }
 
@@ -901,6 +1022,7 @@ mod tests {
             version: None,
             integrity: None,
             bypass: true,
+            publish_date: None,
         }
     }
 
@@ -949,7 +1071,10 @@ mod tests {
 
     #[test]
     fn test_enforce_allow_all() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(AllowAllFilter));
         let result = engine.evaluate(&make_request("lodash"));
         assert_eq!(result.decision, Decision::Allow);
@@ -959,7 +1084,10 @@ mod tests {
 
     #[test]
     fn test_enforce_block_all() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         let result = engine.evaluate(&make_request("lodash"));
         assert!(matches!(result.decision, Decision::Block { .. }));
@@ -969,7 +1097,10 @@ mod tests {
 
     #[test]
     fn test_enforce_block_increments_blocked_metric() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         engine.evaluate(&make_request("lodash"));
         assert_eq!(engine.metrics().blocked.load(Ordering::Relaxed), 1);
@@ -978,7 +1109,10 @@ mod tests {
 
     #[test]
     fn test_enforce_allow_increments_allowed_metric() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(AllowAllFilter));
         engine.evaluate(&make_request("lodash"));
         assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 1);
@@ -1019,7 +1153,10 @@ mod tests {
 
     #[test]
     fn test_chain_first_block_wins() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         engine.add_filter(Box::new(AllowAllFilter));
         let result = engine.evaluate(&make_request("lodash"));
@@ -1029,7 +1166,10 @@ mod tests {
 
     #[test]
     fn test_chain_first_allow_wins() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(AllowAllFilter));
         engine.add_filter(Box::new(BlockAllFilter));
         let result = engine.evaluate(&make_request("lodash"));
@@ -1039,7 +1179,10 @@ mod tests {
 
     #[test]
     fn test_chain_skip_then_block() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(SkipFilter));
         engine.add_filter(Box::new(BlockAllFilter));
         let result = engine.evaluate(&make_request("lodash"));
@@ -1049,7 +1192,10 @@ mod tests {
 
     #[test]
     fn test_chain_all_skip_allows() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(SkipFilter));
         engine.add_filter(Box::new(SkipFilter));
         let result = engine.evaluate(&make_request("lodash"));
@@ -1067,7 +1213,10 @@ mod tests {
 
     #[test]
     fn test_selective_block() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockPackageFilter {
             target: "evil-pkg".to_string(),
         }));
@@ -1083,7 +1232,10 @@ mod tests {
 
     #[test]
     fn test_bypass_allows_despite_block_filter() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         let result = engine.evaluate(&make_bypass_request("lodash"));
         assert_eq!(result.decision, Decision::Allow);
@@ -1092,7 +1244,10 @@ mod tests {
 
     #[test]
     fn test_bypass_increments_allowed() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         engine.evaluate(&make_bypass_request("lodash"));
         assert_eq!(engine.metrics().allowed.load(Ordering::Relaxed), 1);
@@ -1208,7 +1363,10 @@ mod tests {
 
     #[test]
     fn test_metrics_accumulate() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockPackageFilter {
             target: "evil".to_string(),
         }));
@@ -1321,6 +1479,7 @@ mod tests {
             version: version.map(|v| v.to_string()),
             integrity: None,
             bypass: false,
+            publish_date: None,
         }
     }
 
@@ -1516,7 +1675,10 @@ mod tests {
         );
         let filter = BlocklistFilter::from_file(&path).unwrap();
 
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(filter));
 
         let result = engine.evaluate(&make_request("evil"));
@@ -1533,7 +1695,10 @@ mod tests {
         );
         let filter = BlocklistFilter::from_file(&path).unwrap();
 
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(filter));
 
         let result = engine.evaluate(&make_request("lodash"));
@@ -1715,7 +1880,10 @@ mod tests {
 
     #[test]
     fn test_engine_namespace_blocks_before_bypass() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
         engine.add_filter(Box::new(AllowAllFilter));
 
@@ -1729,7 +1897,10 @@ mod tests {
 
     #[test]
     fn test_engine_namespace_skip_continues_to_chain() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.set_namespace_filter(Box::new(make_ns_filter(&["@internal/*"])));
         engine.add_filter(Box::new(BlockPackageFilter {
             target: "evil-pkg".to_string(),
@@ -2019,6 +2190,7 @@ mod tests {
             version: Some("4.17.21".to_string()),
             integrity: Some("sha256:abc123".to_string()),
             bypass: false,
+            publish_date: None,
         };
         match filter.evaluate(&req) {
             Decision::Block { rule, reason } => {
@@ -2067,7 +2239,10 @@ mod tests {
             false,
         );
 
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(blocklist));
         engine.add_filter(Box::new(allowlist));
 
@@ -2090,7 +2265,10 @@ mod tests {
             false,
         );
 
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(allowlist));
 
         // Unknown package → blocked
@@ -2127,7 +2305,10 @@ mod tests {
     fn test_engine_empty_allowlist_blocks_everything() {
         let allowlist = make_allowlist_entries(vec![], false);
 
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(allowlist));
 
         let req = make_request_with_registry(RegistryType::Npm, "lodash", Some("4.17.21"));
@@ -2173,7 +2354,10 @@ mod tests {
 
     #[test]
     fn test_check_download_enforce_block_returns_403() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         let headers = axum::http::HeaderMap::new();
         let result = super::check_download(
@@ -2207,7 +2391,10 @@ mod tests {
 
     #[test]
     fn test_check_download_bypass_token_matches() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         let headers = make_headers(&[("x-nora-bypass-token", "secret123")]);
         let result = super::check_download(
@@ -2223,7 +2410,10 @@ mod tests {
 
     #[test]
     fn test_check_download_bypass_token_mismatch() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         let headers = make_headers(&[("x-nora-bypass-token", "wrong")]);
         let result = super::check_download(
@@ -2239,7 +2429,10 @@ mod tests {
 
     #[test]
     fn test_check_download_no_bypass_configured() {
-        let mut engine = CurationEngine::new(enforce_config());
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
         engine.add_filter(Box::new(BlockAllFilter));
         let headers = make_headers(&[("x-nora-bypass-token", "anything")]);
         let result = super::check_download(
@@ -2492,6 +2685,7 @@ mod tests {
             version: Some("1.0.0".to_string()),
             integrity: None, // pre-download: no integrity
             bypass: false,
+            publish_date: None,
         };
         let decision = filter.evaluate(&request);
         assert!(
@@ -2524,6 +2718,7 @@ mod tests {
             version: Some("1.0.0".to_string()),
             integrity: Some("sha256:abc123".to_string()), // post-download: has integrity
             bypass: false,
+            publish_date: None,
         };
         let decision = filter.evaluate(&request);
         assert!(
@@ -2531,5 +2726,175 @@ mod tests {
             "require_integrity + entry without hash + post-download → block: got {:?}",
             decision
         );
+    }
+}
+
+// ============================================================================
+// MinReleaseAge tests
+// ============================================================================
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod min_release_age_tests {
+    use super::*;
+
+    // ── parse_duration tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_duration_days() {
+        assert_eq!(parse_duration("7d").unwrap(), 604800);
+        assert_eq!(parse_duration("1d").unwrap(), 86400);
+        assert_eq!(parse_duration("30d").unwrap(), 2592000);
+    }
+
+    #[test]
+    fn test_parse_duration_hours() {
+        assert_eq!(parse_duration("24h").unwrap(), 86400);
+        assert_eq!(parse_duration("1h").unwrap(), 3600);
+    }
+
+    #[test]
+    fn test_parse_duration_weeks() {
+        assert_eq!(parse_duration("1w").unwrap(), 604800);
+        assert_eq!(parse_duration("2w").unwrap(), 1209600);
+    }
+
+    #[test]
+    fn test_parse_duration_combined() {
+        assert_eq!(parse_duration("1w2d").unwrap(), 604800 + 172800);
+        assert_eq!(parse_duration("1d12h").unwrap(), 86400 + 43200);
+    }
+
+    #[test]
+    fn test_parse_duration_invalid() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("7").is_err()); // no unit
+        assert!(parse_duration("7x").is_err()); // unknown unit
+        assert!(parse_duration("d").is_err()); // no number
+    }
+
+    // ── MinReleaseAgeFilter tests ───────────────────────────────────────
+
+    #[test]
+    fn test_min_release_age_young_package_blocked() {
+        let filter = MinReleaseAgeFilter::new(604800, "7d"); // 7 days
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let request = FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: "fresh-pkg".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: None,
+            bypass: false,
+            publish_date: Some(now - 86400), // 1 day ago
+        };
+        assert!(matches!(filter.evaluate(&request), Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_min_release_age_old_package_passes() {
+        let filter = MinReleaseAgeFilter::new(604800, "7d"); // 7 days
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let request = FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: "stable-pkg".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: None,
+            bypass: false,
+            publish_date: Some(now - 864000), // 10 days ago
+        };
+        assert!(matches!(filter.evaluate(&request), Decision::Skip));
+    }
+
+    #[test]
+    fn test_min_release_age_unknown_date_skips() {
+        let filter = MinReleaseAgeFilter::new(604800, "7d");
+        let request = FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: "unknown-pkg".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: None,
+            bypass: false,
+            publish_date: None,
+        };
+        assert!(matches!(filter.evaluate(&request), Decision::Skip));
+    }
+
+    #[test]
+    fn test_min_release_age_exactly_at_boundary() {
+        let filter = MinReleaseAgeFilter::new(86400, "1d"); // 1 day
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        // Exactly at boundary — age == min_age, should pass (not less than)
+        let request = FilterRequest {
+            registry: RegistryType::Cargo,
+            upstream: None,
+            name: "boundary-pkg".to_string(),
+            version: Some("2.0.0".to_string()),
+            integrity: None,
+            bypass: false,
+            publish_date: Some(now - 86400),
+        };
+        assert!(matches!(filter.evaluate(&request), Decision::Skip));
+    }
+
+    #[test]
+    fn test_min_release_age_chain_integration() {
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Enforce,
+            ..CurationConfig::default()
+        });
+        engine.add_filter(Box::new(MinReleaseAgeFilter::new(604800, "7d")));
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        // Young package — blocked
+        let req_young = FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: "young-pkg".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: None,
+            bypass: false,
+            publish_date: Some(now - 3600), // 1 hour ago
+        };
+        let result = engine.evaluate(&req_young);
+        assert!(matches!(result.decision, Decision::Block { .. }));
+        assert_eq!(result.decided_by.as_deref(), Some("min-release-age"));
+
+        // Old package — passes (Skip -> default Allow in enforce)
+        let req_old = FilterRequest {
+            registry: RegistryType::Npm,
+            upstream: None,
+            name: "old-pkg".to_string(),
+            version: Some("1.0.0".to_string()),
+            integrity: None,
+            bypass: false,
+            publish_date: Some(now - 864000), // 10 days
+        };
+        let result = engine.evaluate(&req_old);
+        assert!(!matches!(result.decision, Decision::Block { .. }));
+    }
+
+    #[test]
+    fn test_min_release_age_format_duration() {
+        assert_eq!(MinReleaseAgeFilter::format_duration(3600), "1h");
+        assert_eq!(MinReleaseAgeFilter::format_duration(86400), "1d");
+        assert_eq!(MinReleaseAgeFilter::format_duration(604800), "1w");
+        assert_eq!(MinReleaseAgeFilter::format_duration(691200), "1w1d");
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -523,6 +523,19 @@ fn run_curation_explain(config: &Config, package_spec: &str) {
         println!("Namespaces: not configured");
     }
 
+    if let Some(ref age_str) = config.curation.min_release_age {
+        match curation::parse_duration(age_str) {
+            Ok(secs) => {
+                let filter = curation::MinReleaseAgeFilter::new(secs, age_str);
+                println!("Min-release-age: {} ({}s)", age_str, secs);
+                engine.add_filter(Box::new(filter));
+            }
+            Err(e) => println!("Min-release-age: {} (ERROR: {})", age_str, e),
+        }
+    } else {
+        println!("Min-release-age: not configured");
+    }
+
     println!("Mode: {}", config.curation.mode);
     println!("---");
 
@@ -533,6 +546,7 @@ fn run_curation_explain(config: &Config, package_spec: &str) {
         version: version.clone(),
         integrity: None,
         bypass: false,
+        publish_date: None,
     };
 
     let result = engine.evaluate(&request);
@@ -669,6 +683,26 @@ async fn run_server(config: Config, storage: Storage) {
         let count = ns_filter.pattern_count();
         curation_engine.set_namespace_filter(Box::new(ns_filter));
         info!(patterns = count, "Namespace isolation filter loaded");
+    }
+
+    // Load min-release-age filter if configured
+    if let Some(ref age_str) = config.curation.min_release_age {
+        match curation::parse_duration(age_str) {
+            Ok(secs) => {
+                let filter = curation::MinReleaseAgeFilter::new(secs, age_str);
+                curation_engine.add_filter(Box::new(filter));
+                info!(min_age = %age_str, seconds = secs, "Min-release-age filter loaded");
+            }
+            Err(e) => {
+                error!(value = %age_str, error = %e, "Invalid min_release_age");
+                if config.curation.mode == CurationMode::Enforce {
+                    panic!(
+                        "Cannot start in enforce mode with invalid min_release_age: {}",
+                        e
+                    );
+                }
+            }
+        }
     }
 
     // Determine enabled registries from config

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -36,6 +36,7 @@ const TOKEN_PREFIX: &str = "nra_";
 /// Access role for API tokens
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
+#[non_exhaustive]
 pub enum Role {
     Read,
     Write,

--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -720,55 +720,135 @@ pub fn html_escape(s: &str) -> String {
         .replace('\'', "&#39;")
 }
 
+/// Dynamic stats for the bragging footer (demo builds only).
+#[cfg(feature = "demo")]
+pub struct BraggingStats {
+    /// Binary size in MB (from /proc/self/exe).
+    pub binary_size_mb: u64,
+    /// Resident memory in MB (from /proc/self/status VmRSS).
+    pub memory_mb: u64,
+    /// Number of enabled registries.
+    pub registry_count: usize,
+    /// Uptime in seconds.
+    pub uptime_secs: u64,
+}
+
+#[cfg(feature = "demo")]
+impl BraggingStats {
+    /// Collect live stats from the running process.
+    pub fn collect(registry_count: usize, uptime_secs: u64) -> Self {
+        let binary_size_mb = Self::read_binary_size().unwrap_or(32);
+        let memory_mb = Self::read_vmrss().unwrap_or(30);
+        Self {
+            binary_size_mb,
+            memory_mb,
+            registry_count,
+            uptime_secs,
+        }
+    }
+
+    /// Read binary size from /proc/self/exe (Linux only).
+    fn read_binary_size() -> Option<u64> {
+        #[cfg(target_os = "linux")]
+        {
+            std::fs::metadata("/proc/self/exe")
+                .ok()
+                .map(|m| m.len() / (1024 * 1024))
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            None
+        }
+    }
+
+    /// Read VmRSS from /proc/self/status (Linux only).
+    fn read_vmrss() -> Option<u64> {
+        #[cfg(target_os = "linux")]
+        {
+            let status = std::fs::read_to_string("/proc/self/status").ok()?;
+            for line in status.lines() {
+                if let Some(rest) = line.strip_prefix("VmRSS:") {
+                    let trimmed = rest.trim();
+                    // Format: "12345 kB"
+                    let kb_str = trimmed.split_whitespace().next()?;
+                    let kb: u64 = kb_str.parse().ok()?;
+                    return Some(kb / 1024);
+                }
+            }
+            None
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            None
+        }
+    }
+
+    fn format_uptime(&self) -> String {
+        if self.uptime_secs < 60 {
+            format!("{}s", self.uptime_secs)
+        } else if self.uptime_secs < 3600 {
+            format!("{}m", self.uptime_secs / 60)
+        } else if self.uptime_secs < 86400 {
+            format!("{}h", self.uptime_secs / 3600)
+        } else {
+            format!("{}d", self.uptime_secs / 86400)
+        }
+    }
+}
+
 /// Render the "bragging" footer with NORA stats (demo builds only)
 #[cfg(feature = "demo")]
-pub fn render_bragging_footer(lang: Lang) -> String {
+pub fn render_bragging_footer(lang: Lang, stats: &BraggingStats) -> String {
     let t = get_translations(lang);
     format!(
         r##"
     <div class="mt-8 bg-gradient-to-r from-slate-800 to-slate-900 rounded-lg border border-slate-700 p-6">
         <div class="text-center mb-4">
-            <span class="text-slate-400 text-sm uppercase tracking-wider">{}</span>
+            <span class="text-slate-400 text-sm uppercase tracking-wider">{built_for_speed}</span>
         </div>
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 text-center">
             <div class="p-3">
-                <div class="text-2xl font-bold text-blue-400">32 MB</div>
-                <div class="text-xs text-slate-500 mt-1">{}</div>
+                <div class="text-2xl font-bold text-blue-400">{binary_size} MB</div>
+                <div class="text-xs text-slate-500 mt-1">{docker_image}</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-green-400">&lt;1s</div>
-                <div class="text-xs text-slate-500 mt-1">{}</div>
+                <div class="text-2xl font-bold text-green-400">{uptime}</div>
+                <div class="text-xs text-slate-500 mt-1">{cold_start}</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-purple-400">~30 MB</div>
-                <div class="text-xs text-slate-500 mt-1">{}</div>
+                <div class="text-2xl font-bold text-purple-400">~{memory} MB</div>
+                <div class="text-xs text-slate-500 mt-1">{mem_label}</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-yellow-400">13</div>
-                <div class="text-xs text-slate-500 mt-1">{}</div>
+                <div class="text-2xl font-bold text-yellow-400">{reg_count}</div>
+                <div class="text-xs text-slate-500 mt-1">{reg_label}</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-pink-400">{}</div>
+                <div class="text-2xl font-bold text-pink-400">{multi_arch}</div>
                 <div class="text-xs text-slate-500 mt-1">amd64 / arm64</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-cyan-400">{}</div>
+                <div class="text-2xl font-bold text-cyan-400">{zero_config}</div>
                 <div class="text-xs text-slate-500 mt-1">Config</div>
             </div>
         </div>
         <div class="text-center mt-4">
-            <span class="text-slate-500 text-xs">{}</span>
+            <span class="text-slate-500 text-xs">{tagline}</span>
         </div>
     </div>
     "##,
-        t.built_for_speed,
-        t.docker_image,
-        t.cold_start,
-        t.memory,
-        t.registries_count,
-        t.multi_arch,
-        t.zero_config,
-        t.tagline
+        built_for_speed = t.built_for_speed,
+        binary_size = stats.binary_size_mb,
+        docker_image = t.docker_image,
+        uptime = stats.format_uptime(),
+        cold_start = t.cold_start,
+        memory = stats.memory_mb,
+        mem_label = t.memory,
+        reg_count = stats.registry_count,
+        reg_label = t.registries_count,
+        multi_arch = t.multi_arch,
+        zero_config = t.zero_config,
+        tagline = t.tagline,
     )
 }
 
@@ -806,5 +886,56 @@ pub fn format_timestamp(ts: u64) -> String {
     } else {
         let months = diff / 2592000;
         format!("{} month{} ago", months, if months == 1 { "" } else { "s" })
+    }
+}
+
+/// Format a future Unix timestamp as relative time ("in 28d") or past ("Expired").
+/// Returns `(display_text, is_expired)`.
+pub fn format_expiry(ts: u64) -> (String, bool) {
+    if ts == 0 {
+        return ("N/A".to_string(), false);
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    if now >= ts {
+        // Expired
+        let diff = now - ts;
+        if diff < 3600 {
+            let mins = diff / 60;
+            return (
+                format!(
+                    "expired {} min{} ago",
+                    mins.max(1),
+                    if mins <= 1 { "" } else { "s" }
+                ),
+                true,
+            );
+        } else if diff < 86400 {
+            let hours = diff / 3600;
+            return (format!("expired {}h ago", hours), true);
+        } else {
+            let days = diff / 86400;
+            return (format!("expired {}d ago", days), true);
+        }
+    }
+
+    // Future
+    let diff = ts - now;
+    if diff < 3600 {
+        let mins = diff / 60;
+        (
+            format!("in {} min{}", mins.max(1), if mins <= 1 { "" } else { "s" }),
+            false,
+        )
+    } else if diff < 86400 {
+        let hours = diff / 3600;
+        (format!("in {}h", hours), false)
+    } else {
+        let days = diff / 86400;
+        (format!("in {}d", days), false)
     }
 }

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -124,7 +124,10 @@ pub fn render_dashboard(data: &DashboardResponse, lang: Lang, auth_enabled: bool
 
     // Render bragging footer (demo builds only)
     #[cfg(feature = "demo")]
-    let bragging_footer = render_bragging_footer(lang);
+    let bragging_footer = {
+        let stats = BraggingStats::collect(data.registry_stats.len(), data.uptime_seconds);
+        render_bragging_footer(lang, &stats)
+    };
     #[cfg(not(feature = "demo"))]
     let bragging_footer = String::new();
 
@@ -970,7 +973,15 @@ pub fn render_token_list_fragment(tokens: &[TokenListEntry], lang: Lang) -> Stri
         );
     }
 
-    let rows: String = tokens
+    // Sort: active tokens first, expired last
+    let mut sorted_tokens: Vec<&TokenListEntry> = tokens.iter().collect();
+    let now_ts = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    sorted_tokens.sort_by_key(|t| if t.expires_at <= now_ts { 1u8 } else { 0u8 });
+
+    let rows: String = sorted_tokens
         .iter()
         .map(|token| {
             let role_badge = render_role_badge(&token.role);
@@ -978,39 +989,50 @@ pub fn render_token_list_fragment(tokens: &[TokenListEntry], lang: Lang) -> Stri
                 .description
                 .as_deref()
                 .unwrap_or("-");
-            let expires = format_timestamp(token.expires_at);
+            let (expires_text, is_expired) = format_expiry(token.expires_at);
+            let expires_html = if is_expired {
+                format!(r##"<span class="px-2 py-0.5 text-xs font-medium text-red-400 bg-red-900/30 border border-red-800 rounded">{}</span>"##, expires_text)
+            } else {
+                format!(r##"<span class="text-slate-400">{}</span>"##, expires_text)
+            };
             let last_used = token
                 .last_used
                 .map(format_timestamp)
                 .unwrap_or_else(|| t.token_never_used.to_string());
+            let row_class = if is_expired {
+                "border-b border-slate-700/50 opacity-60"
+            } else {
+                "border-b border-slate-700/50"
+            };
 
             format!(
                 r##"
-                <tr class="border-b border-slate-700/50">
-                    <td class="px-6 py-4 text-slate-300">{}</td>
-                    <td class="px-6 py-4 text-slate-400">{}</td>
-                    <td class="px-6 py-4">{}</td>
-                    <td class="px-6 py-4 text-slate-400 text-sm">{}</td>
-                    <td class="px-6 py-4 text-slate-500 text-sm">{}</td>
+                <tr class="{row_class}">
+                    <td class="px-6 py-4 text-slate-300">{desc}</td>
+                    <td class="px-6 py-4 text-slate-400">{user}</td>
+                    <td class="px-6 py-4">{role}</td>
+                    <td class="px-6 py-4 text-sm">{expires}</td>
+                    <td class="px-6 py-4 text-slate-500 text-sm">{last_used}</td>
                     <td class="px-6 py-4">
-                        <button hx-post="/api/ui/tokens/{}/revoke"
-                                hx-confirm="{}"
+                        <button hx-post="/api/ui/tokens/{file_id}/revoke"
+                                hx-confirm="{confirm}"
                                 hx-target="#token-list"
                                 hx-swap="innerHTML"
                                 class="px-3 py-1 text-xs font-medium text-red-400 hover:text-red-300 bg-red-900/20 hover:bg-red-900/40 border border-red-800 rounded transition-colors">
-                            {}
+                            {revoke}
                         </button>
                     </td>
                 </tr>
             "##,
-                html_escape(description),
-                html_escape(&token.user),
-                role_badge,
-                expires,
-                last_used,
-                html_escape(&token.file_id),
-                html_escape(t.token_revoke_confirm),
-                t.token_revoke,
+                row_class = row_class,
+                desc = html_escape(description),
+                user = html_escape(&token.user),
+                role = role_badge,
+                expires = expires_html,
+                last_used = last_used,
+                file_id = html_escape(&token.file_id),
+                confirm = html_escape(t.token_revoke_confirm),
+                revoke = t.token_revoke,
             )
         })
         .collect();


### PR DESCRIPTION
## Summary

- **Min-release-age filter** (#132) — block packages younger than N days/hours/weeks. Supply chain protection via `NORA_CURATION_MIN_RELEASE_AGE=7d`. Supports `Nd`, `Nh`, `Nw` durations. Unknown publish dates → skip (safe default)
- **Token RBAC polish** (#124) — expired tokens show red badge, sorted to bottom with `opacity-60`. `format_expiry()` correctly renders future ("in 28d") and past ("expired 3d ago") dates. `#[non_exhaustive]` on Role enum
- **Dynamic stats footer** — demo builds read `/proc/self/exe` size and VmRSS instead of hardcoded values. Behind `#[cfg(feature = "demo")]`
- 850 tests (up from 821), 0 clippy warnings

Closes #124, closes #132

## Test plan
- [x] `cargo test --package nora-registry` — 850 pass
- [x] `cargo clippy` — 0 warnings
- [x] `cargo build --features demo` — dynamic footer compiles
- [x] `scripts/coherence-check.sh` — 0 errors, 0 warnings
- [ ] CI green