### PR TITLE
fix: correct release notes — remove unimplemented claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 ### Added
 - **Hash Pin Store** — content-addressable integrity verification for all stored artifacts, `put_if_absent()` semantics with NDJSON persistence (#229)
-- **Circuit breaker** — per-registry circuit breaker for upstream proxy connections, returns 503+Retry-After on failures, disabled by default (#229)
-- **Trusted proxy support** — `NORA_TRUSTED_PROXIES` accepts CIDR ranges for X-Forwarded-For extraction (#230)
-- **Cache-Control headers** — proper caching directives for all 13 registry responses (#230)
+- **Trusted proxy support** — `NORA_AUTH_TRUSTED_PROXIES` accepts CIDR ranges for X-Forwarded-For extraction (#230)
+- **Cache-Control headers** — proper caching directives for proxy registries: Docker, Maven, npm, Cargo, PyPI, Go, Pub, Raw (#230)
+- **Auth rate limiting** — per-IP exponential backoff on failed authentication (429+Retry-After) (#229)
 - **Docker publish_locks eviction** — automatic cleanup of stale upload locks (#230)
 - **GOVERNANCE.md and ROADMAP.md** — project governance model and public roadmap (#228)
 - **Version consistency gate** — `scripts/pre-commit-check.sh` validates Cargo.toml vs OpenAPI vs Cargo.lock versions, enforced in release pipeline (#224, #225)
@@ -17,7 +17,7 @@
 - **Docker proxy timeout** — default timeout raised from 60s/120s to 300s, large image pulls no longer time out (#233)
 - **Unicode path validation** — non-ASCII characters in Maven/Raw upload paths now return 400 instead of 500 (#234)
 - **Docker /v2/ auth** — require authentication per Docker V2 spec (#220)
-- **Token auth timing** — constant-time comparison for token validation (#230)
+- **Curation bypass token timing** — constant-time comparison using `subtle` crate (#230)
 - **S3 paginated listing** — storage size calculation now handles >1000 objects correctly (#230)
 - **Docker temp file cleanup** — upload temp files are removed on failure (#230)
 - **OpenAPI schema deduplication** — removed 8 duplicate type definitions (#227)
@@ -84,7 +84,7 @@
   - Blocklist/allowlist rules with glob patterns and namespace isolation
   - Three modes: `off` (passthrough), `audit` (log only), `enforce` (block downloads)
   - Integrity verification via SHA256/SHA512 checksums
-  - CVE blocking via OSV.dev integration
+  - CVE blocking via blocklist rules (manual CVE entries)
   - CLI tools: `nora curation validate`, `nora curation explain`
 - RubyGems proxy registry (`/gems/`) — compact index, gem/gemspec immutable caching, TTL-based index refresh (#141)
 - Terraform proxy registry (`/terraform/`) — provider/module proxy with service discovery, download_url rewriting (#133)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,26 +12,20 @@ For completed milestones, see [CHANGELOG.md](CHANGELOG.md).
 - **v0.6.0** — Retention policies, garbage collection, Maven immutability
 - **v0.7.0** — 13 registry formats, declarative registry selection, curation layer
 - **v0.7.1** — Min-release-age filter for supply chain protection
-- **v0.7.3** — Circuit breaker for upstream proxies, version consistency gate
+- **v0.7.3** — Docker auth fix, raw directory browser, version consistency gate
+- **v0.8.0** — Hash Pin Store, auth rate limiting, trusted proxies, Cache-Control
 
-## v0.8 — Integrity & Hardening
+## v0.9 — Resilience & Enterprise Auth
 
-Focus: supply chain integrity, platform coverage, security hardening.
+Focus: upstream resilience, production-grade authentication, operational maturity.
 
-- **Hash Pin Store** — immutable hash verification for stored artifacts. Detect tampering at the storage level. ([design](ARCHITECTURE.md))
-- **Auth rate limiting** — per-IP throttling on failed authentication attempts
-- **Publish date extraction** — extend min-release-age to all 13 registry formats (currently: npm, PyPI, Cargo, Go)
-- **Metadata cleanup** — automatic removal of metadata entries with zero versions
-- **arm64 support** — Linux arm64 binary and multi-arch Docker image ([#193](https://github.com/getnora-io/nora/issues/193))
-- **Token UI auth fix** — token management requires authentication regardless of anonymous_read setting ([#221](https://github.com/getnora-io/nora/issues/221))
-
-## v0.9 — Enterprise Auth
-
-Focus: production-grade authentication for CI/CD pipelines and corporate environments.
-
+- **Circuit breaker** — per-registry circuit breaker for upstream proxy connections (503+Retry-After on failures, half-open recovery)
+- **Cache-Control completeness** — extend caching headers to remaining registries (Ansible, Conan, Gems, NuGet, Terraform)
+- **Streaming read_timeout** — per-chunk timeout for large blob downloads instead of total request timeout
 - **OIDC / Workload Identity** — zero-secret auth for GitHub Actions and GitLab CI JWT
 - **Hot reload** — apply curation policy and configuration changes without restart
 - **Audit log to stdout** — structured JSON logs for multi-replica deployments and SIEM integration ([#175](https://github.com/getnora-io/nora/issues/175))
+- **arm64 support** — Linux arm64 binary and multi-arch Docker image ([#193](https://github.com/getnora-io/nora/issues/193))
 
 ## v1.0 — Stability
 


### PR DESCRIPTION
## Summary
Coherence audit found 3 P0 discrepancies between release notes and actual code:

1. **Circuit breaker removed** — claimed in v0.8.0 but zero implementation exists. Moved to v0.9 roadmap
2. **Env var name fixed** — `NORA_TRUSTED_PROXIES` → `NORA_AUTH_TRUSTED_PROXIES` (actual name in code)
3. **Cache-Control scope corrected** — "all 13 registries" → actual 8 registries listed by name
4. **CVE/OSV.dev claim fixed** — "CVE blocking via OSV.dev integration" → "CVE blocking via blocklist rules" (no OSV.dev API client exists)
5. **subtle crate scope clarified** — used for curation bypass token, not general token auth

## Test plan
- [x] No code changes — documentation only
- [x] Release notes already updated on GitHub release page