### PR TITLE
chore: bump version to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -18,7 +18,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.7.2",
+        version = "0.7.3",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
## Summary
- Cargo.toml workspace version: 0.7.2 → 0.7.3
- OpenAPI info version: 0.7.2 → 0.7.3
- Cargo.lock regenerated

Post-release version bump so `/health` and `/api-docs` report correct version.