### PR TITLE
v0.8: audit hardening — security, storage, curation completeness

### DIFF
--- a/nora-registry/src/auth.rs
+++ b/nora-registry/src/auth.rs
@@ -163,10 +163,7 @@ fn extract_client_ip(
         .get::<ConnectInfo<SocketAddr>>()
         .map(|ci| ci.0.ip());
 
-    let peer = match peer_ip {
-        Some(ip) => ip,
-        None => return None,
-    };
+    let peer = peer_ip?;
 
     // Only trust forwarding headers from known proxies
     if !trusted_proxies.contains(peer) {
@@ -779,9 +776,10 @@ mod tests {
             .header("x-forwarded-for", "1.2.3.4, 127.0.0.1")
             .body(Body::empty())
             .unwrap();
-        request
-            .extensions_mut()
-            .insert(ConnectInfo(SocketAddr::new("127.0.0.1".parse().unwrap(), 1234)));
+        request.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+            "127.0.0.1".parse().unwrap(),
+            1234,
+        )));
         let ip = extract_client_ip(&request, &proxies);
         assert_eq!(ip, Some("1.2.3.4".parse().unwrap()));
     }
@@ -796,9 +794,10 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         // Peer is NOT in trusted list
-        request
-            .extensions_mut()
-            .insert(ConnectInfo(SocketAddr::new("5.6.7.8".parse().unwrap(), 1234)));
+        request.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+            "5.6.7.8".parse().unwrap(),
+            1234,
+        )));
         let ip = extract_client_ip(&request, &proxies);
         assert_eq!(ip, Some("5.6.7.8".parse().unwrap()));
     }
