### PR TITLE
chore: remove stale advisory ignore from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -4,9 +4,7 @@
 [advisories]
 # Vulnerability database (RustSec)
 db-urls = ["https://github.com/rustsec/advisory-db"]
-ignore = [
-    "RUSTSEC-2025-0119",  # number_prefix unmaintained via indicatif; no fix available. Review by 2026-06-15
-]
+ignore = []
 
 [licenses]
 unused-allowed-license = "allow"


### PR DESCRIPTION
## Summary
- Remove `RUSTSEC-2025-0119` (number_prefix/indicatif) from deny.toml — dependency no longer in tree

## Test plan
- [x] `cargo deny check` → advisories ok, bans ok, licenses ok, sources ok