### PR TITLE
fix: require auth for Docker /v2/ endpoint per V2 spec

### DIFF
--- a/nora-registry/src/auth.rs
+++ b/nora-registry/src/auth.rs
@@ -72,14 +72,19 @@ fn is_public_path(path: &str) -> bool {
         "/" | "/health"
             | "/ready"
             | "/metrics"
-            | "/v2/"
-            | "/v2"
             | "/api/tokens"
             | "/api/tokens/list"
             | "/api/tokens/revoke"
     ) || path.starts_with("/ui")
         || path.starts_with("/api-docs")
         || path.starts_with("/api/ui")
+}
+
+/// Check if path is a Docker V2 auth challenge endpoint.
+/// Per Docker Registry V2 spec, /v2/ must return 401 with WWW-Authenticate
+/// header when auth is enabled, so Docker clients know to send credentials.
+fn is_docker_auth_challenge_path(path: &str) -> bool {
+    matches!(path, "/v2/" | "/v2")
 }
 
 /// Auth middleware - supports Basic auth and Bearer tokens
@@ -99,12 +104,19 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    // Allow anonymous read if configured
+    // Docker V2 auth challenge: /v2/ must NOT bypass auth via anonymous_read.
+    // Per Docker Registry V2 spec, unauthenticated GET /v2/ must return 401
+    // with WWW-Authenticate header, so Docker clients send credentials on
+    // subsequent requests. If /v2/ returns 200 without auth, Docker assumes
+    // the registry is anonymous and never sends Authorization headers.
+    let is_docker_challenge = is_docker_auth_challenge_path(request.uri().path());
+
+    // Allow anonymous read if configured (but not for Docker /v2/ endpoint)
     let is_read_method = matches!(
         *request.method(),
         axum::http::Method::GET | axum::http::Method::HEAD
     );