@@ -807,13 +806,11 @@ mod tests {
     fn test_xff_no_header_uses_peer_ip() {
         use crate::config::TrustedProxies;
         let proxies = TrustedProxies::parse("127.0.0.1,::1");
-        let mut request = Request::builder()
-            .uri("/test")
-            .body(Body::empty())
-            .unwrap();
-        request
-            .extensions_mut()
-            .insert(ConnectInfo(SocketAddr::new("127.0.0.1".parse().unwrap(), 1234)));
+        let mut request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+        request.extensions_mut().insert(ConnectInfo(SocketAddr::new(
+            "127.0.0.1".parse().unwrap(),
+            1234,
+        )));
         let ip = extract_client_ip(&request, &proxies);
         assert_eq!(ip, Some("127.0.0.1".parse().unwrap()));
     }

--- a/nora-registry/src/auth.rs
+++ b/nora-registry/src/auth.rs
@@ -149,8 +149,30 @@ fn is_docker_auth_challenge_path(path: &str) -> bool {
     matches!(path, "/v2/" | "/v2")
 }
 
-/// Extract client IP from request (X-Forwarded-For, X-Real-IP, or ConnectInfo).
-fn extract_client_ip(request: &Request<Body>) -> Option<IpAddr> {
+/// Extract client IP from request, honoring XFF/X-Real-IP only from trusted proxies.
+///
+/// If the direct peer IP is not in `trusted_proxies`, XFF/X-Real-IP headers are
+/// ignored and the peer IP is returned. This prevents attackers from spoofing
+/// their IP to bypass `AuthFailureTracker` lockout.
+fn extract_client_ip(
+    request: &Request<Body>,
+    trusted_proxies: &crate::config::TrustedProxies,
+) -> Option<IpAddr> {
+    let peer_ip = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0.ip());
+
+    let peer = match peer_ip {
+        Some(ip) => ip,
+        None => return None,
+    };
+
+    // Only trust forwarding headers from known proxies
+    if !trusted_proxies.contains(peer) {
+        return Some(peer);
+    }
+
     // Try X-Forwarded-For first (first IP in chain is the client)
     if let Some(xff) = request.headers().get("x-forwarded-for") {
         if let Ok(s) = xff.to_str() {
@@ -169,11 +191,8 @@ fn extract_client_ip(request: &Request<Body>) -> Option<IpAddr> {
             }
         }
     }
-    // Fall back to ConnectInfo
-    request
-        .extensions()
-        .get::<ConnectInfo<SocketAddr>>()
-        .map(|ci| ci.0.ip())
+    // No forwarding headers — use peer IP
+    Some(peer)
 }
 
 /// Auth middleware - supports Basic auth and Bearer tokens
@@ -222,7 +241,7 @@ pub async fn auth_middleware(
     let realm = state.config.server.public_url.as_deref().unwrap_or("Nora");
 
     // Check if client IP is blocked due to too many failed attempts
-    let client_ip = extract_client_ip(&request);
+    let client_ip = extract_client_ip(&request, &state.config.auth.trusted_proxies);
     if let Some(ip) = client_ip {
         if let Some(retry_after) = state.auth_failures.check_blocked(&ip) {
             return (
@@ -752,6 +771,80 @@ mod tests {
     }
 
     #[test]
+    fn test_xff_trusted_proxy_uses_forwarded_ip() {
+        use crate::config::TrustedProxies;
+        let proxies = TrustedProxies::parse("127.0.0.1,::1");
+        let mut request = Request::builder()
+            .uri("/test")
+            .header("x-forwarded-for", "1.2.3.4, 127.0.0.1")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::new("127.0.0.1".parse().unwrap(), 1234)));
+        let ip = extract_client_ip(&request, &proxies);
+        assert_eq!(ip, Some("1.2.3.4".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_xff_untrusted_proxy_uses_peer_ip() {
+        use crate::config::TrustedProxies;
+        let proxies = TrustedProxies::parse("127.0.0.1,::1");
+        let mut request = Request::builder()
+            .uri("/test")
+            .header("x-forwarded-for", "1.2.3.4")
+            .body(Body::empty())
+            .unwrap();
+        // Peer is NOT in trusted list
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::new("5.6.7.8".parse().unwrap(), 1234)));
+        let ip = extract_client_ip(&request, &proxies);
+        assert_eq!(ip, Some("5.6.7.8".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_xff_no_header_uses_peer_ip() {
+        use crate::config::TrustedProxies;
+        let proxies = TrustedProxies::parse("127.0.0.1,::1");
+        let mut request = Request::builder()
+            .uri("/test")
+            .body(Body::empty())
+            .unwrap();
+        request
+            .extensions_mut()
+            .insert(ConnectInfo(SocketAddr::new("127.0.0.1".parse().unwrap(), 1234)));
+        let ip = extract_client_ip(&request, &proxies);
+        assert_eq!(ip, Some("127.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_trusted_proxies_parse_cidr() {
+        use crate::config::TrustedProxies;
+        let proxies = TrustedProxies::parse("10.0.0.0/8");
+        assert!(proxies.contains("10.1.2.3".parse().unwrap()));
+        assert!(proxies.contains("10.255.255.255".parse().unwrap()));
+        assert!(!proxies.contains("11.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_trusted_proxies_parse_single_ip() {
+        use crate::config::TrustedProxies;
+        let proxies = TrustedProxies::parse("192.168.1.1");
+        assert!(proxies.contains("192.168.1.1".parse().unwrap()));
+        assert!(!proxies.contains("192.168.1.2".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_trusted_proxies_default_loopback() {
+        use crate::config::TrustedProxies;
+        let proxies = TrustedProxies::default_loopback();
+        assert!(proxies.contains("127.0.0.1".parse().unwrap()));
+        assert!(proxies.contains("::1".parse().unwrap()));
+        assert!(!proxies.contains("10.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
     fn test_auth_failure_tracker_allows_under_threshold() {
         let tracker = AuthFailureTracker::new(5, 900);
         let ip: IpAddr = "10.0.0.1".parse().unwrap();
@@ -1097,6 +1190,71 @@ mod integration_tests {
         )
         .await;
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Token API endpoints are public (in is_public_path) because they validate
+    /// credentials in the handler body. Verify that empty/missing credentials
+    /// are properly rejected with 401 — defense-in-depth against any future
+    /// refactor that might accidentally remove body-level auth checks.
+    #[tokio::test]
+    async fn test_token_create_without_credentials_returns_401() {
+        let ctx = create_test_context_with_auth(&[("admin", "secret")]);
+        let response = send_with_headers(
+            &ctx.app,
+            Method::POST,
+            "/api/tokens",
+            vec![("content-type", "application/json")],
+            r#"{}"#,
+        )
+        .await;
+        // Empty JSON body has no username/password — serde fails or handler rejects
+        assert!(
+            response.status() == StatusCode::UNAUTHORIZED
+                || response.status() == StatusCode::UNPROCESSABLE_ENTITY
+                || response.status() == StatusCode::BAD_REQUEST,
+            "Expected 401/422/400, got {}",
+            response.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_token_list_without_credentials_returns_401() {
+        let ctx = create_test_context_with_auth(&[("admin", "secret")]);
+        let response = send_with_headers(
+            &ctx.app,
+            Method::POST,
+            "/api/tokens/list",
+            vec![("content-type", "application/json")],
+            r#"{}"#,
+        )
+        .await;
+        assert!(
+            response.status() == StatusCode::UNAUTHORIZED
+                || response.status() == StatusCode::UNPROCESSABLE_ENTITY
+                || response.status() == StatusCode::BAD_REQUEST,
+            "Expected 401/422/400, got {}",
+            response.status()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_token_revoke_without_credentials_returns_401() {
+        let ctx = create_test_context_with_auth(&[("admin", "secret")]);
+        let response = send_with_headers(
+            &ctx.app,
+            Method::POST,
+            "/api/tokens/revoke",
+            vec![("content-type", "application/json")],
+            r#"{}"#,
+        )
+        .await;
+        assert!(
+            response.status() == StatusCode::UNAUTHORIZED
+                || response.status() == StatusCode::UNPROCESSABLE_ENTITY
+                || response.status() == StatusCode::BAD_REQUEST,
+            "Expected 401/422/400, got {}",
+            response.status()
+        );
     }
 
     #[tokio::test]

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -510,6 +510,112 @@ fn default_max_file_size() -> u64 {
     104_857_600 // 100MB
 }
 
+/// CIDR-aware trusted proxy list for X-Forwarded-For validation.
+///
+/// Only connections from trusted proxies have their XFF/X-Real-IP headers
+/// honored. Untrusted sources always use the peer (TCP) IP address.
+#[derive(Debug, Clone)]
+pub struct TrustedProxies {
+    entries: Vec<(std::net::IpAddr, u8)>, // (network address, prefix length)
+}
+
+impl TrustedProxies {
+    /// Parse a comma-separated list of IPs/CIDRs. Invalid entries are skipped with a warning.
+    pub fn parse(input: &str) -> Self {
+        let mut entries = Vec::new();
+        for item in input.split(',') {
+            let item = item.trim();
+            if item.is_empty() {
+                continue;
+            }
+            if let Some((addr_str, prefix_str)) = item.split_once('/') {
+                if let (Ok(addr), Ok(prefix)) = (addr_str.parse::<std::net::IpAddr>(), prefix_str.parse::<u8>()) {
+                    let max_prefix = if addr.is_ipv4() { 32 } else { 128 };
+                    if prefix <= max_prefix {
+                        entries.push((addr, prefix));
+                    } else {
+                        tracing::warn!(value = %item, "Invalid CIDR prefix length, skipping");
+                    }
+                } else {
+                    tracing::warn!(value = %item, "Cannot parse CIDR, skipping");
+                }
+            } else if let Ok(addr) = item.parse::<std::net::IpAddr>() {
+                let prefix = if addr.is_ipv4() { 32 } else { 128 };
+                entries.push((addr, prefix));
+            } else {
+                tracing::warn!(value = %item, "Cannot parse IP address, skipping");
+            }
+        }
+        Self { entries }
+    }
+
+    /// Default: loopback only (127.0.0.1 and ::1).
+    pub fn default_loopback() -> Self {
+        Self {
+            entries: vec![
+                (std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 32),
+                (std::net::IpAddr::V6(std::net::Ipv6Addr::LOCALHOST), 128),
+            ],
+        }
+    }
+
+    /// Check if an IP address is within the trusted proxy list.
+    pub fn contains(&self, ip: std::net::IpAddr) -> bool {
+        self.entries.iter().any(|(network, prefix)| {
+            match (network, ip) {
+                (std::net::IpAddr::V4(net), std::net::IpAddr::V4(addr)) => {
+                    if *prefix >= 32 {
+                        return *net == addr;
+                    }
+                    let net_bits = u32::from(*net);
+                    let addr_bits = u32::from(addr);
+                    let mask = u32::MAX << (32 - prefix);
+                    (net_bits & mask) == (addr_bits & mask)
+                }
+                (std::net::IpAddr::V6(net), std::net::IpAddr::V6(addr)) => {
+                    if *prefix >= 128 {
+                        return *net == addr;
+                    }
+                    let net_bits = u128::from(*net);
+                    let addr_bits = u128::from(addr);
+                    let mask = u128::MAX << (128 - prefix);
+                    (net_bits & mask) == (addr_bits & mask)
+                }
+                _ => false, // v4 vs v6 mismatch
+            }
+        })
+    }
+}
+
+impl Default for TrustedProxies {
+    fn default() -> Self {
+        Self::default_loopback()
+    }
+}
+
+// TrustedProxies doesn't need serde — it's parsed from a string.
+// Provide a dummy Serialize/Deserialize so AuthConfig can derive them.
+impl Serialize for TrustedProxies {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        let parts: Vec<String> = self.entries.iter().map(|(addr, prefix)| {
+            let max = if addr.is_ipv4() { 32 } else { 128 };
+            if *prefix == max {
+                addr.to_string()
+            } else {
+                format!("{}/{}", addr, prefix)
+            }
+        }).collect();
+        parts.join(",").serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for TrustedProxies {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::parse(&s))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthConfig {
     #[serde(default)]
@@ -521,6 +627,11 @@ pub struct AuthConfig {
     pub htpasswd_file: String,
     #[serde(default = "default_token_storage")]
     pub token_storage: String,
+    /// Trusted proxy IPs/CIDRs — only these sources have XFF/X-Real-IP honored.
+    /// Default: 127.0.0.1,::1 (loopback only).
+    /// ENV: NORA_AUTH_TRUSTED_PROXIES=127.0.0.1,::1,10.0.0.0/8
+    #[serde(default)]
+    pub trusted_proxies: TrustedProxies,
 }
 
 fn default_htpasswd_file() -> String {
@@ -605,6 +716,7 @@ impl Default for AuthConfig {
             anonymous_read: false,
             htpasswd_file: "users.htpasswd".to_string(),
             token_storage: "data/tokens".to_string(),
+            trusted_proxies: TrustedProxies::default_loopback(),
         }
     }
 }
@@ -1489,6 +1601,9 @@ impl Config {
         }
         if let Ok(val) = env::var("NORA_AUTH_HTPASSWD_FILE") {
             self.auth.htpasswd_file = val;
+        }
+        if let Ok(val) = env::var("NORA_AUTH_TRUSTED_PROXIES") {
+            self.auth.trusted_proxies = TrustedProxies::parse(&val);
         }
 
         // Registry enabled flags

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -529,7 +529,10 @@ impl TrustedProxies {
                 continue;
             }
             if let Some((addr_str, prefix_str)) = item.split_once('/') {
-                if let (Ok(addr), Ok(prefix)) = (addr_str.parse::<std::net::IpAddr>(), prefix_str.parse::<u8>()) {
+                if let (Ok(addr), Ok(prefix)) = (
+                    addr_str.parse::<std::net::IpAddr>(),
+                    prefix_str.parse::<u8>(),
+                ) {
                     let max_prefix = if addr.is_ipv4() { 32 } else { 128 };
                     if prefix <= max_prefix {
                         entries.push((addr, prefix));
@@ -596,21 +599,30 @@ impl Default for TrustedProxies {
 // TrustedProxies doesn't need serde — it's parsed from a string.
 // Provide a dummy Serialize/Deserialize so AuthConfig can derive them.
 impl Serialize for TrustedProxies {
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
-        let parts: Vec<String> = self.entries.iter().map(|(addr, prefix)| {
-            let max = if addr.is_ipv4() { 32 } else { 128 };
-            if *prefix == max {
-                addr.to_string()
-            } else {
-                format!("{}/{}", addr, prefix)
-            }
-        }).collect();
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        let parts: Vec<String> = self
+            .entries
+            .iter()
+            .map(|(addr, prefix)| {
+                let max = if addr.is_ipv4() { 32 } else { 128 };
+                if *prefix == max {
+                    addr.to_string()
+                } else {
+                    format!("{}/{}", addr, prefix)
+                }
+            })
+            .collect();
         parts.join(",").serialize(serializer)
     }
 }
 
 impl<'de> Deserialize<'de> for TrustedProxies {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
         let s = String::deserialize(deserializer)?;
         Ok(Self::parse(&s))
     }

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -312,12 +312,23 @@ pub fn check_download(
     }
 }
 
+/// Extract publish date from file mtime. ONLY for hosted registries —
+/// proxy mtime reflects cache time, not actual publish date.
+// TODO(v1.0): trust_upstream_dates config for high-security installs
+pub async fn extract_mtime_as_publish_date(
+    storage: &crate::storage::Storage,
+    key: &str,
+) -> Option<i64> {
+    storage.stat(key).await.map(|m| m.modified as i64)
+}
+
 /// Parse an ISO 8601 / RFC 3339 date string to a Unix timestamp (seconds).
 ///
 /// Handles common formats from registry metadata:
 /// - `2024-01-15T10:30:00Z` (Go .info `Time` field)
 /// - `2024-01-15T10:30:00.123Z` (npm `time` field)
 /// - `2024-01-15T10:30:00+00:00` (PyPI `upload_time_iso_8601`)
+/// - `2024-01-15T10:30:00.000+0000` (Conan `time` field — non-standard tz offset)
 ///
 /// Returns `None` if the string is not parseable.
 pub fn parse_iso8601_to_unix(s: &str) -> Option<i64> {
@@ -334,6 +345,15 @@ pub fn parse_iso8601_to_unix(s: &str) -> Option<i64> {
     }
     if let Ok(ndt) = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S") {
         return Some(ndt.and_utc().timestamp());
+    }
+
+    // Try non-standard offset format without colon: +0000, +0530
+    // (Conan center uses this format)
+    if let Ok(dt) = DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z") {
+        return Some(dt.timestamp());
+    }
+    if let Ok(dt) = DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%z") {
+        return Some(dt.timestamp());
     }
 
     None
@@ -2976,5 +2996,25 @@ mod min_release_age_tests {
         assert_eq!(MinReleaseAgeFilter::format_duration(86400), "1d");
         assert_eq!(MinReleaseAgeFilter::format_duration(604800), "1w");
         assert_eq!(MinReleaseAgeFilter::format_duration(691200), "1w1d");
+    }
+
+    #[tokio::test]
+    async fn test_extract_mtime_as_publish_date_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        storage.put("raw/test.txt", b"hello").await.unwrap();
+
+        let result = extract_mtime_as_publish_date(&storage, "raw/test.txt").await;
+        assert!(result.is_some());
+        assert!(result.unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_extract_mtime_as_publish_date_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let result = extract_mtime_as_publish_date(&storage, "raw/nonexistent.txt").await;
+        assert!(result.is_none());
     }
 }

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -49,6 +49,11 @@ lazy_static! {
         "Unix timestamp of last GC run"
     )
     .expect("gc_last_run metric");
+    pub static ref GC_METADATA_PHANTOMS: IntCounter = register_int_counter!(
+        "nora_gc_metadata_phantoms_total",
+        "Total phantom version entries cleaned from metadata"
+    )
+    .expect("gc_metadata_phantoms metric");
 }
 
 // ============================================================================
@@ -64,6 +69,8 @@ pub struct GcResult {
     pub duration_secs: f64,
     /// Registries with data but no GC orphan detection (name, file_count)
     pub uncovered: Vec<(String, usize)>,
+    /// Phantom version entries cleaned from metadata files (npm/PyPI)
+    pub metadata_phantoms_removed: usize,
 }
 
 // ============================================================================
@@ -130,6 +137,19 @@ pub async fn run_gc(storage: &Storage, dry_run: bool) -> GcResult {
         }
     }
 
+    // Metadata phantom cleanup (npm/PyPI) — under the same GC write lock
+    let metadata_phantoms_removed = detect_and_clean_metadata_phantoms(storage, dry_run).await;
+    if metadata_phantoms_removed > 0 {
+        if !dry_run {
+            GC_METADATA_PHANTOMS.inc_by(metadata_phantoms_removed as u64);
+        }
+        info!(
+            "Metadata phantoms {}: {}",
+            if dry_run { "detected" } else { "cleaned" },
+            metadata_phantoms_removed
+        );
+    }
+
     // Detect registries with data but no GC coverage
     // Raw has no version model and no reference graph — nothing to GC by design
     let mut uncovered = Vec::new();
@@ -155,6 +175,7 @@ pub async fn run_gc(storage: &Storage, dry_run: bool) -> GcResult {
         orphan_keys: all_orphans,
         duration_secs: duration,
         uncovered,
+        metadata_phantoms_removed,
     }
 }
 
@@ -390,6 +411,212 @@ async fn detect_cargo_orphans(storage: &Storage) -> DetectionResult {
 }
 
 // ============================================================================
+// Metadata phantom detection (npm/PyPI)
+// ============================================================================
+
+/// Detect and clean phantom version entries from npm/PyPI metadata files.
+///
+/// When GC/retention deletes version tarballs, the metadata.json may still
+/// reference those deleted versions. This function:
+/// 1. Lists all existing tarballs for each package
+/// 2. Reads metadata.json and checks which versions have no tarball
+/// 3. Removes phantom entries (and rewrites metadata.json if not dry_run)
+async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) -> usize {
+    let mut total_removed = 0usize;
+
+    // npm metadata cleanup
+    let npm_keys = storage.list("npm/").await;
+    let mut npm_meta_keys: Vec<String> = Vec::new();
+    let mut npm_tarball_keys: HashSet<String> = HashSet::new();
+
+    for key in &npm_keys {
+        if key.ends_with("/metadata.json") {
+            npm_meta_keys.push(key.clone());
+        } else if key.contains("/tarballs/") {
+            npm_tarball_keys.insert(key.clone());
+        }
+    }
+
+    for meta_key in &npm_meta_keys {
+        if let Some(removed) =
+            clean_npm_metadata(storage, meta_key, &npm_tarball_keys, dry_run).await
+        {
+            total_removed += removed;
+        }
+    }
+
+    // PyPI metadata cleanup
+    let pypi_keys = storage.list("pypi/").await;
+    let mut pypi_meta_keys: Vec<String> = Vec::new();
+    let mut pypi_file_keys: HashSet<String> = HashSet::new();
+
+    for key in &pypi_keys {
+        if key.ends_with("/metadata.json") {
+            pypi_meta_keys.push(key.clone());
+        } else if !key.ends_with(".sha256")
+            && !key.ends_with(".md5")
+            && !key.ends_with(".sha1")
+            && !key.ends_with(".sha512")
+        {
+            pypi_file_keys.insert(key.clone());
+        }
+    }
+
+    for meta_key in &pypi_meta_keys {
+        if let Some(removed) =
+            clean_pypi_metadata(storage, meta_key, &pypi_file_keys, dry_run).await
+        {
+            total_removed += removed;
+        }
+    }
+
+    total_removed
+}
+
+/// Clean phantom versions from a single npm metadata.json.
+///
+/// npm metadata has `versions` and `time` objects keyed by version string.
+/// A phantom = a version key with no corresponding tarball in storage.
+async fn clean_npm_metadata(
+    storage: &Storage,
+    meta_key: &str,
+    all_tarball_keys: &HashSet<String>,
+    dry_run: bool,
+) -> Option<usize> {
+    let data = storage.get(meta_key).await.ok()?;
+    let mut json: serde_json::Value = serde_json::from_slice(&data).ok()?;
+
+    // Extract package name from key: npm/{name}/metadata.json
+    let package_name = meta_key
+        .strip_prefix("npm/")?
+        .strip_suffix("/metadata.json")?;
+
+    let versions = json.get("versions")?.as_object()?.clone();
+    let mut phantoms: Vec<String> = Vec::new();
+
+    for ver_key in versions.keys() {
+        // npm tarballs: npm/{name}/tarballs/{name}-{version}.tgz
+        // For scoped packages @scope/name, tarball uses just "name" part
+        let name_part = if package_name.contains('/') {
+            package_name.rsplit('/').next().unwrap_or(package_name)
+        } else {
+            package_name
+        };
+        let tarball_key = format!(
+            "npm/{}/tarballs/{}-{}.tgz",
+            package_name, name_part, ver_key
+        );
+        if !all_tarball_keys.contains(&tarball_key) {
+            phantoms.push(ver_key.clone());
+        }
+    }
+
+    if phantoms.is_empty() {
+        return Some(0);
+    }
+
+    let count = phantoms.len();
+    for phantom in &phantoms {
+        info!(
+            "[metadata-gc] npm {}: phantom version {} (no tarball)",
+            package_name, phantom
+        );
+    }
+
+    if !dry_run {
+        // Remove phantom entries from versions object
+        if let Some(versions_obj) = json.get_mut("versions").and_then(|v| v.as_object_mut()) {
+            for phantom in &phantoms {
+                versions_obj.remove(phantom.as_str());
+            }
+        }
+        // Remove corresponding time entries
+        if let Some(time_obj) = json.get_mut("time").and_then(|v| v.as_object_mut()) {
+            for phantom in &phantoms {
+                time_obj.remove(phantom.as_str());
+            }
+        }
+        // Rewrite metadata
+        if let Ok(new_data) = serde_json::to_vec(&json) {
+            let _ = storage.put(meta_key, &new_data).await;
+        }
+    }
+
+    Some(count)
+}
+
+/// Clean phantom releases from a single PyPI metadata.json.
+///
+/// PyPI metadata has `releases` keyed by version, each containing an array of files.
+/// A phantom = a version key where none of the referenced files exist in storage.
+async fn clean_pypi_metadata(
+    storage: &Storage,
+    meta_key: &str,
+    all_file_keys: &HashSet<String>,
+    dry_run: bool,
+) -> Option<usize> {
+    let data = storage.get(meta_key).await.ok()?;
+    let mut json: serde_json::Value = serde_json::from_slice(&data).ok()?;
+
+    // Extract package name from key: pypi/{name}/metadata.json
+    let package_name = meta_key
+        .strip_prefix("pypi/")?
+        .strip_suffix("/metadata.json")?;
+
+    let releases = json.get("releases")?.as_object()?.clone();
+    let mut phantoms: Vec<String> = Vec::new();
+
+    for (ver_key, files_val) in &releases {
+        let files = match files_val.as_array() {
+            Some(arr) => arr,
+            None => {
+                phantoms.push(ver_key.clone());
+                continue;
+            }
+        };
+
+        // Check if ANY file from this release exists in storage
+        let has_file = files.iter().any(|f| {
+            if let Some(filename) = f.get("filename").and_then(|v| v.as_str()) {
+                let file_key = format!("pypi/{}/{}", package_name, filename);
+                all_file_keys.contains(&file_key)
+            } else {
+                false
+            }
+        });
+
+        if !has_file && !files.is_empty() {
+            phantoms.push(ver_key.clone());
+        }
+    }
+
+    if phantoms.is_empty() {
+        return Some(0);
+    }
+
+    let count = phantoms.len();
+    for phantom in &phantoms {
+        info!(
+            "[metadata-gc] pypi {}: phantom release {} (no files)",
+            package_name, phantom
+        );
+    }
+
+    if !dry_run {
+        if let Some(releases_obj) = json.get_mut("releases").and_then(|v| v.as_object_mut()) {
+            for phantom in &phantoms {
+                releases_obj.remove(phantom.as_str());
+            }
+        }
+        if let Ok(new_data) = serde_json::to_vec(&json) {
+            let _ = storage.put(meta_key, &new_data).await;
+        }
+    }
+
+    Some(count)
+}
+
+// ============================================================================
 // Background scheduler
 // ============================================================================
 
@@ -419,8 +646,9 @@ pub fn spawn_gc_scheduler(
             info!("GC scheduler: starting periodic run");
             let result = run_gc(&storage, dry_run).await;
             info!(
-                "GC scheduler: done in {:.1}s — {} orphans, {} deleted, {} bytes freed",
-                result.duration_secs, result.orphaned, result.deleted, result.bytes_freed
+                "GC scheduler: done in {:.1}s — {} orphans, {} deleted, {} bytes freed, {} metadata phantoms",
+                result.duration_secs, result.orphaned, result.deleted, result.bytes_freed,
+                result.metadata_phantoms_removed
             );
 
             drop(guard);
@@ -447,6 +675,7 @@ mod tests {
             orphan_keys: vec![],
             duration_secs: 0.0,
             uncovered: vec![],
+            metadata_phantoms_removed: 0,
         };
         assert_eq!(result.total_candidates, 0);
         assert!(result.orphan_keys.is_empty());
@@ -914,5 +1143,218 @@ mod tests {
         let result = run_gc(&storage, false).await;
         assert_eq!(result.deleted, 1);
         assert_eq!(result.bytes_freed, 5); // "12345" = 5 bytes
+    }
+
+    // -- Metadata phantom tests --
+
+    #[tokio::test]
+    async fn test_gc_npm_no_phantoms() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // metadata + matching tarball
+        let meta = serde_json::json!({
+            "versions": {"1.0.0": {"name": "lodash"}},
+            "time": {"1.0.0": "2024-01-15T10:30:00Z"}
+        });
+        storage
+            .put(
+                "npm/lodash/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("npm/lodash/tarballs/lodash-1.0.0.tgz", b"tarball")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, true).await;
+        assert_eq!(result.metadata_phantoms_removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_gc_npm_phantom_detected_dry_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // metadata references 1.0.0 and 2.0.0, but only 2.0.0 tarball exists
+        let meta = serde_json::json!({
+            "versions": {
+                "1.0.0": {"name": "lodash"},
+                "2.0.0": {"name": "lodash"}
+            },
+            "time": {
+                "1.0.0": "2024-01-01T00:00:00Z",
+                "2.0.0": "2024-06-01T00:00:00Z"
+            }
+        });
+        storage
+            .put(
+                "npm/lodash/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("npm/lodash/tarballs/lodash-2.0.0.tgz", b"tarball")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, true).await;
+        assert_eq!(result.metadata_phantoms_removed, 1);
+
+        // Dry run: metadata should be unchanged
+        let data = storage.get("npm/lodash/metadata.json").await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&data).unwrap();
+        assert!(json["versions"]["1.0.0"].is_object()); // still there
+    }
+
+    #[tokio::test]
+    async fn test_gc_npm_phantom_cleaned() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let meta = serde_json::json!({
+            "versions": {
+                "1.0.0": {"name": "lodash"},
+                "2.0.0": {"name": "lodash"}
+            },
+            "time": {
+                "1.0.0": "2024-01-01T00:00:00Z",
+                "2.0.0": "2024-06-01T00:00:00Z"
+            }
+        });
+        storage
+            .put(
+                "npm/lodash/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("npm/lodash/tarballs/lodash-2.0.0.tgz", b"tarball")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, false).await;
+        assert_eq!(result.metadata_phantoms_removed, 1);
+
+        // Verify phantom was removed
+        let data = storage.get("npm/lodash/metadata.json").await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&data).unwrap();
+        assert!(json["versions"]["1.0.0"].is_null());
+        assert!(json["versions"]["2.0.0"].is_object());
+        assert!(json["time"]["1.0.0"].is_null());
+        assert!(json["time"]["2.0.0"].is_string());
+    }
+
+    #[tokio::test]
+    async fn test_gc_pypi_no_phantoms() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let meta = serde_json::json!({
+            "releases": {
+                "1.0.0": [{"filename": "flask-1.0.0.tar.gz"}]
+            }
+        });
+        storage
+            .put(
+                "pypi/flask/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("pypi/flask/flask-1.0.0.tar.gz", b"package")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, true).await;
+        assert_eq!(result.metadata_phantoms_removed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_gc_pypi_phantom_detected() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let meta = serde_json::json!({
+            "releases": {
+                "1.0.0": [{"filename": "flask-1.0.0.tar.gz"}],
+                "2.0.0": [{"filename": "flask-2.0.0.tar.gz"}]
+            }
+        });
+        storage
+            .put(
+                "pypi/flask/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        // Only 2.0.0 tarball exists
+        storage
+            .put("pypi/flask/flask-2.0.0.tar.gz", b"package")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, false).await;
+        assert_eq!(result.metadata_phantoms_removed, 1);
+
+        // Verify phantom was removed
+        let data = storage.get("pypi/flask/metadata.json").await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&data).unwrap();
+        assert!(json["releases"]["1.0.0"].is_null());
+        assert!(json["releases"]["2.0.0"].is_array());
+    }
+
+    #[tokio::test]
+    async fn test_gc_mixed_orphans_and_phantoms() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // Docker: 1 orphan blob
+        let manifest = serde_json::json!({
+            "config": {"digest": "sha256:cfg1"},
+            "layers": []
+        });
+        storage
+            .put(
+                "docker/app/manifests/v1.json",
+                manifest.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("docker/app/blobs/sha256:cfg1", b"config")
+            .await
+            .unwrap();
+        storage
+            .put("docker/app/blobs/sha256:stale", b"old")
+            .await
+            .unwrap();
+
+        // npm: 1 phantom version
+        let meta = serde_json::json!({
+            "versions": {"1.0.0": {}, "2.0.0": {}},
+            "time": {"1.0.0": "2024-01-01T00:00:00Z", "2.0.0": "2024-06-01T00:00:00Z"}
+        });
+        storage
+            .put(
+                "npm/test-pkg/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("npm/test-pkg/tarballs/test-pkg-2.0.0.tgz", b"tarball")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, false).await;
+        assert_eq!(result.orphaned, 1); // docker blob
+        assert_eq!(result.deleted, 1);
+        assert_eq!(result.metadata_phantoms_removed, 1); // npm phantom
     }
 }

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -73,8 +73,7 @@ impl HashPinStore {
     /// hash, this is a no-op. If the hash changed (normal metadata update),
     /// the pin is updated.
     ///
-    /// File I/O is dispatched to a blocking thread to avoid holding the
-    /// write lock during disk writes on the tokio runtime.
+    /// The write lock is released before file I/O to minimize lock contention.
     pub fn record(&self, key: &str, data: &[u8]) {
         let hash = Self::sha256_hex(data);
         let should_write = {
@@ -85,12 +84,9 @@ impl HashPinStore {
             }
             changed
         };
+        // File append after lock release — ~100 bytes, fast on any filesystem
         if should_write {
-            let path = self.path.clone();
-            let key = key.to_string();
-            std::thread::spawn(move || {
-                Self::append_to_file(&path, &key, &hash);
-            });
+            Self::append_to_file(&self.path, key, &hash);
         }
     }
 
@@ -117,18 +113,14 @@ impl HashPinStore {
 
     /// Remove a pin entry. Called on `delete()`.
     ///
-    /// File I/O is dispatched to a separate thread.
+    /// The write lock is released before file I/O.
     pub fn remove(&self, key: &str) {
         let removed = {
             let mut pins = self.pins.write();
             pins.remove(key).is_some()
         };
         if removed {
-            let path = self.path.clone();
-            let key = key.to_string();
-            std::thread::spawn(move || {
-                Self::append_to_file(&path, &key, "");
-            });
+            Self::append_to_file(&self.path, key, "");
         }
     }
 
@@ -287,6 +279,9 @@ mod tests {
         // Same data twice — should not append duplicate
         store.record("key", b"data");
         store.record("key", b"data");
+
+        // Wait for background I/O thread to complete
+        std::thread::sleep(std::time::Duration::from_millis(200));
 
         let content = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = content.lines().collect();

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -72,13 +72,25 @@ impl HashPinStore {
     /// If the key is new, the hash is pinned. If the key exists with the same
     /// hash, this is a no-op. If the hash changed (normal metadata update),
     /// the pin is updated.
+    ///
+    /// File I/O is dispatched to a blocking thread to avoid holding the
+    /// write lock during disk writes on the tokio runtime.
     pub fn record(&self, key: &str, data: &[u8]) {
         let hash = Self::sha256_hex(data);
-        let mut pins = self.pins.write();
-        let should_write = pins.get(key).is_none_or(|existing| *existing != hash);
+        let should_write = {
+            let mut pins = self.pins.write();
+            let changed = pins.get(key).is_none_or(|existing| *existing != hash);
+            if changed {
+                pins.insert(key.to_string(), hash.clone());
+            }
+            changed
+        };
         if should_write {
-            pins.insert(key.to_string(), hash.clone());
-            self.append(key, &hash);
+            let path = self.path.clone();
+            let key = key.to_string();
+            std::thread::spawn(move || {
+                Self::append_to_file(&path, &key, &hash);
+            });
         }
     }
 
@@ -104,10 +116,19 @@ impl HashPinStore {
     }
 
     /// Remove a pin entry. Called on `delete()`.
+    ///
+    /// File I/O is dispatched to a separate thread.
     pub fn remove(&self, key: &str) {
-        let mut pins = self.pins.write();
-        if pins.remove(key).is_some() {
-            self.append(key, "");
+        let removed = {
+            let mut pins = self.pins.write();
+            pins.remove(key).is_some()
+        };
+        if removed {
+            let path = self.path.clone();
+            let key = key.to_string();
+            std::thread::spawn(move || {
+                Self::append_to_file(&path, &key, "");
+            });
         }
     }
 
@@ -140,12 +161,12 @@ impl HashPinStore {
         }
     }
 
-    /// Append a single entry to the NDJSON file.
-    fn append(&self, key: &str, hash: &str) {
+    /// Append a single entry to the NDJSON file (static, safe to call from any thread).
+    fn append_to_file(path: &std::path::Path, key: &str, hash: &str) {
         if let Ok(mut file) = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(&self.path)
+            .open(path)
         {
             let entry = PinEntry {
                 k: key.to_string(),

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -949,14 +949,27 @@ async fn run_server(config: Config, storage: Storage) {
     let metrics_state = state.clone();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+        let mut tick_count: u64 = 0;
         loop {
             interval.tick().await;
+            tick_count += 1;
             metrics_state.metrics.save().await;
             if let Some(ref token_store) = metrics_state.tokens {
                 token_store.flush_last_used().await;
             }
             registry::docker::cleanup_expired_sessions(&metrics_state.upload_sessions);
             metrics_state.auth_failures.cleanup();
+
+            // Every 60s (every other tick): refresh S3 total_size cache
+            if tick_count % 2 == 0 {
+                metrics_state.storage.refresh_total_size_cache().await;
+            }
+
+            // Every 5 minutes (tick_count % 10 == 0): evict unused publish locks
+            if tick_count % 10 == 0 {
+                let mut locks = metrics_state.publish_locks.lock();
+                locks.retain(|_, arc| Arc::strong_count(arc) > 1);
+            }
         }
     });
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -961,12 +961,12 @@ async fn run_server(config: Config, storage: Storage) {
             metrics_state.auth_failures.cleanup();
 
             // Every 60s (every other tick): refresh S3 total_size cache
-            if tick_count % 2 == 0 {
+            if tick_count.is_multiple_of(2) {
                 metrics_state.storage.refresh_total_size_cache().await;
             }
 
             // Every 5 minutes (tick_count % 10 == 0): evict unused publish locks
-            if tick_count % 10 == 0 {
+            if tick_count.is_multiple_of(10) {
                 let mut locks = metrics_state.publish_locks.lock();
                 locks.retain(|_, arc| Arc::strong_count(arc) > 1);
             }

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -165,6 +165,15 @@ async fn download_tarball(
     }
     let (ns, name, ver) = (parts[0], parts[1], parts[2]);
 
+    let storage_key = format!("ansible/download/{}", filename);
+
+    // mtime fallback for hosted-only mode (proxy mtime = cache time, not publish time)
+    let publish_date = if state.config.ansible.proxy.is_none() {
+        crate::curation::extract_mtime_as_publish_date(&state.storage, &storage_key).await
+    } else {
+        None
+    };
+
     // Curation check
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -173,12 +182,10 @@ async fn download_tarball(
         crate::curation::RegistryType::Ansible,
         &format!("{}.{}", ns, name),
         Some(ver),
-        None,
+        publish_date,
     ) {
         return response;
     }
-
-    let storage_key = format!("ansible/download/{}", filename);
 
     // Immutable cache
     if let Ok(data) = state.storage.get(&storage_key).await {

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -298,6 +298,9 @@ async fn recipe_file_download(
     let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
     let artifact = format!("{} rrev={} {}", ref_str, rrev, filename);
 
+    // Extract publish date from cached revision metadata
+    let publish_date = extract_conan_publish_date(&state.storage, &name, &ver, &user, &chan).await;
+
     // Curation check
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -306,7 +309,7 @@ async fn recipe_file_download(
         crate::curation::RegistryType::Conan,
         &name,
         Some(&ver),
-        None,
+        publish_date,
     ) {
         return response;
     }
@@ -572,6 +575,9 @@ async fn package_file_download(
     let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
     let artifact = format!("{}#{}:{}#{} {}", ref_str, rrev, pkg_id, prev, filename);
 
+    // Extract publish date from cached revision metadata
+    let publish_date = extract_conan_publish_date(&state.storage, &name, &ver, &user, &chan).await;
+
     // Curation check
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -580,7 +586,7 @@ async fn package_file_download(
         crate::curation::RegistryType::Conan,
         &name,
         Some(&ver),
-        None,
+        publish_date,
     ) {
         return response;
     }
@@ -766,6 +772,28 @@ async fn fetch_and_cache_immutable_json(
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
+
+/// Extract publish date from cached Conan recipe revision metadata.
+///
+/// Conan v2 `latest.json` contains:
+/// ```json
+/// { "revision": "abc123", "time": "2024-01-15T10:30:00.000+0000" }
+/// ```
+// TODO(v1.0): trust_upstream_dates config for high-security installs
+async fn extract_conan_publish_date(
+    storage: &crate::storage::Storage,
+    name: &str,
+    ver: &str,
+    user: &str,
+    chan: &str,
+) -> Option<i64> {
+    let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
+    let meta_key = format!("conan/{}/latest.json", ref_str);
+    let data = storage.get(&meta_key).await.ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
+    let date_str = json.get("time")?.as_str()?;
+    crate::curation::parse_iso8601_to_unix(date_str)
+}
 
 fn upstream_url(state: &AppState) -> String {
     state
@@ -1159,5 +1187,52 @@ mod integration_tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_bytes(resp).await;
         assert_eq!(&body[..], b"safe recipe");
+    }
+
+    #[tokio::test]
+    async fn test_extract_conan_publish_date_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({
+            "revision": "abc123",
+            "time": "2024-03-15T14:30:00.000+0000"
+        });
+        storage
+            .put(
+                "conan/zlib/1.3/_/_/latest.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_").await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_extract_conan_publish_date_no_time_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({"revision": "abc123"});
+        storage
+            .put(
+                "conan/zlib/1.3/_/_/latest.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_extract_conan_publish_date_no_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let result =
+            super::extract_conan_publish_date(&storage, "nonexistent", "1.0", "_", "_").await;
+        assert!(result.is_none());
     }
 }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -44,9 +44,15 @@ pub struct LayerInfo {
     pub size: u64,
 }
 
-/// In-progress upload session with metadata
+/// In-progress upload session with metadata.
+///
+/// Blob data is streamed to a temporary file instead of being buffered in memory.
+/// This prevents 100 concurrent 2GB uploads from consuming 200GB of RAM.
 pub struct UploadSession {
-    data: Vec<u8>,
+    /// Path to the temporary file holding blob data.
+    temp_path: std::path::PathBuf,
+    /// Current size of data written to temp file.
+    size: u64,
     name: String,
     created_at: std::time::Instant,
 }
@@ -75,11 +81,18 @@ fn max_session_size() -> usize {
     mb.saturating_mul(1024 * 1024)
 }
 
-/// Remove expired upload sessions (called by background task)
+/// Remove expired upload sessions and their temp files (called by background task)
 pub fn cleanup_expired_sessions(sessions: &RwLock<HashMap<String, UploadSession>>) {
     let mut guard = sessions.write();
     let before = guard.len();
-    guard.retain(|_, s| s.created_at.elapsed() < SESSION_TTL);
+    guard.retain(|_, s| {
+        if s.created_at.elapsed() >= SESSION_TTL {
+            let _ = std::fs::remove_file(&s.temp_path);
+            false
+        } else {
+            true
+        }
+    });
     let removed = before - guard.len();
     if removed > 0 {
         tracing::info!(
@@ -88,6 +101,13 @@ pub fn cleanup_expired_sessions(sessions: &RwLock<HashMap<String, UploadSession>
             "Cleaned up expired upload sessions"
         );
     }
+}
+
+/// Get the temp directory for Docker uploads, creating it if needed.
+fn upload_temp_dir(data_dir: &str) -> std::path::PathBuf {
+    let dir = std::path::PathBuf::from(data_dir).join("tmp/docker-uploads");
+    let _ = std::fs::create_dir_all(&dir);
+    dir
 }
 
 pub fn routes() -> Router<Arc<AppState>> {
@@ -355,13 +375,18 @@ async fn start_upload(State(state): State<Arc<AppState>>, Path(name): Path<Strin
 
     let uuid = uuid::Uuid::new_v4().to_string();
 
+    // Create temp file for blob data
+    let temp_dir = upload_temp_dir(&state.config.storage.path);
+    let temp_path = temp_dir.join(&uuid);
+
     // Create session with metadata
     {
         let mut sessions = state.upload_sessions.write();
         sessions.insert(
             uuid.clone(),
             UploadSession {
-                data: Vec::new(),
+                temp_path,
+                size: 0,
                 name: name.clone(),
                 created_at: std::time::Instant::now(),
             },
@@ -390,7 +415,7 @@ async fn patch_blob(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    // Append data to the upload session and get total size
+    // Append data to temp file and get total size
     let total_size = {
         let mut sessions = state.upload_sessions.write();
         let session = match sessions.get_mut(&uuid) {
@@ -417,13 +442,15 @@ async fn patch_blob(
 
         // Check session TTL
         if session.created_at.elapsed() >= SESSION_TTL {
+            let _ = std::fs::remove_file(&session.temp_path);
             sessions.remove(&uuid);
             return (StatusCode::NOT_FOUND, "Upload session expired").into_response();
         }
 
         // Check size limit
-        let new_size = session.data.len() + body.len();
+        let new_size = session.size as usize + body.len();
         if new_size > max_session_size() {
+            let _ = std::fs::remove_file(&session.temp_path);
             sessions.remove(&uuid);
             return (
                 StatusCode::PAYLOAD_TOO_LARGE,
@@ -432,8 +459,31 @@ async fn patch_blob(
                 .into_response();
         }
 
-        session.data.extend_from_slice(&body);
-        session.data.len()
+        // Append to temp file
+        use std::io::Write;
+        let temp_path = session.temp_path.clone();
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&temp_path)
+        {
+            Ok(mut file) => {
+                if let Err(e) = file.write_all(&body) {
+                    tracing::error!(error = %e, "Failed to write to upload temp file");
+                    let _ = std::fs::remove_file(&temp_path);
+                    sessions.remove(&uuid);
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to open upload temp file");
+                sessions.remove(&uuid);
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        }
+
+        session.size = new_size as u64;
+        new_size
     };
 
     let location = format!("/v2/{}/blobs/uploads/{}", name, uuid);
@@ -477,7 +527,7 @@ async fn upload_blob(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    // Get data from chunked session if exists, otherwise use body directly
+    // Get data from chunked session (temp file) if exists, otherwise use body directly
     let data = {
         let mut sessions = state.upload_sessions.write();
         if let Some(session) = sessions.remove(&uuid) {
@@ -488,14 +538,24 @@ async fn upload_blob(
                     request_name = %name,
                     "SECURITY: upload finalization name mismatch"
                 );
+                let _ = std::fs::remove_file(&session.temp_path);
                 return (
                     StatusCode::BAD_REQUEST,
                     "Session does not belong to this repository",
                 )
                     .into_response();
             }
-            // Chunked upload: append any final body data and use session
-            let mut session_data = session.data;
+            // Chunked upload: read temp file, append any final body data
+            let mut session_data = match std::fs::read(&session.temp_path) {
+                Ok(data) => data,
+                Err(e) => {
+                    tracing::error!(error = %e, "Failed to read upload temp file");
+                    let _ = std::fs::remove_file(&session.temp_path);
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
+            };
+            // Clean up temp file
+            let _ = std::fs::remove_file(&session.temp_path);
             if !body.is_empty() {
                 session_data.extend_from_slice(&body);
             }
@@ -580,6 +640,15 @@ async fn get_manifest(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
+    // Extract publish date from .meta.json sidecar
+    let publish_date = extract_docker_publish_date(
+        &state.storage,
+        &name,
+        &reference,
+        state.config.docker.upstreams.is_empty(),
+    )
+    .await;
+
     // Curation check — manifests carry the image identity
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -588,7 +657,7 @@ async fn get_manifest(
         crate::curation::RegistryType::Docker,
         &name,
         Some(&reference),
-        None,
+        publish_date,
     ) {
         return response;
     }
@@ -1236,6 +1305,36 @@ fn detect_manifest_media_type(data: &[u8]) -> String {
     "application/vnd.docker.distribution.manifest.v2+json".to_string()
 }
 
+/// Extract publish date from Docker manifest `.meta.json` sidecar.
+///
+/// Docker metadata sidecar stores `push_timestamp` (Unix seconds) when the
+/// manifest was first pushed or cached.
+// TODO(v1.0): trust_upstream_dates config for high-security installs
+async fn extract_docker_publish_date(
+    storage: &Storage,
+    name: &str,
+    reference: &str,
+    upstreams_empty: bool,
+) -> Option<i64> {
+    // Try .meta.json sidecar (has push_timestamp)
+    let meta_key = format!("docker/{}/manifests/{}.meta.json", name, reference);
+    if let Ok(data) = storage.get(&meta_key).await {
+        if let Ok(meta) = serde_json::from_slice::<ImageMetadata>(&data) {
+            if meta.push_timestamp > 0 {
+                return Some(meta.push_timestamp as i64);
+            }
+        }
+    }
+
+    // mtime fallback — only for hosted mode (no upstreams configured)
+    if upstreams_empty {
+        let manifest_key = format!("docker/{}/manifests/{}.json", name, reference);
+        return crate::curation::extract_mtime_as_publish_date(storage, &manifest_key).await;
+    }
+
+    None
+}
+
 /// Extract metadata from a Docker manifest
 /// Handles both single-arch manifests and multi-arch indexes
 async fn extract_metadata(manifest: &[u8], storage: &Storage, name: &str) -> ImageMetadata {
@@ -1486,10 +1585,14 @@ mod tests {
     #[test]
     fn test_cleanup_expired_sessions_fresh() {
         let sessions: RwLock<HashMap<String, UploadSession>> = RwLock::new(HashMap::new());
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let temp_path = temp_dir.path().join("uuid-1");
+        std::fs::write(&temp_path, b"test data").unwrap();
         sessions.write().insert(
             "uuid-1".to_string(),
             UploadSession {
-                data: vec![1, 2, 3],
+                temp_path,
+                size: 9,
                 name: "test/image".to_string(),
                 created_at: std::time::Instant::now(),
             },
@@ -1984,5 +2087,74 @@ mod integration_tests {
             .to_str()
             .unwrap()
             .starts_with("sha256:"));
+    }
+
+    #[tokio::test]
+    async fn test_extract_docker_publish_date_from_meta() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = super::ImageMetadata {
+            push_timestamp: 1700000000,
+            ..Default::default()
+        };
+        storage
+            .put(
+                "docker/library/nginx/manifests/latest.meta.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_docker_publish_date(
+            &storage,
+            "library/nginx",
+            "latest",
+            true, // no upstreams
+        )
+        .await;
+        assert_eq!(result, Some(1700000000));
+    }
+
+    #[tokio::test]
+    async fn test_extract_docker_publish_date_mtime_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // No .meta.json, but manifest exists — should fall back to mtime (hosted mode)
+        storage
+            .put("docker/library/nginx/manifests/latest.json", b"{}")
+            .await
+            .unwrap();
+
+        let result = super::extract_docker_publish_date(
+            &storage,
+            "library/nginx",
+            "latest",
+            true, // hosted mode (no upstreams)
+        )
+        .await;
+        assert!(result.is_some());
+        assert!(result.unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_extract_docker_publish_date_proxy_no_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // No .meta.json, manifest exists, but proxy mode — no fallback
+        storage
+            .put("docker/library/nginx/manifests/latest.json", b"{}")
+            .await
+            .unwrap();
+
+        let result = super::extract_docker_publish_date(
+            &storage,
+            "library/nginx",
+            "latest",
+            false, // proxy mode (has upstreams)
+        )
+        .await;
+        assert!(result.is_none());
     }
 }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -270,7 +270,13 @@ async fn download_blob(
         ));
         return (
             StatusCode::OK,
-            [(header::CONTENT_TYPE, "application/octet-stream")],
+            [
+                (header::CONTENT_TYPE, "application/octet-stream"),
+                (
+                    header::CACHE_CONTROL,
+                    "public, max-age=31536000, immutable",
+                ),
+            ],
             data,
         )
             .into_response();

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -272,10 +272,7 @@ async fn download_blob(
             StatusCode::OK,
             [
                 (header::CONTENT_TYPE, "application/octet-stream"),
-                (
-                    header::CACHE_CONTROL,
-                    "public, max-age=31536000, immutable",
-                ),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
             ],
             data,
         )
@@ -551,17 +548,23 @@ async fn upload_blob(
                 )
                     .into_response();
             }
-            // Chunked upload: read temp file, append any final body data
-            let mut session_data = match std::fs::read(&session.temp_path) {
-                Ok(data) => data,
-                Err(e) => {
-                    tracing::error!(error = %e, "Failed to read upload temp file");
-                    let _ = std::fs::remove_file(&session.temp_path);
-                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            // Read temp file if it exists (may not exist for monolithic uploads
+            // where no PATCH was sent before the final PUT)
+            let mut session_data = if session.temp_path.exists() {
+                match std::fs::read(&session.temp_path) {
+                    Ok(data) => {
+                        let _ = std::fs::remove_file(&session.temp_path);
+                        data
+                    }
+                    Err(e) => {
+                        tracing::error!(error = %e, "Failed to read upload temp file");
+                        let _ = std::fs::remove_file(&session.temp_path);
+                        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                    }
                 }
+            } else {
+                Vec::new()
             };
-            // Clean up temp file
-            let _ = std::fs::remove_file(&session.temp_path);
             if !body.is_empty() {
                 session_data.extend_from_slice(&body);
             }

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -238,6 +238,14 @@ async fn download_gem(
     }
 
     let artifact = format!("{}-{}", name, version);
+    let storage_key = format!("gems/gems/{}.gem", artifact);
+
+    // mtime fallback for hosted-only mode (proxy mtime = cache time, not publish time)
+    let publish_date = if state.config.gems.proxy.is_none() {
+        crate::curation::extract_mtime_as_publish_date(&state.storage, &storage_key).await
+    } else {
+        None
+    };
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
@@ -247,12 +255,10 @@ async fn download_gem(
         crate::curation::RegistryType::Gems,
         &name,
         Some(&version),
-        None,
+        publish_date,
     ) {
         return response;
     }
-
-    let storage_key = format!("gems/gems/{}.gem", artifact);
 
     // Immutable: if cached, serve directly
     if let Ok(data) = state.storage.get(&storage_key).await {

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -360,9 +360,23 @@ fn format_artifact(module: &str, file: &str) -> String {
 
 /// Build response with Content-Type header
 fn with_content_type(data: Vec<u8>, content_type: &'static str) -> Response {
+    // .zip and .mod are content-addressed/versioned (immutable)
+    // .info, list, @latest are metadata (mutable)
+    let cache_control = if content_type == "application/zip" || content_type == "text/plain" {
+        "public, max-age=31536000, immutable"
+    } else {
+        "public, max-age=60, must-revalidate"
+    };
+
     (
         StatusCode::OK,
-        [(header::CONTENT_TYPE, HeaderValue::from_static(content_type))],
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static(content_type)),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static(cache_control),
+            ),
+        ],
         data,
     )
         .into_response()

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -129,6 +129,13 @@ async fn download(
 
     // Curation check — only for versioned artifact files, not metadata
     if let Some((ref maven_name, ref maven_version)) = curation_coords {
+        // mtime fallback for hosted-only mode (proxy mtime = cache time, not publish time)
+        let publish_date = if state.config.maven.proxies.is_empty() {
+            crate::curation::extract_mtime_as_publish_date(&state.storage, &key).await
+        } else {
+            None
+        };
+
         if let Some(response) = crate::curation::check_download(
             &state.curation,
             state.config.curation.bypass_token.as_deref(),
@@ -136,7 +143,7 @@ async fn download(
             crate::curation::RegistryType::Maven,
             maven_name,
             Some(maven_version),
-            None,
+            publish_date,
         ) {
             return response;
         }
@@ -467,7 +474,7 @@ fn generate_metadata_xml(group_id: &str, artifact_id: &str, versions: &[String])
 fn with_content_type(
     path: &str,
     data: Bytes,
-) -> (StatusCode, [(header::HeaderName, &'static str); 1], Bytes) {
+) -> (StatusCode, [(header::HeaderName, &'static str); 2], Bytes) {
     let content_type = if path.ends_with(".pom") {
         "application/xml"
     } else if path.ends_with(".jar") {
@@ -484,7 +491,24 @@ fn with_content_type(
         "application/octet-stream"
     };
 
-    (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data)
+    // maven-metadata.xml is mutable; release artifacts are immutable
+    let cache_control = if path.ends_with("maven-metadata.xml")
+        || path.ends_with("maven-metadata.xml.sha1")
+        || path.ends_with("maven-metadata.xml.md5")
+    {
+        "public, max-age=60, must-revalidate"
+    } else {
+        "public, max-age=31536000, immutable"
+    };
+
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::CACHE_CONTROL, cache_control),
+        ],
+        data,
+    )
 }
 
 // ============================================================================

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -488,11 +488,7 @@ async fn extract_npm_publish_date(
 fn with_content_type(
     is_tarball: bool,
     data: Bytes,
-) -> (
-    StatusCode,
-    [(header::HeaderName, &'static str); 2],
-    Bytes,
-) {
+) -> (StatusCode, [(header::HeaderName, &'static str); 2], Bytes) {
     let (content_type, cache_control) = if is_tarball {
         (
             "application/octet-stream",

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -488,14 +488,28 @@ async fn extract_npm_publish_date(
 fn with_content_type(
     is_tarball: bool,
     data: Bytes,
-) -> (StatusCode, [(header::HeaderName, &'static str); 1], Bytes) {
-    let content_type = if is_tarball {
-        "application/octet-stream"
+) -> (
+    StatusCode,
+    [(header::HeaderName, &'static str); 2],
+    Bytes,
+) {
+    let (content_type, cache_control) = if is_tarball {
+        (
+            "application/octet-stream",
+            "public, max-age=31536000, immutable",
+        )
     } else {
-        "application/json"
+        ("application/json", "public, max-age=60, must-revalidate")
     };
 
-    (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data)
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, content_type),
+            (header::CACHE_CONTROL, cache_control),
+        ],
+        data,
+    )
 }
 
 #[cfg(test)]

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -279,6 +279,9 @@ async fn flatcontainer_download(
 
     // Curation check for .nupkg downloads
     if filename.ends_with(".nupkg") {
+        // Extract publish date from cached registration index
+        let publish_date = extract_nuget_publish_date(&state.storage, &id_lower, ver).await;
+
         if let Some(response) = crate::curation::check_download(
             &state.curation,
             state.config.curation.bypass_token.as_deref(),
@@ -286,7 +289,7 @@ async fn flatcontainer_download(
             crate::curation::RegistryType::Nuget,
             &id_lower,
             Some(ver),
-            None,
+            publish_date,
         ) {
             return response;
         }
@@ -399,6 +402,36 @@ fn extract_host(state: &AppState, headers: &HeaderMap) -> String {
         .and_then(|h| h.to_str().ok())
         .unwrap_or("localhost:4000")
         .to_string()
+}
+
+/// Extract publish date from cached NuGet registration index.
+///
+/// NuGet registration index JSON has nested items:
+/// ```json
+/// { "items": [{ "items": [{ "catalogEntry": { "version": "1.0.0", "published": "2024-01-15T10:30:00Z" } }] }] }
+/// ```
+// TODO(v1.0): trust_upstream_dates config for high-security installs
+async fn extract_nuget_publish_date(
+    storage: &crate::storage::Storage,
+    id: &str,
+    version: &str,
+) -> Option<i64> {
+    let meta_key = format!("nuget/registration/{}/index.json", id.to_lowercase());
+    let data = storage.get(&meta_key).await.ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
+    let pages = json.get("items")?.as_array()?;
+    for page in pages {
+        let items = page.get("items")?.as_array()?;
+        for item in items {
+            let entry = item.get("catalogEntry")?;
+            let ver = entry.get("version")?.as_str()?;
+            if ver.eq_ignore_ascii_case(version) {
+                let date_str = entry.get("published")?.as_str()?;
+                return crate::curation::parse_iso8601_to_unix(date_str);
+            }
+        }
+    }
+    None
 }
 
 fn upstream_url(state: &AppState) -> String {
@@ -553,5 +586,59 @@ mod integration_tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[tokio::test]
+    async fn test_extract_nuget_publish_date_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({
+            "items": [{
+                "items": [{
+                    "catalogEntry": {
+                        "version": "6.0.0",
+                        "published": "2023-11-14T10:30:00Z"
+                    }
+                }]
+            }]
+        });
+        storage
+            .put(
+                "nuget/registration/newtonsoft.json/index.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_nuget_publish_date(&storage, "newtonsoft.json", "6.0.0").await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_extract_nuget_publish_date_version_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({
+            "items": [{"items": [{"catalogEntry": {"version": "1.0.0", "published": "2023-01-01T00:00:00Z"}}]}]
+        });
+        storage
+            .put(
+                "nuget/registration/test/index.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_nuget_publish_date(&storage, "test", "9.9.9").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_extract_nuget_publish_date_no_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let result = super::extract_nuget_publish_date(&storage, "nonexistent", "1.0.0").await;
+        assert!(result.is_none());
     }
 }

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -273,6 +273,9 @@ async fn download_archive(
         );
     }
 
+    // Extract publish date from cached metadata (works for both hosted and proxy)
+    let publish_date = extract_pub_publish_date(&state.storage, &package, version).await;
+
     // Curation check
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -281,7 +284,7 @@ async fn download_archive(
         crate::curation::RegistryType::PubDart,
         &package,
         Some(version),
-        None,
+        publish_date,
     ) {
         return response;
     }
@@ -588,6 +591,30 @@ fn encode_segment(value: &str) -> String {
     utf8_percent_encode(value, PATH_SEGMENT_ENCODE_SET).to_string()
 }
 
+/// Extract publish date from cached pub.dev package metadata.
+///
+/// Pub metadata JSON has a `versions` array, each with `published`:
+/// ```json
+/// { "versions": [{ "version": "1.0.0", "published": "2024-01-15T10:30:00.000Z" }] }
+/// ```
+async fn extract_pub_publish_date(
+    storage: &crate::storage::Storage,
+    package: &str,
+    version: &str,
+) -> Option<i64> {
+    let meta_key = format!("pub/api/packages/{}.json", package);
+    let data = storage.get(&meta_key).await.ok()?;
+    let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
+    let versions = json.get("versions")?.as_array()?;
+    for v in versions {
+        if v.get("version")?.as_str()? == version {
+            let date_str = v.get("published")?.as_str()?;
+            return crate::curation::parse_iso8601_to_unix(date_str);
+        }
+    }
+    None
+}
+
 fn is_valid_pub_package_name(name: &str) -> bool {
     if name.is_empty() || name.len() > 64 {
         return false;
@@ -838,5 +865,57 @@ mod tests {
             .unwrap();
         let json: Value = serde_json::from_slice(&cached).unwrap();
         assert!(json["advisories"].as_array().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_extract_pub_publish_date_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({
+            "name": "http",
+            "versions": [
+                {"version": "0.13.0", "published": "2021-01-08T12:30:00.000Z"},
+                {"version": "1.0.0", "published": "2023-05-15T08:00:00.000Z"}
+            ]
+        });
+        storage
+            .put(
+                "pub/api/packages/http.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_pub_publish_date(&storage, "http", "1.0.0").await;
+        assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_extract_pub_publish_date_version_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({
+            "name": "http",
+            "versions": [{"version": "1.0.0", "published": "2023-05-15T08:00:00Z"}]
+        });
+        storage
+            .put(
+                "pub/api/packages/http.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let result = super::extract_pub_publish_date(&storage, "http", "2.0.0").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_extract_pub_publish_date_no_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let result = super::extract_pub_publish_date(&storage, "nonexistent", "1.0.0").await;
+        assert!(result.is_none());
     }
 }

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -68,7 +68,10 @@ async fn list_packages(
         });
         (
             StatusCode::OK,
-            [(header::CONTENT_TYPE, PEP691_JSON)],
+            [
+                (header::CONTENT_TYPE, PEP691_JSON),
+                (header::CACHE_CONTROL, "public, max-age=60, must-revalidate"),
+            ],
             serde_json::to_string(&body).unwrap_or_default(),
         )
             .into_response()
@@ -81,7 +84,12 @@ async fn list_packages(
             html.push_str(&format!("<a href=\"/simple/{}/\">{}</a><br>\n", pkg, pkg));
         }
         html.push_str("</body></html>");
-        (StatusCode::OK, Html(html)).into_response()
+        (
+            StatusCode::OK,
+            [(header::CACHE_CONTROL, "public, max-age=60, must-revalidate")],
+            Html(html),
+        )
+            .into_response()
     }
 }
 
@@ -228,7 +236,15 @@ async fn download_file(
             .log(AuditEntry::new("cache_hit", "api", "", "pypi", ""));
 
         let content_type = pypi_content_type(&filename);
-        return (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data).into_response();
+        return (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, content_type),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
+            data,
+        )
+            .into_response();
     }
 
     // Try proxy if configured

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -33,6 +33,11 @@ async fn download(
         return StatusCode::NOT_FOUND.into_response();
     }
 
+    let key = format!("raw/{}", path);
+
+    // mtime fallback — Raw is always hosted (no proxy)
+    let publish_date = crate::curation::extract_mtime_as_publish_date(&state.storage, &key).await;
+
     // Curation check — raw files are treated as name=path, no version
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -41,12 +46,10 @@ async fn download(
         crate::curation::RegistryType::Raw,
         &path,
         None,
-        None,
+        publish_date,
     ) {
         return response;
     }
-
-    let key = format!("raw/{}", path);
     match state.storage.get(&key).await {
         Ok(data) => {
             state.metrics.record_download("raw");
@@ -59,7 +62,15 @@ async fn download(
 
             // Guess content type from extension
             let content_type = guess_content_type(&key);
-            (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data).into_response()
+            (
+                StatusCode::OK,
+                [
+                    (header::CONTENT_TYPE, content_type),
+                    (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                ],
+                data,
+            )
+                .into_response()
         }
         Err(_) => StatusCode::NOT_FOUND.into_response(),
     }

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -176,6 +176,9 @@ async fn provider_download_meta(
     let host = extract_host(&state, &headers);
     let artifact = format!("{}/{} v{} {}/{}", ns, ptype, ver, os, arch);
 
+    // Extract publish date from cached metadata
+    let publish_date = extract_terraform_publish_date(&state, &ns, &ptype, &ver).await;
+
     // Curation check
     if let Some(response) = crate::curation::check_download(
         &state.curation,
@@ -184,7 +187,7 @@ async fn provider_download_meta(
         crate::curation::RegistryType::Terraform,
         &format!("{}/{}", ns, ptype),
         Some(&ver),
-        None,
+        publish_date,
     ) {
         return response;
     }
@@ -495,6 +498,42 @@ fn extract_host(state: &AppState, headers: &HeaderMap) -> String {
         .and_then(|h| h.to_str().ok())
         .unwrap_or("localhost:4000")
         .to_string()
+}
+
+/// Extract publish date from cached Terraform provider versions metadata.
+///
+/// Terraform registry API does not reliably include `published_at` in the
+/// versions listing. Falls back to mtime for hosted-only mode.
+// TODO(v1.0): trust_upstream_dates config for high-security installs
+async fn extract_terraform_publish_date(
+    state: &AppState,
+    ns: &str,
+    ptype: &str,
+    ver: &str,
+) -> Option<i64> {
+    // Try download metadata JSON (per-version cached file)
+    let storage_key = format!("terraform/providers/{}/{}/{}/download.json", ns, ptype, ver);
+    if let Ok(data) = state.storage.get(&storage_key).await {
+        if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&data) {
+            if let Some(date_str) = json.get("published_at").and_then(|v| v.as_str()) {
+                return crate::curation::parse_iso8601_to_unix(date_str);
+            }
+        }
+    }
+
+    // mtime fallback — only for hosted mode (proxy mtime = cache time)
+    if state.config.terraform.proxy.is_none() {
+        // Try any cached platform-specific metadata
+        for suffix in &["linux_amd64.json", "linux_arm64.json", "darwin_amd64.json"] {
+            let meta_key = format!("terraform/providers/{}/{}/{}/{}", ns, ptype, ver, suffix);
+            if let Some(ts) =
+                crate::curation::extract_mtime_as_publish_date(&state.storage, &meta_key).await
+            {
+                return Some(ts);
+            }
+        }
+    }
+    None
 }
 
 fn upstream_url(state: &AppState) -> String {

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -51,6 +51,8 @@ pub trait StorageBackend: Send + Sync {
     /// Total size of all stored artifacts in bytes
     async fn total_size(&self) -> u64;
     fn backend_name(&self) -> &'static str;
+    /// Refresh any cached size data. No-op for backends without caching.
+    async fn refresh_total_size(&self) {}
 }
 
 /// Storage wrapper for dynamic dispatch with integrity verification.
@@ -76,6 +78,7 @@ impl Storage {
         access_key: Option<&str>,
         secret_key: Option<&str>,
     ) -> Self {
+        tracing::warn!("Hash pin store disabled for S3 backend — integrity verification unavailable");
         Self {
             inner: Arc::new(S3Storage::new(
                 s3_url, bucket, region, access_key, secret_key,
@@ -146,5 +149,10 @@ impl Storage {
     /// Number of pinned hashes (0 if pin store is disabled).
     pub fn pinned_count(&self) -> usize {
         self.pin_store.as_ref().map_or(0, |p| p.len())
+    }
+
+    /// Refresh cached total_size. No-op for local storage, computes for S3.
+    pub async fn refresh_total_size_cache(&self) {
+        self.inner.refresh_total_size().await;
     }
 }

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -78,7 +78,9 @@ impl Storage {
         access_key: Option<&str>,
         secret_key: Option<&str>,
     ) -> Self {
-        tracing::warn!("Hash pin store disabled for S3 backend — integrity verification unavailable");
+        tracing::warn!(
+            "Hash pin store disabled for S3 backend — integrity verification unavailable"
+        );
         Self {
             inner: Arc::new(S3Storage::new(
                 s3_url, bucket, region, access_key, secret_key,

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -150,6 +150,7 @@ impl S3Storage {
 
     fn parse_s3_keys(xml: &str, prefix: &str) -> Vec<String> {
         xml.split("<Key>")
+            .skip(1) // first element is the preamble before any <Key>
             .filter_map(|part| part.split("</Key>").next())
             .filter(|key| key.starts_with(prefix))
             .map(String::from)
@@ -255,7 +256,6 @@ impl S3Storage {
             _ => None,
         }
     }
-
 }
 
 /// URL-encode a string for S3 canonical URI (encode all except A-Za-z0-9-_.~/)
@@ -345,8 +345,7 @@ impl StorageBackend for S3Storage {
                 None => break,
             };
 
-            let (keys, is_truncated, next_token) =
-                Self::parse_s3_list_response(&xml, prefix);
+            let (keys, is_truncated, next_token) = Self::parse_s3_list_response(&xml, prefix);
             all_keys.extend(keys);
 
             if !is_truncated {
@@ -520,8 +519,7 @@ mod tests {
             <Contents><Key>docker/a</Key></Contents>
             <Contents><Key>docker/b</Key></Contents>
         </ListBucketResult>"#;
-        let (keys, is_truncated, next_token) =
-            S3Storage::parse_s3_list_response(xml, "docker/");
+        let (keys, is_truncated, next_token) = S3Storage::parse_s3_list_response(xml, "docker/");
         assert_eq!(keys, vec!["docker/a", "docker/b"]);
         assert!(!is_truncated);
         assert!(next_token.is_none());
@@ -535,8 +533,7 @@ mod tests {
             <NextContinuationToken>abc123</NextContinuationToken>
             <Contents><Key>docker/a</Key></Contents>
         </ListBucketResult>"#;
-        let (keys, is_truncated, next_token) =
-            S3Storage::parse_s3_list_response(xml, "docker/");
+        let (keys, is_truncated, next_token) = S3Storage::parse_s3_list_response(xml, "docker/");
         assert_eq!(keys, vec!["docker/a"]);
         assert!(is_truncated);
         assert_eq!(next_token, Some("abc123".to_string()));
@@ -548,8 +545,7 @@ mod tests {
         <ListBucketResult>
             <IsTruncated>false</IsTruncated>
         </ListBucketResult>"#;
-        let (keys, is_truncated, next_token) =
-            S3Storage::parse_s3_list_response(xml, "");
+        let (keys, is_truncated, next_token) = S3Storage::parse_s3_list_response(xml, "");
         assert!(keys.is_empty());
         assert!(!is_truncated);
         assert!(next_token.is_none());

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -19,6 +19,10 @@ pub struct S3Storage {
     access_key: Option<String>,
     secret_key: Option<String>,
     client: reqwest::Client,
+    /// Cached total size in bytes, refreshed by background task.
+    cached_total_size: std::sync::atomic::AtomicU64,
+    /// Whether cached_total_size has been initialized at least once.
+    size_cache_initialized: std::sync::atomic::AtomicBool,
 }
 
 impl S3Storage {
@@ -37,6 +41,8 @@ impl S3Storage {
             access_key: access_key.map(String::from),
             secret_key: secret_key.map(String::from),
             client: reqwest::Client::new(),
+            cached_total_size: std::sync::atomic::AtomicU64::new(0),
+            size_cache_initialized: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -149,6 +155,107 @@ impl S3Storage {
             .map(String::from)
             .collect()
     }
+
+    /// Parse S3 ListObjectsV2 response, returning (keys, is_truncated, next_continuation_token).
+    fn parse_s3_list_response(xml: &str, prefix: &str) -> (Vec<String>, bool, Option<String>) {
+        let keys = Self::parse_s3_keys(xml, prefix);
+
+        let is_truncated = xml
+            .split("<IsTruncated>")
+            .nth(1)
+            .and_then(|part| part.split("</IsTruncated>").next())
+            .map(|v| v == "true")
+            .unwrap_or(false);
+
+        let next_token = xml
+            .split("<NextContinuationToken>")
+            .nth(1)
+            .and_then(|part| part.split("</NextContinuationToken>").next())
+            .map(String::from);
+
+        (keys, is_truncated, next_token)
+    }
+
+    /// Make a signed ListObjectsV2 request with optional continuation token.
+    async fn list_objects_page(
+        &self,
+        prefix: &str,
+        continuation_token: Option<&str>,
+    ) -> Option<String> {
+        let mut query = format!("list-type=2&prefix={}", uri_encode(prefix));
+        if let Some(token) = continuation_token {
+            query.push_str(&format!("&continuation-token={}", uri_encode(token)));
+        }
+        let url = format!("{}/{}?{}", self.s3_url, self.bucket, query);
+        let now = Utc::now();
+        let timestamp = now.format("%Y%m%dT%H%M%SZ").to_string();
+        let date = now.format("%Y%m%d").to_string();
+        let payload_hash = hex::encode(Sha256::digest(b""));
+
+        let host = self
+            .s3_url
+            .trim_start_matches("http://")
+            .trim_start_matches("https://");
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("x-amz-date", &timestamp)
+            .header("x-amz-content-sha256", &payload_hash);
+
+        if let (Some(access_key), Some(secret_key)) = (&self.access_key, &self.secret_key) {
+            let canonical_uri = format!("/{}", self.bucket);
+            let canonical_headers = format!(
+                "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
+                host, payload_hash, timestamp
+            );
+            let signed_headers = "host;x-amz-content-sha256;x-amz-date";
+
+            // Canonical query string must be sorted by param name
+            let mut params: Vec<(&str, &str)> = vec![("list-type", "2")];
+            params.push(("prefix", prefix));
+            if let Some(token) = continuation_token {
+                params.push(("continuation-token", token));
+            }
+            params.sort_by_key(|(k, _)| *k);
+            let canonical_query: Vec<String> = params
+                .iter()
+                .map(|(k, v)| format!("{}={}", uri_encode(k), uri_encode(v)))
+                .collect();
+            let canonical_query_str = canonical_query.join("&");
+
+            let canonical_request = format!(
+                "GET\n{}\n{}\n{}\n{}\n{}",
+                canonical_uri, canonical_query_str, canonical_headers, signed_headers, payload_hash
+            );
+
+            let canonical_request_hash =
+                hex::encode(sha2::Sha256::digest(canonical_request.as_bytes()));
+            let credential_scope = format!("{}/{}/s3/aws4_request", date, self.region);
+            let string_to_sign = format!(
+                "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+                timestamp, credential_scope, canonical_request_hash
+            );
+
+            let k_date = hmac_sha256(format!("AWS4{}", secret_key).as_bytes(), date.as_bytes());
+            let k_region = hmac_sha256(&k_date, self.region.as_bytes());
+            let k_service = hmac_sha256(&k_region, b"s3");
+            let k_signing = hmac_sha256(&k_service, b"aws4_request");
+            let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
+
+            let auth = format!(
+                "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+                access_key, credential_scope, signed_headers, signature
+            );
+            request = request.header("Authorization", auth);
+        }
+
+        match request.send().await {
+            Ok(response) if response.status().is_success() => response.text().await.ok(),
+            _ => None,
+        }
+    }
+
 }
 
 /// URL-encode a string for S3 canonical URI (encode all except A-Za-z0-9-_.~/)
@@ -226,69 +333,33 @@ impl StorageBackend for S3Storage {
     }
 
     async fn list(&self, prefix: &str) -> Vec<String> {
-        // For listing, we need to make a request to the bucket
-        let url = format!("{}/{}", self.s3_url, self.bucket);
-        let now = Utc::now();
-        let timestamp = now.format("%Y%m%dT%H%M%SZ").to_string();
-        let date = now.format("%Y%m%d").to_string();
-        let payload_hash = hex::encode(Sha256::digest(b""));
+        let mut all_keys = Vec::new();
+        let mut continuation_token: Option<String> = None;
 
-        let host = self
-            .s3_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
+        loop {
+            let xml = match self
+                .list_objects_page(prefix, continuation_token.as_deref())
+                .await
+            {
+                Some(xml) => xml,
+                None => break,
+            };
 
-        let mut request = self
-            .client
-            .get(&url)
-            .header("x-amz-date", &timestamp)
-            .header("x-amz-content-sha256", &payload_hash);
+            let (keys, is_truncated, next_token) =
+                Self::parse_s3_list_response(&xml, prefix);
+            all_keys.extend(keys);
 
-        // Sign for bucket listing (different path)
-        if let (Some(access_key), Some(secret_key)) = (&self.access_key, &self.secret_key) {
-            let canonical_uri = format!("/{}", self.bucket);
-            let canonical_headers = format!(
-                "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
-                host, payload_hash, timestamp
-            );
-            let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-
-            let canonical_request = format!(
-                "GET\n{}\n\n{}\n{}\n{}",
-                canonical_uri, canonical_headers, signed_headers, payload_hash
-            );
-
-            let canonical_request_hash =
-                hex::encode(sha2::Sha256::digest(canonical_request.as_bytes()));
-            let credential_scope = format!("{}/{}/s3/aws4_request", date, self.region);
-            let string_to_sign = format!(
-                "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-                timestamp, credential_scope, canonical_request_hash
-            );
-
-            let k_date = hmac_sha256(format!("AWS4{}", secret_key).as_bytes(), date.as_bytes());
-            let k_region = hmac_sha256(&k_date, self.region.as_bytes());
-            let k_service = hmac_sha256(&k_region, b"s3");
-            let k_signing = hmac_sha256(&k_service, b"aws4_request");
-            let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
-
-            let auth = format!(
-                "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
-                access_key, credential_scope, signed_headers, signature
-            );
-            request = request.header("Authorization", auth);
-        }
-
-        match request.send().await {
-            Ok(response) if response.status().is_success() => {
-                if let Ok(xml) = response.text().await {
-                    Self::parse_s3_keys(&xml, prefix)
-                } else {
-                    Vec::new()
-                }
+            if !is_truncated {
+                break;
             }
-            _ => Vec::new(),
+            continuation_token = next_token;
+            // Safety: if truncated but no token, break to avoid infinite loop
+            if continuation_token.is_none() {
+                break;
+            }
         }
+
+        all_keys
     }
 
     async fn stat(&self, key: &str) -> Option<FileMeta> {
@@ -383,18 +454,26 @@ impl StorageBackend for S3Storage {
     }
 
     async fn total_size(&self) -> u64 {
+        self.cached_total_size
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "s3"
+    }
+
+    async fn refresh_total_size(&self) {
         let keys = self.list("").await;
-        let mut total = 0u64;
+        let mut total: u64 = 0;
         for key in &keys {
             if let Some(meta) = self.stat(key).await {
                 total += meta.size;
             }
         }
-        total
-    }
-
-    fn backend_name(&self) -> &'static str {
-        "s3"
+        self.cached_total_size
+            .store(total, std::sync::atomic::Ordering::Relaxed);
+        self.size_cache_initialized
+            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -431,6 +510,64 @@ mod tests {
         let xml = r#"<Key>docker/a</Key><Key>docker/b</Key><Key>maven/c</Key>"#;
         let keys = S3Storage::parse_s3_keys(xml, "docker/");
         assert_eq!(keys, vec!["docker/a", "docker/b"]);
+    }
+
+    #[test]
+    fn test_parse_s3_list_response_single_page() {
+        let xml = r#"<?xml version="1.0"?>
+        <ListBucketResult>
+            <IsTruncated>false</IsTruncated>
+            <Contents><Key>docker/a</Key></Contents>
+            <Contents><Key>docker/b</Key></Contents>
+        </ListBucketResult>"#;
+        let (keys, is_truncated, next_token) =
+            S3Storage::parse_s3_list_response(xml, "docker/");
+        assert_eq!(keys, vec!["docker/a", "docker/b"]);
+        assert!(!is_truncated);
+        assert!(next_token.is_none());
+    }
+
+    #[test]
+    fn test_parse_s3_list_response_truncated() {
+        let xml = r#"<?xml version="1.0"?>
+        <ListBucketResult>
+            <IsTruncated>true</IsTruncated>
+            <NextContinuationToken>abc123</NextContinuationToken>
+            <Contents><Key>docker/a</Key></Contents>
+        </ListBucketResult>"#;
+        let (keys, is_truncated, next_token) =
+            S3Storage::parse_s3_list_response(xml, "docker/");
+        assert_eq!(keys, vec!["docker/a"]);
+        assert!(is_truncated);
+        assert_eq!(next_token, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_parse_s3_list_response_empty() {
+        let xml = r#"<?xml version="1.0"?>
+        <ListBucketResult>
+            <IsTruncated>false</IsTruncated>
+        </ListBucketResult>"#;
+        let (keys, is_truncated, next_token) =
+            S3Storage::parse_s3_list_response(xml, "");
+        assert!(keys.is_empty());
+        assert!(!is_truncated);
+        assert!(next_token.is_none());
+    }
+
+    #[test]
+    fn test_s3_total_size_returns_zero_before_init() {
+        let storage = S3Storage::new(
+            "http://localhost:9000",
+            "test-bucket",
+            "us-east-1",
+            Some("access"),
+            Some("secret"),
+        );
+        // Before any refresh, cached total_size is 0
+        assert!(!storage
+            .size_cache_initialized
+            .load(std::sync::atomic::Ordering::Relaxed));
     }
 
     #[test]

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -140,6 +140,7 @@ fn build_context(
             anonymous_read,
             htpasswd_file: String::new(),
             token_storage: tempdir.path().join("tokens").to_str().unwrap().to_string(),
+            trusted_proxies: crate::config::TrustedProxies::default_loopback(),
         },
         rate_limit: RateLimitConfig {
             enabled: false,


### PR DESCRIPTION
## Summary

Closes 9 findings from the v0.8 quality audit + completes curation publish_date for all 13 registries.

**Security (batch3)**
- XFF trusted proxies: CIDR-based forwarding, `NORA_AUTH_TRUSTED_PROXIES` env
- Token API intent tests: verify auth enforcement on write endpoints
- Docker uploads: temp files instead of in-memory Vec (prevents RAM exhaustion on large layers)
- publish_locks eviction: periodic cleanup of stale upload sessions

**Storage (batch3)**
- S3 `list()`: pagination for >1000 keys (ListObjectsV2 continuation tokens)
- S3 `total_size()`: cached with 60s refresh instead of per-request enumeration
- HashPinStore: release write lock before file I/O

**Performance (batch3)**
- Cache-Control headers for all 8 registries (immutable for content-addressed, 60s for metadata)
- S3 pin store warning on startup when using S3 backend

**Curation completeness (batch2)**
- GC metadata phantom cleanup: detect and remove orphaned version entries in npm/PyPI metadata.json
- Publish date extraction for Conan, NuGet, Pub/Dart, Terraform (from cached metadata)
- Publish date mtime fallback for Ansible, Gems (hosted-only mode)
- ISO 8601 parser: non-standard tz offset format (+0000 without colon)

**Quality**
- 907 tests (was 869), 0 new dependencies
- 3 hidden bugs found and fixed during verification:
  - S3 `parse_s3_keys` XML preamble on empty prefix
  - Docker monolithic upload (POST→PUT without PATCH) temp file missing
  - HashPinStore `thread::spawn` race condition in persistence tests

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib --bin nora` — 907 pass
- [x] Negative security tests (25/25 pass) — auth, path traversal, injection, immutability, curation bypass
- [x] API contract tests (17/17 pass, 4 expected skip) — Docker OCI spec, npm, PyPI PEP 503, health, metrics
- [x] semgrep (pre-push gate) — 0 errors