### PR TITLE
feat: add Cache-Control headers to remaining 5 registries

### DIFF
--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -312,10 +312,16 @@ fn upstream_url(state: &AppState) -> String {
 fn with_json(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=60, must-revalidate"),
+            ),
+        ],
         data,
     )
         .into_response()
@@ -324,10 +330,16 @@ fn with_json(data: Vec<u8>) -> Response {
 fn with_binary(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/gzip"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/gzip"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=31536000, immutable"),
+            ),
+        ],
         data,
     )
         .into_response()

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -815,10 +815,16 @@ fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
 fn with_json(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=60, must-revalidate"),
+            ),
+        ],
         data,
     )
         .into_response()
@@ -827,10 +833,16 @@ fn with_json(data: Vec<u8>) -> Response {
 fn with_binary(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/octet-stream"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/octet-stream"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=31536000, immutable"),
+            ),
+        ],
         data,
     )
         .into_response()

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -427,7 +427,13 @@ fn upstream_url(state: &AppState) -> String {
 fn with_binary(data: Vec<u8>, content_type: &'static str) -> Response {
     (
         StatusCode::OK,
-        [(header::CONTENT_TYPE, HeaderValue::from_static(content_type))],
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static(content_type)),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=31536000, immutable"),
+            ),
+        ],
         data,
     )
         .into_response()
@@ -436,10 +442,16 @@ fn with_binary(data: Vec<u8>, content_type: &'static str) -> Response {
 fn with_text(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("text/plain; charset=utf-8"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("text/plain; charset=utf-8"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=60, must-revalidate"),
+            ),
+        ],
         data,
     )
         .into_response()

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -326,7 +326,10 @@ async fn flatcontainer_download(
         ));
         return (
             StatusCode::OK,
-            [(header::CONTENT_TYPE, content_type)],
+            [
+                (header::CONTENT_TYPE, content_type),
+                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            ],
             data.to_vec(),
         )
             .into_response();
@@ -375,7 +378,10 @@ async fn flatcontainer_download(
             state.repo_index.invalidate("nuget");
             (
                 StatusCode::OK,
-                [(header::CONTENT_TYPE, content_type)],
+                [
+                    (header::CONTENT_TYPE, content_type),
+                    (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
+                ],
                 bytes.to_vec(),
             )
                 .into_response()
@@ -454,10 +460,16 @@ fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
 fn with_json(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=60, must-revalidate"),
+            ),
+        ],
         data,
     )
         .into_response()

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -77,10 +77,16 @@ async fn service_discovery(State(state): State<Arc<AppState>>, headers: HeaderMa
     });
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=300"),
+            ),
+        ],
         serde_json::to_vec(&json).unwrap_or_default(),
     )
         .into_response()
@@ -556,10 +562,16 @@ fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
 fn with_json(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/json"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=60, must-revalidate"),
+            ),
+        ],
         data,
     )
         .into_response()
@@ -568,10 +580,16 @@ fn with_json(data: Vec<u8>) -> Response {
 fn with_binary(data: Vec<u8>) -> Response {
     (
         StatusCode::OK,
-        [(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/zip"),
-        )],
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/zip"),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=31536000, immutable"),
+            ),
+        ],
         data,
     )
         .into_response()


### PR DESCRIPTION
## Summary
- Add Cache-Control headers to terraform, nuget, gems, conan, and ansible registries
- Apply consistent two-tier caching: immutable for versioned artifacts (1yr), must-revalidate for metadata (60s)
- Terraform discovery endpoint gets 300s cache (slow-changing service config)
- All 13 registries now have proper Cache-Control headers

## Test plan
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --package nora-registry -- -D warnings` passes (0 warnings)
- [x] `cargo test --package nora-registry --lib` passes (38 tests)
- [ ] Verify Cache-Control headers appear in responses via curl

Closes #247