-    if state.config.auth.anonymous_read && is_read_method {
+    if state.config.auth.anonymous_read && is_read_method && !is_docker_challenge {
         // Read requests allowed without auth
         return next.run(request).await;
     }
@@ -455,8 +467,6 @@ mod tests {
         assert!(is_public_path("/health"));
         assert!(is_public_path("/ready"));
         assert!(is_public_path("/metrics"));
-        assert!(is_public_path("/v2/"));
-        assert!(is_public_path("/v2"));
         assert!(is_public_path("/ui"));
         assert!(is_public_path("/ui/dashboard"));
         assert!(is_public_path("/api-docs"));
@@ -465,6 +475,10 @@ mod tests {
         assert!(is_public_path("/api/tokens"));
         assert!(is_public_path("/api/tokens/list"));
         assert!(is_public_path("/api/tokens/revoke"));
+
+        // Docker /v2/ is NOT public — requires auth challenge per V2 spec
+        assert!(!is_public_path("/v2/"));
+        assert!(!is_public_path("/v2"));
 
         // Token UI pages are NOT public (require auth)
         assert!(!is_public_path("/ui/tokens"));
@@ -500,9 +514,17 @@ mod tests {
     }
 
     #[test]
-    fn test_is_public_path_v2() {
-        assert!(is_public_path("/v2/"));
-        assert!(is_public_path("/v2"));
+    fn test_v2_is_not_public_path() {
+        // Docker /v2/ must NOT be public — it needs auth challenge per V2 spec
+        assert!(!is_public_path("/v2/"));
+        assert!(!is_public_path("/v2"));
+        // But it IS a docker auth challenge path
+        assert!(is_docker_auth_challenge_path("/v2/"));
+        assert!(is_docker_auth_challenge_path("/v2"));
+        // Sub-paths are neither public nor docker challenge
+        assert!(!is_docker_auth_challenge_path(
+            "/v2/alpine/manifests/latest"
+        ));
     }
 
     #[test]
@@ -619,6 +641,63 @@ mod integration_tests {
         assert_eq!(response.status(), StatusCode::OK);
         let response = send(&ctx.app, Method::GET, "/ready", "").await;
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Docker Registry V2 spec: GET /v2/ without credentials must return 401
+    /// with WWW-Authenticate header when auth is enabled (issue #219)
+    #[tokio::test]
+    async fn test_docker_v2_requires_auth_when_enabled() {
+        let ctx = create_test_context_with_auth(&[("admin", "secret")]);
+
+        // Without credentials: must return 401 + WWW-Authenticate
+        let response = send(&ctx.app, Method::GET, "/v2/", "").await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response.headers().contains_key("www-authenticate"));
+
+        // With valid credentials: must return 200
+        let header_val = format!("Basic {}", STANDARD.encode("admin:secret"));
+        let response = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/v2/",
+            vec![("authorization", &header_val)],
+            "",
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// Docker /v2/ must NOT pass through anonymous_read bypass.
+    /// Even with anonymous_read=true, /v2/ must require auth so Docker
+    /// clients know to send credentials on subsequent push/pull requests.
+    #[tokio::test]
+    async fn test_docker_v2_ignores_anonymous_read() {
+        let ctx = create_test_context_with_anonymous_read(&[("admin", "secret")]);
+
+        // /v2/ without auth: must still return 401 even with anonymous_read=true
+        let response = send(&ctx.app, Method::GET, "/v2/", "").await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert!(response.headers().contains_key("www-authenticate"));
+
+        // Other read endpoints should still work anonymously
+        let header_val = format!("Basic {}", STANDARD.encode("admin:secret"));
+        let response = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/test.txt",
+            vec![("authorization", &header_val)],
+            b"data".to_vec(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let response = send(&ctx.app, Method::GET, "/raw/test.txt", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// When auth is disabled, /v2/ should pass through normally
+    #[tokio::test]
+    async fn test_docker_v2_passes_when_auth_disabled() {
+        let ctx = create_test_context();
         let response = send(&ctx.app, Method::GET, "/v2/", "").await;
         assert_eq!(response.status(), StatusCode::OK);
     }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -137,8 +137,15 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/v2/{ns}/{name}/tags/list", get(list_tags_ns))
 }
 
-async fn check() -> (StatusCode, Json<Value>) {
-    (StatusCode::OK, Json(json!({})))
+async fn check() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        [(
+            HeaderName::from_static("docker-distribution-api-version"),
+            "registry/2.0",
+        )],
+        Json(json!({})),
+    )
 }
 
 /// List all repositories in the registry


### PR DESCRIPTION
## Summary

Fixes #219 — Docker `login` succeeded but `pull`/`push` failed with "unauthorized: authentication required" when auth was enabled.

**Root cause**: The `/v2/` endpoint was listed in `is_public_path()`, returning `200 OK` without authentication. Per the [Docker Registry V2 specification](https://docs.docker.com/registry/spec/auth/), `/v2/` must return `401 Unauthorized` with `WWW-Authenticate` header when auth is enabled, so Docker clients know to send credentials on subsequent requests. When `/v2/` returned `200` without auth, Docker assumed the registry was anonymous and never sent `Authorization` headers on `pull`/`push`.

**Changes:**
- Remove `/v2/` and `/v2` from `is_public_path()` in `auth.rs`
- Add `is_docker_auth_challenge_path()` to exclude `/v2/` from `anonymous_read` bypass — even with `NORA_AUTH_ANONYMOUS_READ=true`, `/v2/` must require auth so Docker clients send credentials
- Add `Docker-Distribution-API-Version: registry/2.0` header to `/v2/` response per spec
- Replace incorrect `test_is_public_path_v2` with correct auth challenge tests
- Add 3 integration tests covering: auth enabled, anonymous_read, auth disabled

## Verification

| Test | Before | After |
|------|--------|-------|
| `GET /v2/` no auth | 200 OK (bug) | **401 + `WWW-Authenticate: Basic realm="Nora"`** |
| `GET /v2/` wrong creds | 200 OK (bug) | **401** |
| `GET /v2/` correct creds | 200 OK | **200 OK + `Docker-Distribution-API-Version: registry/2.0`** |
| `GET /health` no auth | 200 OK | **200 OK** (unchanged) |

**853 tests pass** (851 → 853, +2 new tests).

## Test plan

- [x] `cargo test` — 853 passed, 0 failed
- [x] Built Docker image, deployed with `NORA_AUTH_ENABLED=true`
- [x] Verified `GET /v2/` returns 401 without credentials
- [x] Verified `GET /v2/` returns 200 with correct Basic auth
- [x] Verified `WWW-Authenticate` header present in 401 response
- [x] Verified `Docker-Distribution-API-Version` header present in 200 response
- [x] Verified `/health`, `/ready` still work without auth
- [x] Verify `docker login` + `docker pull`/`push` E2E with real Docker daemon