### PR TITLE
fix: reject non-ASCII characters in storage paths (400 not 500)

### DIFF
--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -228,6 +228,10 @@ async fn upload(
     Path(path): Path<String>,
     body: Bytes,
 ) -> Response {
+    if !path.is_ascii() {
+        return (StatusCode::BAD_REQUEST, "Path must contain only ASCII characters").into_response();
+    }
+
     let key = format!("maven/{}", path);
 
     let artifact_name = path

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -229,7 +229,11 @@ async fn upload(
     body: Bytes,
 ) -> Response {
     if !path.is_ascii() {
-        return (StatusCode::BAD_REQUEST, "Path must contain only ASCII characters").into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            "Path must contain only ASCII characters",
+        )
+            .into_response();
     }
 
     let key = format!("maven/{}", path);

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -85,6 +85,10 @@ async fn upload(
         return StatusCode::NOT_FOUND.into_response();
     }
 
+    if !path.is_ascii() {
+        return (StatusCode::BAD_REQUEST, "Path must contain only ASCII characters").into_response();
+    }
+
     // Check file size limit
     if body.len() as u64 > state.config.raw.max_file_size {
         return (

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -86,7 +86,11 @@ async fn upload(
     }
 
     if !path.is_ascii() {
-        return (StatusCode::BAD_REQUEST, "Path must contain only ASCII characters").into_response();
+        return (
+            StatusCode::BAD_REQUEST,
+            "Path must contain only ASCII characters",
+        )
+            .into_response();
     }
 
     // Check file size limit

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -73,6 +73,11 @@ pub fn validate_storage_key(key: &str) -> Result<(), ValidationError> {
         });
     }
 
+    // Reject non-ASCII characters — all registry paths are ASCII-only
+    if let Some(ch) = key.chars().find(|c| !c.is_ascii()) {
+        return Err(ValidationError::ForbiddenCharacter(ch));
+    }
+
     // Check for null bytes
     if key.contains('\0') {
         return Err(ValidationError::ForbiddenCharacter('\0'));
@@ -362,6 +367,21 @@ mod tests {
             validate_storage_key("foo\0bar"),
             Err(ValidationError::ForbiddenCharacter('\0'))
         ));
+    }
+
+    #[test]
+    fn test_storage_key_non_ascii() {
+        assert!(matches!(
+            validate_storage_key("maven/com/café/1.0/file.jar"),
+            Err(ValidationError::ForbiddenCharacter('é'))
+        ));
+        assert!(matches!(
+            validate_storage_key("raw/ünïcödé.txt"),
+            Err(ValidationError::ForbiddenCharacter(_))
+        ));
+        // ASCII-only paths remain valid
+        assert!(validate_storage_key("maven/com/example/1.0/file.jar").is_ok());
+        assert!(validate_storage_key("raw/file-name_v2.0.tar.gz").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Reject non-ASCII characters in storage keys with 400 Bad Request instead of 500 Internal Server Error
- Affects Maven PUT and Raw PUT handlers — both now validate path encoding before touching storage
- Defense-in-depth: `validate_storage_key()` also rejects non-ASCII for all registries

## Context
OpenAPI fuzz testing (schemathesis) found that `PUT /maven2/café` and `PUT /raw/ünïcödé` returned 500.
All registry path specs (Maven, npm, PyPI, Cargo, Go, Docker) use ASCII-only identifiers — non-ASCII paths are always invalid input.

## Changes
| File | Change |
|------|--------|
| `validation.rs` | Add `!is_ascii()` check to `validate_storage_key()` |
| `maven.rs` | Early-return 400 on non-ASCII path in upload handler |
| `raw.rs` | Early-return 400 on non-ASCII path in upload handler |
| `validation.rs` | Add `test_storage_key_non_ascii` test |

## Test plan
- [x] New test `test_storage_key_non_ascii` — verifies `é`, `ü` rejected with `ForbiddenCharacter`
- [x] Existing proptest `storage_key_never_panics` still passes
- [x] All 908 tests pass