### PR TITLE
ci: bump cargo-deny-action to v2.0.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
       # ── Licenses, banned crates, supply chain policy ────────────────────────
       - name: cargo deny — licenses and banned crates
-        uses: EmbarkStudios/cargo-deny-action@82eb9f621fbc699dd0918f3ea06864c14cc84246 # v2
+        uses: EmbarkStudios/cargo-deny-action@a4d2d701318fdc1c6ae17ba8cea8f329c5110eb2 # v2.0.17
         with:
           command: check
           arguments: --all-features


### PR DESCRIPTION
## Summary
- Bump `EmbarkStudios/cargo-deny-action` from stale SHA `82eb9f6` to `v2.0.17` (`a4d2d70`)
- Previous version fails Docker build: curl/tar download of cargo-deny binary returns exit code 2 (stale release URL in Dockerfile)

Fixes CI Security job failure on main.