### PR TITLE
feat: v0.8 security batch — token auth fix, rate limiting, hash pin store

### DIFF
--- a/nora-registry/src/auth.rs
+++ b/nora-registry/src/auth.rs
@@ -3,18 +3,80 @@
 
 use axum::{
     body::Body,
-    extract::State,
+    extract::{ConnectInfo, State},
     http::{header, Request, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::collections::HashMap;
+use std::net::{IpAddr, SocketAddr};
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::tokens::Role;
 use crate::AppState;
+
+/// Tracks failed authentication attempts per IP for brute-force protection.
+///
+/// After `max_failures` consecutive failures, the IP is locked out with
+/// exponential backoff: 2^(failures - max_failures) seconds, capped at 15 minutes.
+pub struct AuthFailureTracker {
+    /// IP -> (consecutive failures, last failure time)
+    entries: parking_lot::Mutex<HashMap<IpAddr, (u32, Instant)>>,
+    /// Number of failures before lockout kicks in (default: 5)
+    max_failures: u32,
+    /// Maximum lockout duration in seconds (default: 900 = 15 minutes)
+    max_lockout_secs: u64,
+}
+
+impl AuthFailureTracker {
+    pub fn new(max_failures: u32, max_lockout_secs: u64) -> Self {
+        Self {
+            entries: parking_lot::Mutex::new(HashMap::new()),
+            max_failures,
+            max_lockout_secs,
+        }
+    }
+
+    /// Check if IP is currently locked out. Returns remaining lockout seconds if blocked.
+    pub fn check_blocked(&self, ip: &IpAddr) -> Option<u64> {
+        let entries = self.entries.lock();
+        let (failures, last_failure) = entries.get(ip)?;
+        if *failures < self.max_failures {
+            return None;
+        }
+        let exponent = (*failures - self.max_failures).min(20);
+        let lockout_secs = (1u64 << exponent).min(self.max_lockout_secs);
+        let elapsed = last_failure.elapsed().as_secs();
+        if elapsed < lockout_secs {
+            Some(lockout_secs - elapsed)
+        } else {
+            None
+        }
+    }
+
+    /// Record a failed auth attempt for an IP.
+    pub fn record_failure(&self, ip: IpAddr) {
+        let mut entries = self.entries.lock();
+        let entry = entries.entry(ip).or_insert_with(|| (0, Instant::now()));
+        entry.0 += 1;
+        entry.1 = Instant::now();
+    }
+
+    /// Clear failure count on successful auth.
+    pub fn record_success(&self, ip: &IpAddr) {
+        let mut entries = self.entries.lock();
+        entries.remove(ip);
+    }
+
+    /// Remove entries older than max_lockout_secs (call periodically).
+    pub fn cleanup(&self) {
+        let mut entries = self.entries.lock();
+        entries.retain(|_, (_, last)| last.elapsed().as_secs() < self.max_lockout_secs * 2);
+    }
+}
 
 /// Htpasswd-based authentication
 #[derive(Clone)]
@@ -87,6 +149,33 @@ fn is_docker_auth_challenge_path(path: &str) -> bool {
     matches!(path, "/v2/" | "/v2")
 }
 
+/// Extract client IP from request (X-Forwarded-For, X-Real-IP, or ConnectInfo).
+fn extract_client_ip(request: &Request<Body>) -> Option<IpAddr> {
+    // Try X-Forwarded-For first (first IP in chain is the client)
+    if let Some(xff) = request.headers().get("x-forwarded-for") {
+        if let Ok(s) = xff.to_str() {
+            if let Some(first) = s.split(',').next() {
+                if let Ok(ip) = first.trim().parse::<IpAddr>() {
+                    return Some(ip);
+                }
+            }
+        }
+    }
+    // Try X-Real-IP
+    if let Some(xri) = request.headers().get("x-real-ip") {
+        if let Ok(s) = xri.to_str() {
+            if let Ok(ip) = s.trim().parse::<IpAddr>() {
+                return Some(ip);
+            }
+        }
+    }
+    // Fall back to ConnectInfo
+    request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip())
+}
+
 /// Auth middleware - supports Basic auth and Bearer tokens
 pub async fn auth_middleware(
     State(state): State<Arc<AppState>>,
@@ -109,20 +198,47 @@ pub async fn auth_middleware(
     // with WWW-Authenticate header, so Docker clients send credentials on
     // subsequent requests. If /v2/ returns 200 without auth, Docker assumes
     // the registry is anonymous and never sends Authorization headers.
-    let is_docker_challenge = is_docker_auth_challenge_path(request.uri().path());
+    let path = request.uri().path();
+    let is_docker_challenge = is_docker_auth_challenge_path(path);
 
-    // Allow anonymous read if configured (but not for Docker /v2/ endpoint)
+    // Token management always requires auth, even with anonymous_read
+    let is_token_management = path.starts_with("/ui/tokens") || path.starts_with("/api/ui/tokens");
+
+    // Allow anonymous read if configured (but not for Docker /v2/ or token management)
     let is_read_method = matches!(
         *request.method(),
         axum::http::Method::GET | axum::http::Method::HEAD
     );
-    if state.config.auth.anonymous_read && is_read_method && !is_docker_challenge {
+    if state.config.auth.anonymous_read
+        && is_read_method
+        && !is_docker_challenge
+        && !is_token_management
+    {
         // Read requests allowed without auth
         return next.run(request).await;
     }
 
     // Compute realm from public_url for WWW-Authenticate header
     let realm = state.config.server.public_url.as_deref().unwrap_or("Nora");
+
+    // Check if client IP is blocked due to too many failed attempts
+    let client_ip = extract_client_ip(&request);
+    if let Some(ip) = client_ip {
+        if let Some(retry_after) = state.auth_failures.check_blocked(&ip) {
+            return (
+                StatusCode::TOO_MANY_REQUESTS,
+                [
+                    (header::RETRY_AFTER, retry_after.to_string()),
+                    (header::CONTENT_TYPE, "application/json".to_string()),
+                ],
+                format!(
+                    r#"{{"error":"Too many failed attempts. Retry after {} seconds."}}"#,
+                    retry_after
+                ),
+            )
+                .into_response();
+        }
+    }
 
     // Extract Authorization header
     let auth_header = request
@@ -140,6 +256,9 @@ pub async fn auth_middleware(
         if let Some(ref token_store) = state.tokens {
             match token_store.verify_token(token) {
                 Ok((_user, role)) => {
+                    if let Some(ip) = client_ip {
+                        state.auth_failures.record_success(&ip);
+                    }
                     let method = request.method().clone();
                     if (method == axum::http::Method::PUT
                         || method == axum::http::Method::POST
@@ -151,7 +270,12 @@ pub async fn auth_middleware(
                     }
                     return next.run(request).await;
                 }
-                Err(_) => return unauthorized_response("Invalid or expired token", realm),
+                Err(_) => {
+                    if let Some(ip) = client_ip {
+                        state.auth_failures.record_failure(ip);
+                    }
+                    return unauthorized_response("Invalid or expired token", realm);
+                }
             }
         } else {
             return unauthorized_response("Token authentication not configured", realm);
@@ -181,10 +305,16 @@ pub async fn auth_middleware(
 
     // Verify credentials
     if !auth.authenticate(username, password) {
+        if let Some(ip) = client_ip {
+            state.auth_failures.record_failure(ip);
+        }
         return unauthorized_response("Invalid username or password", realm);
     }
 
-    // Auth successful
+    // Auth successful — clear failure counter
+    if let Some(ip) = client_ip {
+        state.auth_failures.record_success(&ip);
+    }
     next.run(request).await
 }
 
@@ -620,6 +750,97 @@ mod tests {
         assert!(!is_public_path("/api/ui/tokens/list"));
         assert!(!is_public_path("/api/ui/tokens/abcd1234abcd1234/revoke"));
     }
+
+    #[test]
+    fn test_auth_failure_tracker_allows_under_threshold() {
+        let tracker = AuthFailureTracker::new(5, 900);
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        for _ in 0..4 {
+            tracker.record_failure(ip);
+        }
+        assert!(tracker.check_blocked(&ip).is_none());
+    }
+
+    #[test]
+    fn test_auth_failure_tracker_blocks_at_threshold() {
+        let tracker = AuthFailureTracker::new(5, 900);
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        for _ in 0..5 {
+            tracker.record_failure(ip);
+        }
+        assert!(tracker.check_blocked(&ip).is_some());
+    }
+
+    #[test]
+    fn test_auth_failure_tracker_success_clears() {
+        let tracker = AuthFailureTracker::new(5, 900);
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        for _ in 0..10 {
+            tracker.record_failure(ip);
+        }
+        assert!(tracker.check_blocked(&ip).is_some());
+        tracker.record_success(&ip);
+        assert!(tracker.check_blocked(&ip).is_none());
+    }
+
+    #[test]
+    fn test_auth_failure_tracker_independent_ips() {
+        let tracker = AuthFailureTracker::new(3, 900);
+        let ip1: IpAddr = "10.0.0.1".parse().unwrap();
+        let ip2: IpAddr = "10.0.0.2".parse().unwrap();
+        for _ in 0..3 {
+            tracker.record_failure(ip1);
+        }
+        assert!(tracker.check_blocked(&ip1).is_some());
+        assert!(tracker.check_blocked(&ip2).is_none());
+    }
+
+    #[test]
+    fn test_auth_failure_tracker_cleanup() {
+        let tracker = AuthFailureTracker::new(3, 1); // 1 sec max lockout
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        for _ in 0..5 {
+            tracker.record_failure(ip);
+        }
+        // Cleanup should remove entries older than 2x max_lockout_secs
+        std::thread::sleep(std::time::Duration::from_secs(3));
+        tracker.cleanup();
+        assert!(tracker.check_blocked(&ip).is_none());
+    }
+
+    #[test]
+    fn test_auth_failure_tracker_exponential_backoff() {
+        let tracker = AuthFailureTracker::new(5, 900);
+        let ip: IpAddr = "10.0.0.1".parse().unwrap();
+        // 5 failures = threshold, lockout = 2^0 = 1 sec
+        for _ in 0..5 {
+            tracker.record_failure(ip);
+        }
+        let retry1 = tracker.check_blocked(&ip).unwrap();
+        assert!(
+            retry1 <= 1,
+            "first lockout should be ~1 sec, got {}",
+            retry1
+        );
+
+        // 6 failures = 2^1 = 2 sec
+        tracker.record_failure(ip);
+        let retry2 = tracker.check_blocked(&ip).unwrap();
+        assert!(
+            retry2 <= 2,
+            "second lockout should be ~2 sec, got {}",
+            retry2
+        );
+
+        // 7 failures = 2^2 = 4 sec
+        tracker.record_failure(ip);
+        let retry3 = tracker.check_blocked(&ip).unwrap();
+        assert!(
+            retry3 <= 4,
+            "third lockout should be ~4 sec, got {}",
+            retry3
+        );
+    }
 }
 
 #[cfg(test)]
@@ -762,6 +983,36 @@ mod integration_tests {
         // Write without auth should fail
         let response = send(&ctx.app, Method::PUT, "/raw/test2.txt", b"data".to_vec()).await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Token management must require auth even with anonymous_read=true (#221)
+    #[tokio::test]
+    async fn test_token_ui_requires_auth_with_anonymous_read() {
+        let ctx = create_test_context_with_anonymous_read(&[("admin", "secret")]);
+
+        // GET /ui/tokens without auth must return 401 even with anonymous_read
+        let response = send(&ctx.app, Method::GET, "/ui/tokens", "").await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        // GET /api/ui/tokens/list without auth must also return 401
+        let response = send(&ctx.app, Method::GET, "/api/ui/tokens/list", "").await;
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+        // With auth, token UI should work
+        let header_val = format!("Basic {}", STANDARD.encode("admin:secret"));
+        let response = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/ui/tokens",
+            vec![("authorization", &header_val)],
+            "",
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Other read endpoints should still work anonymously
+        let response = send(&ctx.app, Method::GET, "/health", "").await;
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -1,0 +1,294 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+
+//! Hash Pin Store — immutable hash verification for stored artifacts.
+//!
+//! Records SHA-256 hashes on every `Storage::put()` and verifies them on
+//! `Storage::get()`. Detects tampering at the storage layer (e.g. direct
+//! filesystem modification bypassing NORA).
+//!
+//! Persistence: append-only NDJSON file (`.nora-pins.ndjson`) compacted on
+//! startup. Each line: `{"k":"storage/key","h":"sha256hex"}`. An empty `h`
+//! marks a deletion (tombstone).
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+use std::path::PathBuf;
+use tracing::warn;
+
+#[derive(Serialize, Deserialize)]
+struct PinEntry {
+    k: String,
+    h: String,
+}
+
+pub struct HashPinStore {
+    pins: RwLock<HashMap<String, String>>,
+    path: PathBuf,
+}
+
+impl HashPinStore {
+    /// Load (or create) a pin store backed by the given NDJSON file.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        let path = path.into();
+        let mut pins = HashMap::new();
+
+        // Replay NDJSON log — last entry per key wins
+        if let Ok(file) = std::fs::File::open(&path) {
+            let reader = std::io::BufReader::new(file);
+            for line in reader.lines().map_while(Result::ok) {
+                if let Ok(entry) = serde_json::from_str::<PinEntry>(&line) {
+                    if entry.h.is_empty() {
+                        pins.remove(&entry.k);
+                    } else {
+                        pins.insert(entry.k, entry.h);
+                    }
+                }
+            }
+        }
+
+        let store = Self {
+            pins: RwLock::new(pins),
+            path,
+        };
+
+        // Compact on startup to remove tombstones and duplicates
+        store.compact();
+        store
+    }
+
+    /// Compute SHA-256 hex digest.
+    fn sha256_hex(data: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        hex::encode(hasher.finalize())
+    }
+
+    /// Record the hash for a storage key. Called on every `put()`.
+    ///
+    /// If the key is new, the hash is pinned. If the key exists with the same
+    /// hash, this is a no-op. If the hash changed (normal metadata update),
+    /// the pin is updated.
+    pub fn record(&self, key: &str, data: &[u8]) {
+        let hash = Self::sha256_hex(data);
+        let mut pins = self.pins.write();
+        let should_write = pins.get(key).is_none_or(|existing| *existing != hash);
+        if should_write {
+            pins.insert(key.to_string(), hash.clone());
+            self.append(key, &hash);
+        }
+    }
+
+    /// Verify data integrity against pinned hash. Called on every `get()`.
+    ///
+    /// Returns `true` if the hash matches or no pin exists for this key.
+    /// Returns `false` and logs a warning if tampering is detected.
+    pub fn verify(&self, key: &str, data: &[u8]) -> bool {
+        let pins = self.pins.read();
+        if let Some(expected) = pins.get(key) {
+            let actual = Self::sha256_hex(data);
+            if *expected != actual {
+                warn!(
+                    key = key,
+                    expected = expected.as_str(),
+                    actual = actual.as_str(),
+                    "INTEGRITY VIOLATION: stored artifact hash mismatch"
+                );
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Remove a pin entry. Called on `delete()`.
+    pub fn remove(&self, key: &str) {
+        let mut pins = self.pins.write();
+        if pins.remove(key).is_some() {
+            self.append(key, "");
+        }
+    }
+
+    /// Number of pinned entries.
+    pub fn len(&self) -> usize {
+        self.pins.read().len()
+    }
+
+    /// Compact the NDJSON file: rewrite with only live entries.
+    fn compact(&self) {
+        let pins = self.pins.read();
+        if pins.is_empty() {
+            // Remove empty file
+            let _ = std::fs::remove_file(&self.path);
+            return;
+        }
+
+        let temp_path = self.path.with_extension("ndjson.tmp");
+        if let Ok(mut file) = std::fs::File::create(&temp_path) {
+            for (key, hash) in pins.iter() {
+                let entry = PinEntry {
+                    k: key.clone(),
+                    h: hash.clone(),
+                };
+                if let Ok(line) = serde_json::to_string(&entry) {
+                    let _ = writeln!(file, "{}", line);
+                }
+            }
+            let _ = std::fs::rename(&temp_path, &self.path);
+        }
+    }
+
+    /// Append a single entry to the NDJSON file.
+    fn append(&self, key: &str, hash: &str) {
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.path)
+        {
+            let entry = PinEntry {
+                k: key.to_string(),
+                h: hash.to_string(),
+            };
+            if let Ok(line) = serde_json::to_string(&entry) {
+                let _ = writeln!(file, "{}", line);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn pin_path(dir: &TempDir) -> PathBuf {
+        dir.path().join(".nora-pins.ndjson")
+    }
+
+    #[test]
+    fn test_record_and_verify() {
+        let dir = TempDir::new().unwrap();
+        let store = HashPinStore::new(pin_path(&dir));
+
+        store.record("maven/com/example/1.0/app.jar", b"jar-content");
+        assert!(store.verify("maven/com/example/1.0/app.jar", b"jar-content"));
+        assert!(!store.verify("maven/com/example/1.0/app.jar", b"tampered"));
+    }
+
+    #[test]
+    fn test_verify_unknown_key_passes() {
+        let dir = TempDir::new().unwrap();
+        let store = HashPinStore::new(pin_path(&dir));
+
+        // No pin exists — verification passes (open world)
+        assert!(store.verify("unknown/key", b"anything"));
+    }
+
+    #[test]
+    fn test_record_update_overwrites_pin() {
+        let dir = TempDir::new().unwrap();
+        let store = HashPinStore::new(pin_path(&dir));
+
+        store.record("npm/meta/express", b"v1");
+        assert!(store.verify("npm/meta/express", b"v1"));
+
+        // Metadata update — pin is updated
+        store.record("npm/meta/express", b"v2");
+        assert!(store.verify("npm/meta/express", b"v2"));
+        assert!(!store.verify("npm/meta/express", b"v1"));
+    }
+
+    #[test]
+    fn test_remove_pin() {
+        let dir = TempDir::new().unwrap();
+        let store = HashPinStore::new(pin_path(&dir));
+
+        store.record("key", b"data");
+        assert_eq!(store.len(), 1);
+
+        store.remove("key");
+        assert_eq!(store.len(), 0);
+
+        // After removal, any data passes verification (no pin)
+        assert!(store.verify("key", b"whatever"));
+    }
+
+    #[test]
+    fn test_persistence_and_reload() {
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+
+        {
+            let store = HashPinStore::new(&path);
+            store.record("a", b"data-a");
+            store.record("b", b"data-b");
+            store.remove("b");
+        }
+
+        // Reload from disk
+        let store = HashPinStore::new(&path);
+        assert_eq!(store.len(), 1);
+        assert!(store.verify("a", b"data-a"));
+        assert!(store.verify("b", b"anything")); // removed, no pin
+    }
+
+    #[test]
+    fn test_compact_removes_tombstones() {
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+
+        {
+            let store = HashPinStore::new(&path);
+            store.record("keep", b"data");
+            store.record("remove", b"data");
+            store.remove("remove");
+        }
+
+        // After reload + compact, file should only have 1 entry
+        let store = HashPinStore::new(&path);
+        assert_eq!(store.len(), 1);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("keep"));
+    }
+
+    #[test]
+    fn test_idempotent_record() {
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+        let store = HashPinStore::new(&path);
+
+        // Same data twice — should not append duplicate
+        store.record("key", b"data");
+        store.record("key", b"data");
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1, "duplicate record should be idempotent");
+    }
+
+    #[test]
+    fn test_empty_store_no_file() {
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+        let store = HashPinStore::new(&path);
+
+        assert_eq!(store.len(), 0);
+        assert!(!path.exists(), "empty store should not create file");
+    }
+
+    #[test]
+    fn test_sha256_correctness() {
+        // Known test vector: SHA-256 of empty string
+        let hash = HashPinStore::sha256_hex(b"");
+        assert_eq!(
+            hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+}

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -11,6 +11,7 @@ mod curation;
 mod dashboard_metrics;
 mod error;
 mod gc;
+mod hash_pin_store;
 mod health;
 mod metrics;
 mod migrate;
@@ -155,6 +156,8 @@ pub struct AppState {
     /// Per-key publish locks for TOCTOU protection (immutable releases)
     publish_locks: parking_lot::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     pub curation: curation::CurationEngine,
+    /// Per-IP failed auth attempt tracker for brute-force protection
+    pub auth_failures: auth::AuthFailureTracker,
 }
 
 impl AppState {
@@ -838,6 +841,7 @@ async fn run_server(config: Config, storage: Storage) {
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
         curation: curation_engine,
+        auth_failures: auth::AuthFailureTracker::new(5, 900),
     });
 
     // Shared lock: GC and Retention must not run concurrently (both call storage.delete)
@@ -952,6 +956,7 @@ async fn run_server(config: Config, storage: Storage) {
                 token_store.flush_last_used().await;
             }
             registry::docker::cleanup_expired_sessions(&metrics_state.upload_sessions);
+            metrics_state.auth_failures.cleanup();
         }
     });
 

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -7,9 +7,11 @@ mod s3;
 pub use local::LocalStorage;
 pub use s3::S3Storage;
 
+use crate::hash_pin_store::HashPinStore;
 use crate::validation::{validate_storage_key, ValidationError};
 use async_trait::async_trait;
 use axum::body::Bytes;
+use std::path::PathBuf;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -51,16 +53,19 @@ pub trait StorageBackend: Send + Sync {
     fn backend_name(&self) -> &'static str;
 }
 
-/// Storage wrapper for dynamic dispatch
+/// Storage wrapper for dynamic dispatch with integrity verification.
 #[derive(Clone)]
 pub struct Storage {
     inner: Arc<dyn StorageBackend>,
+    pin_store: Option<Arc<HashPinStore>>,
 }
 
 impl Storage {
     pub fn new_local(path: &str) -> Self {
+        let pin_path = PathBuf::from(path).join(".nora-pins.ndjson");
         Self {
             inner: Arc::new(LocalStorage::new(path)),
+            pin_store: Some(Arc::new(HashPinStore::new(pin_path))),
         }
     }
 
@@ -75,22 +80,35 @@ impl Storage {
             inner: Arc::new(S3Storage::new(
                 s3_url, bucket, region, access_key, secret_key,
             )),
+            pin_store: None,
         }
     }
 
     pub async fn put(&self, key: &str, data: &[u8]) -> Result<()> {
         validate_storage_key(key)?;
-        self.inner.put(key, data).await
+        self.inner.put(key, data).await?;
+        if let Some(ref pins) = self.pin_store {
+            pins.record(key, data);
+        }
+        Ok(())
     }
 
     pub async fn get(&self, key: &str) -> Result<Bytes> {
         validate_storage_key(key)?;
-        self.inner.get(key).await
+        let data = self.inner.get(key).await?;
+        if let Some(ref pins) = self.pin_store {
+            pins.verify(key, &data);
+        }
+        Ok(data)
     }
 
     pub async fn delete(&self, key: &str) -> Result<()> {
         validate_storage_key(key)?;
-        self.inner.delete(key).await
+        self.inner.delete(key).await?;
+        if let Some(ref pins) = self.pin_store {
+            pins.remove(key);
+        }
+        Ok(())
     }
 
     pub async fn list(&self, prefix: &str) -> Vec<String> {
@@ -98,7 +116,12 @@ impl Storage {
         if !prefix.is_empty() && validate_storage_key(prefix).is_err() {
             return Vec::new();
         }
-        self.inner.list(prefix).await
+        self.inner
+            .list(prefix)
+            .await
+            .into_iter()
+            .filter(|k| !k.starts_with(".nora-"))
+            .collect()
     }
 
     pub async fn stat(&self, key: &str) -> Option<FileMeta> {
@@ -118,5 +141,10 @@ impl Storage {
 
     pub fn backend_name(&self) -> &'static str {
         self.inner.backend_name()
+    }
+
+    /// Number of pinned hashes (0 if pin store is disabled).
+    pub fn pinned_count(&self) -> usize {
+        self.pin_store.as_ref().map_or(0, |p| p.len())
     }
 }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -218,6 +218,7 @@ fn build_context(
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
         curation: curation_engine,
+        auth_failures: crate::auth::AuthFailureTracker::new(5, 900),
     });
 
     // Build router identical to run_server() but without TcpListener / rate-limiting


### PR DESCRIPTION
## Summary

- **Fix #221**: Token management UI (`/ui/tokens`, `/api/ui/tokens/*`) now requires authentication even when `anonymous_read` is enabled
- **Auth rate limiting**: Per-IP exponential backoff on failed auth attempts. 5 failures → lockout (1s → 2s → 4s ... → 15min cap). Returns `429 Too Many Requests` with `Retry-After` header. Supports `X-Forwarded-For` / `X-Real-IP`
- **Hash Pin Store**: Transparent SHA-256 integrity verification at the storage layer. Every `put()` records a hash pin, every `get()` verifies. Detects direct filesystem tampering. Append-only NDJSON persistence, compacted on startup. Local storage only (S3 planned for v0.9)

874 tests (was 859). 0 clippy warnings.

Closes #221

## Test plan

- [x] Token UI returns 401 with anonymous_read + no credentials
- [x] Token UI works with valid credentials + anonymous_read
- [x] /health still accessible anonymously
- [x] Rate limiter allows under threshold, blocks at threshold
- [x] Rate limiter: success clears counter, independent IPs
- [x] Rate limiter: exponential backoff escalation
- [x] Rate limiter: cleanup removes expired entries
- [x] Pin store: record + verify, tamper detection
- [x] Pin store: persistence + reload from NDJSON
- [x] Pin store: compact removes tombstones
- [x] Pin store: idempotent record
- [x] Pin store: SHA-256 known test vector
- [x] All 874 existing + new tests pass
- [x] Migration and backup tests unaffected (pin file filtered from listings)