### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,39 @@
 # Changelog
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-02
+
+### Added
+- **Hash Pin Store** — content-addressable integrity verification for all stored artifacts, `put_if_absent()` semantics with NDJSON persistence (#229)
+- **Circuit breaker** — per-registry circuit breaker for upstream proxy connections, returns 503+Retry-After on failures, disabled by default (#229)
+- **Trusted proxy support** — `NORA_TRUSTED_PROXIES` accepts CIDR ranges for X-Forwarded-For extraction (#230)
+- **Cache-Control headers** — proper caching directives for all 13 registry responses (#230)
+- **Docker publish_locks eviction** — automatic cleanup of stale upload locks (#230)
+- **GOVERNANCE.md and ROADMAP.md** — project governance model and public roadmap (#228)
+- **Version consistency gate** — `scripts/pre-commit-check.sh` validates Cargo.toml vs OpenAPI vs Cargo.lock versions, enforced in release pipeline (#224, #225)
+- 908 total tests (up from 851)
+
+### Fixed
+- **Docker proxy timeout** — default timeout raised from 60s/120s to 300s, large image pulls no longer time out (#233)
+- **Unicode path validation** — non-ASCII characters in Maven/Raw upload paths now return 400 instead of 500 (#234)
+- **Docker /v2/ auth** — require authentication per Docker V2 spec (#220)
+- **Token auth timing** — constant-time comparison for token validation (#230)
+- **S3 paginated listing** — storage size calculation now handles >1000 objects correctly (#230)
+- **Docker temp file cleanup** — upload temp files are removed on failure (#230)
+- **OpenAPI schema deduplication** — removed 8 duplicate type definitions (#227)
+- **OpenAPI status codes** — documented 400/409/413/422/503 responses that API already returns (#235)
+
+### Changed
+- Mobile-responsive UI — dashboard grid, hidden table columns on small screens, Raw registry "Files" tab (#218)
+- Startup metric renamed to `startup_duration_ms` with Cold Start display on dashboard (#218)
+- Guardrails: semver-checks, Renovate config, pre-commit hooks, clippy deny rules (#225)
+- cargo-deny-action bumped to v2.0.17 (#231)
+
+### Security
+- Rate limiting hardening for token endpoints (#229)
+- Curation completeness checks for all registry formats (#230)
+- Raw registry glob pattern validation (#230)
+
 ## [0.7.2] - 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.7.3",
+        version = "0.8.0",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
## Summary
- Bump version from 0.7.3 to 0.8.0
- Update Cargo.toml, OpenAPI spec, Cargo.lock
- Add CHANGELOG entry covering 15 commits since v0.7.2

## What's in v0.8.0
- Hash Pin Store for content integrity
- Circuit breaker for upstream proxies
- Docker timeout fix (60s→300s)
- Unicode path validation (500→400)
- Mobile-responsive UI
- Trusted proxy support (CIDR)
- Version consistency gate
- 908 tests (up from 851)

## Test plan
- [x] `scripts/pre-commit-check.sh` — versions consistent
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 908 pass
- [x] Full audit: red team 117/117, schemathesis 0 real 500s, k6 p95=157ms