### PR TITLE
fix: version consistency gate in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,17 @@ jobs:
           echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
 
+      - name: Verify Cargo.toml version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+          echo "Tag version:   ${TAG_VERSION}"
+          echo "Cargo version: ${CARGO_VERSION}"
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Version mismatch! Tag ${GITHUB_REF_NAME} but Cargo.toml has ${CARGO_VERSION}. Bump version before tagging."
+            exit 1
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@
 
 CARGO := cargo
 
-.PHONY: check test build release fmt clippy coherence lock-audit
+.PHONY: check test build release fmt clippy coherence lock-audit version-check
 
-check: fmt clippy test coherence lock-audit
+check: version-check fmt clippy test coherence lock-audit
 	@echo ""
 	@echo "=== All checks passed ==="
 
@@ -30,11 +30,14 @@ lock-audit:
 build:
 	$(CARGO) build --release
 
+version-check:
+	@scripts/pre-commit-check.sh
+
 release:
 ifndef VERSION
-	$(error VERSION is required. Usage: make release VERSION=0.6.3)
+	$(error VERSION is required. Usage: make release VERSION=0.7.3)
 endif
-	@echo "=== Release v$(VERSION) ==="
+	@scripts/pre-commit-check.sh "v$(VERSION)"
 	$(MAKE) check
 	git tag -a "v$(VERSION)" -m "Release v$(VERSION)"
 	@echo "Ready to push: git push origin v$(VERSION)"

--- a/scripts/pre-commit-check.sh
+++ b/scripts/pre-commit-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Pre-commit / pre-release quality gate for NORA
+# Validates version consistency across all version sources.
+#
+# Usage:
+#   ./scripts/pre-commit-check.sh          — check Cargo.toml vs OpenAPI
+#   ./scripts/pre-commit-check.sh v0.7.3   — also check against a tag
+
+set -euo pipefail
+
+ERRORS=0
+CARGO_VERSION=$(grep -m1 '^version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+
+echo "=== NORA pre-commit checks ==="
+echo "Cargo.toml version: ${CARGO_VERSION}"
+
+# ── Check: OpenAPI version matches Cargo.toml ────────────────────────────────
+OPENAPI_FILE="nora-registry/src/openapi.rs"
+if [ -f "$OPENAPI_FILE" ]; then
+    OPENAPI_VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' "$OPENAPI_FILE" | head -1)
+    if [ -n "$OPENAPI_VERSION" ] && [ "$OPENAPI_VERSION" != "$CARGO_VERSION" ]; then
+        echo "FAIL: OpenAPI version (${OPENAPI_VERSION}) != Cargo.toml (${CARGO_VERSION})"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "OK:   OpenAPI version matches"
+    fi
+fi
+
+# ── Check: tag version matches Cargo.toml (when tag is provided) ─────────────
+TAG="${1:-}"
+if [ -n "$TAG" ]; then
+    TAG_VERSION="${TAG#v}"
+    if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+        echo "FAIL: Tag version (${TAG_VERSION}) != Cargo.toml (${CARGO_VERSION})"
+        echo "      Bump version in Cargo.toml before tagging!"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "OK:   Tag version matches Cargo.toml"
+    fi
+fi
+
+# ── Check: Cargo.lock is consistent ──────────────────────────────────────────
+if [ -f "Cargo.lock" ]; then
+    LOCK_VERSION=$(grep -A1 'name = "nora-registry"' Cargo.lock | grep -oP 'version = "\K[^"]+' | head -1)
+    if [ -n "$LOCK_VERSION" ] && [ "$LOCK_VERSION" != "$CARGO_VERSION" ]; then
+        echo "FAIL: Cargo.lock nora-registry version (${LOCK_VERSION}) != Cargo.toml (${CARGO_VERSION})"
+        echo "      Run: cargo update --workspace"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo "OK:   Cargo.lock version matches"
+    fi
+fi
+
+echo ""
+if [ "$ERRORS" -gt 0 ]; then
+    echo "=== ${ERRORS} version check(s) FAILED ==="
+    exit 1
+else
+    echo "=== All version checks passed ==="
+fi


### PR DESCRIPTION
## Summary
- Add version validation step to `release.yml` — the workflow now fails fast if the git tag doesn't match `Cargo.toml` version, preventing binaries from reporting a stale version
- Add `scripts/pre-commit-check.sh` — validates consistency between `Cargo.toml`, OpenAPI spec, and `Cargo.lock` versions
- Add `version-check` target to Makefile, integrated into `make check` and `make release`

Fixes #223

## Test plan
- [ ] `make version-check` passes on current main
- [ ] `make release VERSION=X.Y.Z` fails if Cargo.toml has a different version
- [ ] Release workflow rejects tag push when versions don't match