### PR TITLE
fix(s3): add colon to uri_encode whitelist for sha256 digest paths

### DIFF
--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -258,12 +258,12 @@ impl S3Storage {
     }
 }
 
-/// URL-encode a string for S3 canonical URI (encode all except A-Za-z0-9-_.~/)
+/// URL-encode a string for S3 canonical URI (encode all except A-Za-z0-9-_.~/:)
 fn uri_encode(s: &str) -> String {
     let mut result = String::with_capacity(s.len() * 3);
     for c in s.chars() {
         match c {
-            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' => result.push(c),
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' | ':' => result.push(c),
             _ => {
                 for b in c.to_string().as_bytes() {
                     result.push_str(&format!("%{:02X}", b));


### PR DESCRIPTION
## What
Add `:` to `uri_encode` whitelist in S3 storage backend.

## Why
Docker image blobs are addressed as `sha256:<digest>`, where `:` is a valid
path character per RFC 3986. The previous implementation percent-encoded `:`
to `%3A` in the canonical URI, while reqwest sent the raw colon in the actual
HTTP request. Garage S3 rejected all blob GET/PUT/HEAD with `403 Invalid
signature` due to this mismatch.

## Checklist
- [x] Tests pass (`cargo test`)
- [x] No new clippy warnings (`cargo clippy -- -D warnings`)
- [ ] Updated CHANGELOG.md (if user-facing change)
- [ ] New registry? See CONTRIBUTING.md checklist
