### PR TITLE
ci: add git-cliff changelog automation and conventional commit enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,29 @@ on:
 permissions: read-all
 
 jobs:
+  conventional-commits:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            ci
+            refactor
+            perf
+            test
+            security
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must follow conventional commits: type(scope): description"
+
   typos:
     name: Typos
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,10 +282,20 @@ jobs:
             --bundle nora-linux-amd64.bundle \
             ./nora-linux-amd64
 
+      - name: Generate changelog with git-cliff
+        id: changelog
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+        env:
+          OUTPUT: CHANGES.md
+          GITHUB_REPO: ${{ github.repository }}
+
       - name: Create Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
-          generate_release_notes: true
+          generate_release_notes: false
           files: |
             nora-linux-amd64
             nora-linux-amd64.sha256
@@ -295,13 +305,9 @@ jobs:
             nora-${{ github.ref_name }}.sbom.spdx.json
             nora-${{ github.ref_name }}.sbom.cdx.json
           body: |
+            ${{ steps.changelog.outputs.content }}
+
             ## Install
-
-            ```bash
-            curl -fsSL https://getnora.io/install.sh | sh
-            ```
-
-            Or download the binary directly:
 
             ```bash
             curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/nora-linux-amd64
@@ -311,26 +317,16 @@ jobs:
 
             ## Docker
 
-            **Alpine (standard):**
             ```bash
             docker pull getnora/nora:${{ steps.ver.outputs.tag }}
-            # or from GHCR:
-            docker pull ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}
             ```
 
-            **RED OS:**
-            ```bash
-            docker pull getnora/nora:${{ steps.ver.outputs.tag }}-redos
-            # or from GHCR:
-            docker pull ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}-redos
-            ```
-
-            **Astra Linux SE:**
-            ```bash
-            docker pull getnora/nora:${{ steps.ver.outputs.tag }}-astra
-            # or from GHCR:
-            docker pull ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}-astra
-            ```
+            | Variant | Image |
+            |---------|-------|
+            | Alpine (default) | `getnora/nora:${{ steps.ver.outputs.tag }}` |
+            | RED OS | `getnora/nora:${{ steps.ver.outputs.tag }}-redos` |
+            | Astra Linux SE | `getnora/nora:${{ steps.ver.outputs.tag }}-astra` |
+            | GHCR | `ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}` |
 
             ## Changelog
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,84 @@
+# git-cliff configuration for NORA
+# https://git-cliff.org/docs/configuration
+#
+# Usage:
+#   git cliff                          # full changelog
+#   git cliff --unreleased             # changes since last tag
+#   git cliff --latest                 # latest tag only
+#   git cliff v0.7.3..v0.8.0          # specific range
+#   git cliff --unreleased -o /dev/stdout  # preview without overwriting
+
+[changelog]
+header = """# Changelog
+
+All notable changes to NORA are documented in this file.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).\n
+"""
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits
+| filter(attribute="scope")
+| sort(attribute="scope") %}
+- **{{ commit.scope }}** — {{ commit.message | split(pat="\n") | first | upper_first }}
+{%- endfor -%}
+{% for commit in commits %}
+{%- if not commit.scope %}
+- {{ commit.message | split(pat="\n") | first | upper_first }}
+{%- endif -%}
+{%- endfor -%}
+{% endfor %}\n
+"""
+footer = ""
+trim = true
+postprocessors = [
+  # Link PR references: (#123) -> ([#123](url))
+  { pattern = '\(#(\d+)\)', replace = "([#${1}](https://github.com/getnora-io/nora/pull/${1}))" },
+]
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+commit_preprocessors = [
+  # Strip PR number suffix — postprocessor will re-link them
+  { pattern = '\s*\(#\d+\)\s*$', replace = "" },
+  # Normalize non-conventional commits that start with a common verb
+  { pattern = '^[Aa]dd\s', replace = "feat: add " },
+  { pattern = '^[Ff]ix\s', replace = "fix: fix " },
+  { pattern = '^[Uu]pdate\s', replace = "docs: update " },
+  { pattern = '^[Rr]emove\s', replace = "refactor: remove " },
+  { pattern = '^[Bb]ump\s', replace = "chore: bump " },
+]
+commit_parsers = [
+  # Skip noise
+  { message = "^chore\\(deps\\)", group = "<!-- 90 -->Dependencies" },
+  { message = "^chore: bump version", skip = true },
+  { message = "^chore: release", skip = true },
+  { message = "^Merge", skip = true },
+
+  # Map conventional types to Keep a Changelog sections
+  { message = "^feat", group = "<!-- 0 -->Added" },
+  { message = "^fix", group = "<!-- 1 -->Fixed" },
+  { message = "^security", group = "<!-- 2 -->Security" },
+  { message = "^refactor", group = "<!-- 3 -->Changed" },
+  { message = "^perf", group = "<!-- 3 -->Changed" },
+  { message = "^docs", group = "<!-- 4 -->Documentation" },
+  { message = "^ci", group = "<!-- 5 -->CI" },
+  { message = "^chore", group = "<!-- 6 -->Maintenance" },
+  { message = "^test", group = "<!-- 7 -->Testing" },
+
+  # Catch-all for non-conventional commits (anti-phantom: nothing is hidden)
+  { message = ".*", group = "<!-- 8 -->Other" },
+]
+protect_breaking_commits = false
+filter_commits = false
+topo_order = false
+sort_commits = "oldest"
+tag_pattern = "v[0-9].*"


### PR DESCRIPTION
## Summary

- Add `cliff.toml` configuration for git-cliff changelog generator
- Add conventional commit PR title enforcement to CI (`amannn/action-semantic-pull-request`)
- Replace hardcoded release notes body in `release.yml` with git-cliff auto-generated changelog

## Motivation

Coherence audit of v0.5-v0.8 release notes revealed features documented but never merged to main. Auto-generating release notes from git log between tags eliminates phantom features by construction.

## What changed

### cliff.toml
- Maps conventional commit types to Keep a Changelog sections (Added/Fixed/Changed/Security/Documentation/CI/Maintenance)
- Preprocessors normalize non-conventional commit messages
- Postprocessors auto-link PR references
- Catch-all group for non-conventional commits ensures nothing is hidden

### ci.yml
- New Conventional Commits job (PR-only): validates PR title matches type(scope): description format
- Allowed types: feat, fix, docs, chore, ci, refactor, perf, test, security

### release.yml
- Added orhun/git-cliff-action step to generate changelog from merged commits
- Release body now starts with auto-generated changelog, followed by install/Docker instructions

## Test plan

- [x] git cliff generates correct output for v0.6.4-v0.8.0
- [x] git cliff --latest --strip header produces clean release body
- [x] YAML validation passes for ci.yml and release.yml
- [x] 908 tests pass