### PR TITLE
fix(s3,nuget): S3 key encoding for SeaweedFS, NuGet HTTPS scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,6 +354,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,12 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "cmov"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +495,16 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -536,7 +551,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -556,7 +571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -607,15 +622,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "ctutils"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
-dependencies = [
- "cmov",
 ]
 
 [[package]]
@@ -681,7 +687,6 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid",
  "crypto-common 0.2.1",
- "ctutils",
 ]
 
 [[package]]
@@ -943,6 +948,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -964,7 +970,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.4",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1051,15 +1057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hmac"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
-dependencies = [
- "digest 0.11.2",
-]
-
-[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1148,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1386,6 +1390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1516,16 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -1604,14 +1627,14 @@ dependencies = [
  "clap",
  "criterion",
  "flate2",
+ "futures",
  "governor",
  "hex",
- "hmac",
  "http-body-util",
- "httpdate",
  "indicatif",
  "lazy_static",
- "md-5",
+ "md-5 0.11.0",
+ "object_store",
  "parking_lot",
  "percent-encoding",
  "prometheus",
@@ -1668,6 +1691,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5 0.10.6",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.10.1",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1745,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "page_size"
@@ -1863,7 +1930,7 @@ dependencies = [
  "bit-vec",
  "bitflags",
  "num-traits",
- "rand",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -1914,6 +1981,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quick-xml"
+version = "0.39.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1942,7 +2019,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2000,6 +2077,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2114,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -2123,6 +2217,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
@@ -2135,6 +2230,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2142,12 +2238,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -2234,6 +2332,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2288,10 +2398,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3179,6 +3321,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "gzip"] }
 sha2 = "0.11"
 async-trait = "0.1"
-hmac = "0.13"
 hex = "0.4"
 
 [workspace.lints.clippy]

--- a/nora-registry/Cargo.toml
+++ b/nora-registry/Cargo.toml
@@ -30,15 +30,15 @@ sha2.workspace = true
 sha1 = "0.11"
 md-5 = "0.11"
 async-trait.workspace = true
-hmac.workspace = true
 hex.workspace = true
+object_store = { version = "0.13", features = ["aws"] }
+futures = "0.3"
 toml = "1.1"
 uuid = { version = "1", features = ["v4"] }
 bcrypt = "0.19"
 base64 = "0.22"
 prometheus = "0.14"
 lazy_static = "1.5"
-httpdate = "1"
 utoipa = { version = "5", features = ["axum_extras", "chrono"] }
 utoipa-swagger-ui = { version = "9", features = ["axum", "reqwest"] }
 clap = { version = "4", features = ["derive"] }

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -13,6 +13,7 @@
 //! - [`CurationMetrics`] for raw counters
 
 use crate::config::{CurationConfig, CurationMode};
+use crate::validation::ends_with_ci;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
@@ -473,7 +474,7 @@ pub fn parse_pypi_version(normalized_name: &str, filename: &str) -> Option<Strin
     // For sdist: rest is just "VERSION"
     // Heuristic: version chars are digits, dots, letters (rc, alpha, beta, post, dev)
     // Split at first '-' followed by non-digit (wheel tags like py3, cp39)
-    let version = if filename.ends_with(".whl") {
+    let version = if ends_with_ci(filename, ".whl") {
         rest.split('-').next()?
     } else {
         rest

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -24,6 +24,7 @@ use prometheus::{
 use tracing::info;
 
 use crate::storage::Storage;
+use crate::validation::ends_with_ci;
 
 // ============================================================================
 // Prometheus metrics
@@ -202,7 +203,10 @@ async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
 
     // Parse manifests for referenced digests
     for key in &keys {
-        if !key.contains("/manifests/") || !key.ends_with(".json") || key.ends_with(".meta.json") {
+        if !key.contains("/manifests/")
+            || !ends_with_ci(key, ".json")
+            || ends_with_ci(key, ".meta.json")
+        {
             continue;
         }
 
@@ -257,7 +261,7 @@ async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
 const CHECKSUM_EXTENSIONS: &[&str] = &[".md5", ".sha1", ".sha256", ".sha512"];
 
 fn is_checksum_sidecar(key: &str) -> bool {
-    CHECKSUM_EXTENSIONS.iter().any(|ext| key.ends_with(ext))
+    CHECKSUM_EXTENSIONS.iter().any(|ext| ends_with_ci(key, ext))
 }
 
 fn primary_key_for_checksum(key: &str) -> Option<&str> {
@@ -326,8 +330,8 @@ async fn detect_go_incomplete_versions(storage: &Storage) -> DetectionResult {
     let mut orphans = Vec::new();
     for (version_key, files) in &versions {
         // A complete version has at least .info and .zip (.mod is optional for some modules)
-        let has_info = files.iter().any(|f| f.ends_with(".info"));
-        let has_zip = files.iter().any(|f| f.ends_with(".zip"));
+        let has_info = files.iter().any(|f| ends_with_ci(f, ".info"));
+        let has_zip = files.iter().any(|f| ends_with_ci(f, ".zip"));
         if !has_info || !has_zip {
             info!(
                 "Go incomplete version: {} (has {} of 3 expected files)",
@@ -364,7 +368,7 @@ async fn detect_cargo_orphans(storage: &Storage) -> DetectionResult {
                 index_entries.insert(name.to_string());
                 index_keys.push(key.clone());
             }
-        } else if key.ends_with(".crate") {
+        } else if ends_with_ci(key, ".crate") {
             // cargo/name/version/name-version.crate
             let parts: Vec<&str> = key
                 .strip_prefix("cargo/")
@@ -430,7 +434,7 @@ async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) ->
     let mut npm_tarball_keys: HashSet<String> = HashSet::new();
 
     for key in &npm_keys {
-        if key.ends_with("/metadata.json") {
+        if ends_with_ci(key, "/metadata.json") {
             npm_meta_keys.push(key.clone());
         } else if key.contains("/tarballs/") {
             npm_tarball_keys.insert(key.clone());
@@ -451,12 +455,12 @@ async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) ->
     let mut pypi_file_keys: HashSet<String> = HashSet::new();
 
     for key in &pypi_keys {
-        if key.ends_with("/metadata.json") {
+        if ends_with_ci(key, "/metadata.json") {
             pypi_meta_keys.push(key.clone());
-        } else if !key.ends_with(".sha256")
-            && !key.ends_with(".md5")
-            && !key.ends_with(".sha1")
-            && !key.ends_with(".sha512")
+        } else if !ends_with_ci(key, ".sha256")
+            && !ends_with_ci(key, ".md5")
+            && !ends_with_ci(key, ".sha1")
+            && !ends_with_ci(key, ".sha512")
         {
             pypi_file_keys.insert(key.clone());
         }

--- a/nora-registry/src/mirror/npm.rs
+++ b/nora-registry/src/mirror/npm.rs
@@ -200,11 +200,10 @@ pub async fn mirror_npm_packages(
     let mut handles = Vec::new();
 
     for target in targets {
-        let permit = sem
-            .clone()
-            .acquire_owned()
-            .await
-            .expect("semaphore closed unexpectedly");
+        let permit = match sem.clone().acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => break, // semaphore closed — stop scheduling
+        };
         let client = client.clone();
         let pb = pb.clone();
         let fetched = fetched.clone();

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -12,7 +12,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
+use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, ProxyError};
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -607,17 +607,6 @@ fn is_valid_crate_name(name: &str) -> bool {
     // Only alphanumeric, `-`, `_`
     name.chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-}
-
-/// Construct NORA base URL from config.
-fn nora_base_url(state: &AppState) -> String {
-    if let Some(url) = &state.config.server.public_url {
-        return url.clone();
-    }
-    format!(
-        "http://{}:{}",
-        state.config.server.host, state.config.server.port
-    )
 }
 
 /// Build response with sparse index content-type.

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -6,7 +6,9 @@ use crate::audit::AuditEntry;
 use crate::config::basic_auth_header;
 use crate::registry::docker_auth::DockerAuth;
 use crate::storage::Storage;
-use crate::validation::{validate_digest, validate_docker_name, validate_docker_reference};
+use crate::validation::{
+    ends_with_ci, validate_digest, validate_docker_name, validate_docker_reference,
+};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -932,7 +934,7 @@ async fn list_tags(State(state): State<Arc<AppState>>, Path(name): Path<String>)
                 .and_then(|t| t.strip_suffix(".json"))
                 .map(String::from)
         })
-        .filter(|t| !t.ends_with(".meta") && !t.contains(".meta."))
+        .filter(|t| !ends_with_ci(t, ".meta") && !t.contains(".meta."))
         .collect();
     (StatusCode::OK, Json(json!({"name": name, "tags": tags}))).into_response()
 }

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -13,6 +13,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     extract::{Path, State},
@@ -58,7 +59,7 @@ async fn handle(
     };
 
     // Parse curation coords for .zip downloads (used in both pre-download and integrity checks)
-    let go_curation = if file.ends_with(".zip") {
+    let go_curation = if ends_with_ci(&file, ".zip") {
         let module_name =
             decode_module_path(&module_encoded).unwrap_or_else(|_| module_encoded.clone());
         let version = file
@@ -145,14 +146,14 @@ async fn handle(
     );
 
     // Use longer timeout for .zip files
-    let timeout = if file.ends_with(".zip") {
+    let timeout = if ends_with_ci(&file, ".zip") {
         state.config.go.proxy_timeout_zip
     } else {
         state.config.go.proxy_timeout
     };
 
     // Fetch: binary for .zip, text for everything else
-    let data = if file.ends_with(".zip") {
+    let data = if ends_with_ci(&file, ".zip") {
         proxy_fetch(
             &state.http_client,
             &upstream_url,
@@ -179,7 +180,7 @@ async fn handle(
     match data {
         Ok(bytes) => {
             // Enforce size limit for .zip
-            if file.ends_with(".zip") && bytes.len() as u64 > state.config.go.max_zip_size {
+            if ends_with_ci(&file, ".zip") && bytes.len() as u64 > state.config.go.max_zip_size {
                 tracing::warn!(
                     module = module_encoded,
                     size = bytes.len(),
@@ -332,9 +333,9 @@ fn is_safe_path(path: &str) -> bool {
 
 /// Content-Type for Go proxy responses
 fn content_type_for(file: &str) -> &'static str {
-    if file.ends_with(".info") || file == "@latest" {
+    if ends_with_ci(file, ".info") || file == "@latest" {
         "application/json"
-    } else if file.ends_with(".zip") {
+    } else if ends_with_ci(file, ".zip") {
         "application/zip"
     } else {
         // .mod, @v/list

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -11,6 +11,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -84,10 +85,10 @@ fn classify_path(path: &str) -> MavenPathKind {
 }
 
 fn is_checksum_file(filename: &str) -> bool {
-    filename.ends_with(".md5")
-        || filename.ends_with(".sha1")
-        || filename.ends_with(".sha256")
-        || filename.ends_with(".sha512")
+    ends_with_ci(filename, ".md5")
+        || ends_with_ci(filename, ".sha1")
+        || ends_with_ci(filename, ".sha256")
+        || ends_with_ci(filename, ".sha512")
 }
 
 fn is_snapshot(version: &str) -> bool {
@@ -486,16 +487,16 @@ fn with_content_type(
     path: &str,
     data: Bytes,
 ) -> (StatusCode, [(header::HeaderName, &'static str); 2], Bytes) {
-    let content_type = if path.ends_with(".pom") {
+    let content_type = if ends_with_ci(path, ".pom") {
         "application/xml"
-    } else if path.ends_with(".jar") {
+    } else if ends_with_ci(path, ".jar") {
         "application/java-archive"
-    } else if path.ends_with(".xml") {
+    } else if ends_with_ci(path, ".xml") {
         "application/xml"
-    } else if path.ends_with(".sha1")
-        || path.ends_with(".md5")
-        || path.ends_with(".sha256")
-        || path.ends_with(".sha512")
+    } else if ends_with_ci(path, ".sha1")
+        || ends_with_ci(path, ".md5")
+        || ends_with_ci(path, ".sha256")
+        || ends_with_ci(path, ".sha512")
     {
         "text/plain"
     } else {
@@ -503,9 +504,9 @@ fn with_content_type(
     };
 
     // maven-metadata.xml is mutable; release artifacts are immutable
-    let cache_control = if path.ends_with("maven-metadata.xml")
-        || path.ends_with("maven-metadata.xml.sha1")
-        || path.ends_with("maven-metadata.xml.md5")
+    let cache_control = if ends_with_ci(path, "maven-metadata.xml")
+        || ends_with_ci(path, "maven-metadata.xml.sha1")
+        || ends_with_ci(path, "maven-metadata.xml.md5")
     {
         "public, max-age=60, must-revalidate"
     } else {

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -33,9 +33,29 @@ pub use terraform::routes as terraform_routes;
 
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
+use crate::AppState;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use std::time::Duration;
+
+/// Build NORA base URL from config (for URL rewriting).
+///
+/// Returns `public_url` (trimmed trailing slash) if set,
+/// otherwise constructs `http://host:port`.
+pub(crate) fn nora_base_url(state: &AppState) -> String {
+    state
+        .config
+        .server
+        .public_url
+        .as_deref()
+        .map(|u| u.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| {
+            format!(
+                "http://{}:{}",
+                state.config.server.host, state.config.server.port
+            )
+        })
+}
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -3,7 +3,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
+use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, ProxyError};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -21,16 +21,6 @@ pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/npm/{*path}", get(handle_request))
         .route("/npm/{*path}", put(handle_publish))
-}
-
-/// Build NORA base URL from config (for URL rewriting)
-fn nora_base_url(state: &AppState) -> String {
-    state.config.server.public_url.clone().unwrap_or_else(|| {
-        format!(
-            "http://{}:{}",
-            state.config.server.host, state.config.server.port
-        )
-    })
 }
 
 /// Rewrite tarball URLs in npm metadata to point to NORA.

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -15,11 +15,13 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry::{
+    circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
+};
 use crate::AppState;
 use axum::{
     extract::{Path, State},
-    http::{header, HeaderMap, HeaderValue, StatusCode},
+    http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Router,
@@ -51,8 +53,8 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 // ── Service index ──────────────────────────────────────────────────────
 
-async fn service_index(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
-    let host = extract_host(&state, &headers);
+async fn service_index(State(state): State<Arc<AppState>>) -> Response {
+    let base_url = nora_base_url(&state);
     let proxy_url = upstream_url(&state);
     let url = format!("{}/v3/index.json", proxy_url.trim_end_matches('/'));
 
@@ -69,7 +71,7 @@ async fn service_index(State(state): State<Arc<AppState>>, headers: HeaderMap) -
     {
         Ok(text) => {
             // Rewrite @id URLs to point through NORA
-            let rewritten = rewrite_service_index(&text, &host);
+            let rewritten = rewrite_service_index(&text, &base_url);
 
             state.metrics.record_download("nuget");
             state.metrics.record_cache_miss();
@@ -454,20 +456,6 @@ async fn flatcontainer_download(
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
-fn extract_host(state: &AppState, headers: &HeaderMap) -> String {
-    if let Some(public_url) = &state.config.server.public_url {
-        return public_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://")
-            .to_string();
-    }
-    headers
-        .get("host")
-        .and_then(|h| h.to_str().ok())
-        .unwrap_or("localhost:4000")
-        .to_string()
-}
-
 /// Extract publish date from cached NuGet registration index.
 ///
 /// NuGet registration index JSON has nested items:
@@ -534,20 +522,21 @@ fn with_json(data: Vec<u8>) -> Response {
 }
 
 /// Rewrite known Microsoft NuGet service index URLs with NORA endpoints.
+/// `base_url` is the full NORA base URL including scheme (e.g. `https://artifact.company.local`).
 /// Targets api.nuget.org and azuresearch-{usnc,ussc}.nuget.org specifically.
-fn rewrite_service_index(json_text: &str, host: &str) -> String {
-    let nora_base = format!("http://{}/nuget", host);
-    let nora_query = format!("{}/v3/query", nora_base);
+fn rewrite_service_index(json_text: &str, base_url: &str) -> String {
+    let nora_nuget = format!("{}/nuget", base_url.trim_end_matches('/'));
+    let nora_query = format!("{}/v3/query", nora_nuget);
 
     // Rewrite major service URLs to route through NORA
     json_text
         .replace(
             "https://api.nuget.org/v3-flatcontainer/",
-            &format!("{}/v3/flatcontainer/", nora_base),
+            &format!("{}/v3/flatcontainer/", nora_nuget),
         )
         .replace(
             "https://api.nuget.org/v3/registration5-gz-semver2/",
-            &format!("{}/v3/registration/", nora_base),
+            &format!("{}/v3/registration/", nora_nuget),
         )
         // Rewrite search endpoints to proxy through NORA
         .replace("https://azuresearch-usnc.nuget.org/query", &nora_query)
@@ -595,9 +584,9 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_service_index() {
+    fn test_rewrite_service_index_http() {
         let input = r#"{"resources":[{"@id":"https://api.nuget.org/v3-flatcontainer/","@type":"PackageBaseAddress/3.0.0"}]}"#;
-        let result = rewrite_service_index(input, "nora:4000");
+        let result = rewrite_service_index(input, "http://nora:4000");
         assert!(result.contains("http://nora:4000/nuget/v3/flatcontainer/"));
         assert!(!result.contains("api.nuget.org/v3-flatcontainer/"));
     }
@@ -605,10 +594,20 @@ mod tests {
     #[test]
     fn test_rewrite_service_index_search_urls() {
         let input = r#"{"resources":[{"@id":"https://azuresearch-usnc.nuget.org/query","@type":"SearchQueryService"},{"@id":"https://azuresearch-ussc.nuget.org/query","@type":"SearchQueryService"}]}"#;
-        let result = rewrite_service_index(input, "nora:4000");
+        let result = rewrite_service_index(input, "http://nora:4000");
         assert!(result.contains("http://nora:4000/nuget/v3/query"));
         assert!(!result.contains("azuresearch-usnc.nuget.org"));
         assert!(!result.contains("azuresearch-ussc.nuget.org"));
+    }
+
+    #[test]
+    fn test_rewrite_service_index_https() {
+        let input = r#"{"resources":[{"@id":"https://api.nuget.org/v3-flatcontainer/","@type":"PackageBaseAddress/3.0.0"},{"@id":"https://api.nuget.org/v3/registration5-gz-semver2/","@type":"RegistrationsBaseUrl/3.6.0"}]}"#;
+        let result = rewrite_service_index(input, "https://artifact.company.local");
+        assert!(result.contains("https://artifact.company.local/nuget/v3/flatcontainer/"));
+        assert!(result.contains("https://artifact.company.local/nuget/v3/registration/"));
+        assert!(!result.contains("http://artifact.company.local"));
+        assert!(!result.contains("api.nuget.org"));
     }
 }
 

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -18,6 +18,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
 };
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     extract::{Path, State},
@@ -328,14 +329,14 @@ async fn flatcontainer_download(
     }
 
     // Only serve .nupkg and .nuspec files
-    if !filename.ends_with(".nupkg") && !filename.ends_with(".nuspec") {
+    if !ends_with_ci(filename, ".nupkg") && !ends_with_ci(filename, ".nuspec") {
         return StatusCode::NOT_FOUND.into_response();
     }
 
     let id_lower = id.to_lowercase();
 
     // Curation check for .nupkg downloads
-    if filename.ends_with(".nupkg") {
+    if ends_with_ci(filename, ".nupkg") {
         // Extract publish date from cached registration index
         let publish_date = extract_nuget_publish_date(&state.storage, &id_lower, ver).await;
 
@@ -353,7 +354,7 @@ async fn flatcontainer_download(
     }
 
     let storage_key = format!("nuget/flatcontainer/{}", path.to_lowercase());
-    let content_type = if filename.ends_with(".nuspec") {
+    let content_type = if ends_with_ci(filename, ".nuspec") {
         "application/xml"
     } else {
         "application/octet-stream"
@@ -361,7 +362,7 @@ async fn flatcontainer_download(
 
     // Immutable cache
     if let Ok(data) = state.storage.get(&storage_key).await {
-        if filename.ends_with(".nupkg") {
+        if ends_with_ci(filename, ".nupkg") {
             if let Some(response) = crate::curation::verify_integrity(
                 &state.curation,
                 crate::curation::RegistryType::Nuget,

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -16,7 +16,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
+use crate::registry::{
+    circuit_open_response, nora_base_url as nora_base_url_shared, proxy_fetch, ProxyError,
+};
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -594,13 +596,7 @@ fn nora_version_url(nora_base: &str, package: &str, version: &str) -> String {
 
 /// Build NORA base URL with /pub prefix for URL rewriting.
 fn nora_base_url(state: &AppState) -> String {
-    if let Some(url) = &state.config.server.public_url {
-        return format!("{}/pub", url.trim_end_matches('/'));
-    }
-    format!(
-        "http://{}:{}/pub",
-        state.config.server.host, state.config.server.port
-    )
+    format!("{}/pub", nora_base_url_shared(state))
 }
 
 fn encode_segment(value: &str) -> String {

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -12,6 +12,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text};
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     extract::{Multipart, Path, State},
@@ -21,6 +22,7 @@ use axum::{
     Router,
 };
 use sha2::Digest;
+use std::fmt::Write;
 use std::sync::Arc;
 
 /// PEP 691 JSON content type
@@ -81,7 +83,7 @@ async fn list_packages(
             "<!DOCTYPE html>\n<html><head><title>Simple Index</title></head><body><h1>Simple Index</h1>\n",
         );
         for pkg in pkg_list {
-            html.push_str(&format!("<a href=\"/simple/{}/\">{}</a><br>\n", pkg, pkg));
+            let _ = writeln!(html, "<a href=\"/simple/{}/\">{}</a><br>", pkg, pkg);
         }
         html.push_str("</body></html>");
         (
@@ -112,7 +114,7 @@ async fn package_versions(
     let mut files: Vec<FileEntry> = Vec::new();
     for key in &keys {
         if let Some(filename) = key.strip_prefix(&prefix) {
-            if !filename.is_empty() && !filename.ends_with(".sha256") {
+            if !filename.is_empty() && !ends_with_ci(filename, ".sha256") {
                 let sha256 = state
                     .storage
                     .get(&format!("{}.sha256", key))
@@ -494,10 +496,11 @@ fn versions_html_response(normalized: &str, files: &[FileEntry], base_url: &str)
             .as_ref()
             .map(|h| format!("#sha256={}", h))
             .unwrap_or_default();
-        html.push_str(&format!(
-            "<a href=\"{}/simple/{}/{}{}\">{}</a><br>\n",
+        let _ = writeln!(
+            html,
+            "<a href=\"{}/simple/{}/{}{}\">{}</a><br>",
             base_url, normalized, f.filename, hash_fragment, f.filename
-        ));
+        );
     }
     html.push_str("</body></html>");
 
@@ -542,9 +545,9 @@ fn wants_json(headers: &HeaderMap) -> bool {
 
 /// Content-type for PyPI files.
 fn pypi_content_type(filename: &str) -> &'static str {
-    if filename.ends_with(".whl") {
+    if ends_with_ci(filename, ".whl") {
         "application/zip"
-    } else if filename.ends_with(".tar.gz") || filename.ends_with(".tgz") {
+    } else if ends_with_ci(filename, ".tar.gz") || ends_with_ci(filename, ".tgz") {
         "application/gzip"
     } else {
         "application/octet-stream"
@@ -558,11 +561,11 @@ fn is_valid_pypi_filename(name: &str) -> bool {
         && !name.contains('/')
         && !name.contains('\\')
         && !name.contains('\0')
-        && (name.ends_with(".tar.gz")
-            || name.ends_with(".tgz")
-            || name.ends_with(".whl")
-            || name.ends_with(".zip")
-            || name.ends_with(".egg"))
+        && (ends_with_ci(name, ".tar.gz")
+            || ends_with_ci(name, ".tgz")
+            || ends_with_ci(name, ".whl")
+            || ends_with_ci(name, ".zip")
+            || ends_with_ci(name, ".egg"))
 }
 
 /// Rewrite PyPI links to point to our registry.
@@ -580,10 +583,11 @@ fn rewrite_pypi_links(html: &str, package_name: &str, base_url: &str) -> String 
             if let Some(filename) = extract_filename(url) {
                 // Extract hash fragment from original URL
                 let hash_fragment = url.find('#').map(|pos| &url[pos..]).unwrap_or("");
-                result.push_str(&format!(
+                let _ = write!(
+                    result,
                     "{}/simple/{}/{}{}",
                     base_url, package_name, filename, hash_fragment
-                ));
+                );
             } else {
                 result.push_str(url);
             }
@@ -621,11 +625,11 @@ fn extract_filename(url: &str) -> Option<&str> {
     let url = url.split('#').next()?;
     let filename = url.rsplit('/').next()?;
 
-    if filename.ends_with(".tar.gz")
-        || filename.ends_with(".tgz")
-        || filename.ends_with(".whl")
-        || filename.ends_with(".zip")
-        || filename.ends_with(".egg")
+    if ends_with_ci(filename, ".tar.gz")
+        || ends_with_ci(filename, ".tgz")
+        || ends_with_ci(filename, ".whl")
+        || ends_with_ci(filename, ".zip")
+        || ends_with_ci(filename, ".egg")
     {
         Some(filename)
     } else {

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -11,7 +11,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text};
+use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text};
 use crate::AppState;
 use axum::{
     extract::{Multipart, Path, State},
@@ -97,23 +97,6 @@ async fn list_packages(
 // Package versions
 // ============================================================================
 
-/// Returns base URL for PyPI download links.
-/// Uses public_url if set, otherwise http://host:port.
-fn pypi_base_url(state: &AppState) -> String {
-    state
-        .config
-        .server
-        .public_url
-        .as_deref()
-        .map(|u| u.trim_end_matches('/').to_string())
-        .unwrap_or_else(|| {
-            format!(
-                "http://{}:{}",
-                state.config.server.host, state.config.server.port
-            )
-        })
-}
-
 /// GET /simple/{name}/ — list files for a package (PEP 503 HTML or PEP 691 JSON).
 async fn package_versions(
     State(state): State<Arc<AppState>>,
@@ -123,7 +106,7 @@ async fn package_versions(
     let normalized = normalize_name(&name);
     let prefix = format!("pypi/{}/", normalized);
     let keys = state.storage.list(&prefix).await;
-    let base_url = pypi_base_url(&state);
+    let base_url = nora_base_url(&state);
 
     // Collect files with their hashes
     let mut files: Vec<FileEntry> = Vec::new();

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -12,6 +12,7 @@
 use crate::registry_type::RegistryType;
 use crate::storage::Storage;
 use crate::ui::components::format_timestamp;
+use crate::validation::ends_with_ci;
 use parking_lot::RwLock;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -182,7 +183,7 @@ async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
     let mut repos: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
-        if key.ends_with(".meta.json") {
+        if ends_with_ci(key, ".meta.json") {
             continue;
         }
 
@@ -193,7 +194,7 @@ async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
             let parts: Vec<_> = rest.split('/').collect();
             let manifest_pos = parts.iter().position(|&p| p == "manifests");
             if let Some(pos) = manifest_pos {
-                if pos >= 1 && key.ends_with(".json") {
+                if pos >= 1 && ends_with_ci(key, ".json") {
                     let name = parts[..pos].join("/");
                     let entry = repos.entry(name).or_insert((0, 0, 0));
                     entry.0 += 1;
@@ -265,7 +266,7 @@ async fn build_npm_index(storage: &Storage) -> Vec<RepoInfo> {
         if let Some(rest) = key.strip_prefix("npm/") {
             // Pattern: npm/{package}/tarballs/{file}.tgz
             // Scoped:  npm/@scope/package/tarballs/{file}.tgz
-            if rest.contains("/tarballs/") && key.ends_with(".tgz") {
+            if rest.contains("/tarballs/") && ends_with_ci(key, ".tgz") {
                 let parts: Vec<_> = rest.split('/').collect();
                 if !parts.is_empty() {
                     // Scoped packages: @scope/package → parts[0]="@scope", parts[1]="package"
@@ -296,7 +297,7 @@ async fn build_cargo_index(storage: &Storage) -> Vec<RepoInfo> {
     let mut crates: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
-        if key.ends_with(".crate") {
+        if ends_with_ci(key, ".crate") {
             if let Some(rest) = key.strip_prefix("cargo/") {
                 let parts: Vec<_> = rest.split('/').collect();
                 if !parts.is_empty() {
@@ -351,7 +352,7 @@ async fn build_go_index(storage: &Storage) -> Vec<RepoInfo> {
         if let Some(rest) = key.strip_prefix("go/") {
             // Pattern: go/{module}/@v/{version}.zip
             // Count .zip files as versions (authoritative artifacts)
-            if rest.contains("/@v/") && key.ends_with(".zip") {
+            if rest.contains("/@v/") && ends_with_ci(key, ".zip") {
                 // Extract module path: everything before /@v/
                 if let Some(pos) = rest.rfind("/@v/") {
                     let module = &rest[..pos];

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -17,6 +17,7 @@ use tracing::info;
 
 use crate::config::RetentionRule;
 use crate::storage::Storage;
+use crate::validation::ends_with_ci;
 
 // ============================================================================
 // Prometheus metrics
@@ -244,7 +245,7 @@ async fn collect_docker_versions(storage: &Storage) -> Vec<(String, Vec<VersionE
             if let Some(idx) = rest.find("/manifests/") {
                 let repo = &rest[..idx];
                 let tag_file = &rest[idx + "/manifests/".len()..];
-                if tag_file.ends_with(".json") && !tag_file.ends_with(".meta.json") {
+                if ends_with_ci(tag_file, ".json") && !ends_with_ci(tag_file, ".meta.json") {
                     let tag = tag_file.strip_suffix(".json").unwrap_or(tag_file);
                     repos
                         .entry(repo.to_string())
@@ -285,7 +286,7 @@ async fn collect_npm_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntr
     for key in &all_keys {
         // npm/{package}/tarballs/{file} — each tarball is a "version"
         if let Some(rest) = key.strip_prefix("npm/") {
-            if rest.contains("/tarballs/") && !key.ends_with(".sha256") {
+            if rest.contains("/tarballs/") && !ends_with_ci(key, ".sha256") {
                 let pkg = rest.split("/tarballs/").next().unwrap_or("");
                 if !pkg.is_empty() {
                     packages
@@ -329,7 +330,7 @@ async fn collect_pypi_versions(storage: &Storage) -> Vec<(String, Vec<VersionEnt
 
     for key in &all_keys {
         if let Some(rest) = key.strip_prefix("pypi/") {
-            if !key.ends_with(".sha256") {
+            if !ends_with_ci(key, ".sha256") {
                 let pkg = rest.split('/').next().unwrap_or("");
                 if !pkg.is_empty() {
                     packages

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -3,22 +3,16 @@
 
 use async_trait::async_trait;
 use axum::body::Bytes;
-use chrono::Utc;
-use hmac::{digest::KeyInit, Hmac, Mac};
-use sha2::{Digest, Sha256};
+use futures::TryStreamExt;
+use object_store::aws::{AmazonS3, AmazonS3Builder};
+use object_store::path::Path;
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 
 use super::{FileMeta, Result, StorageBackend, StorageError};
 
-type HmacSha256 = Hmac<Sha256>;
-
-/// S3-compatible storage backend (AWS S3, Ceph RGW, etc.)
+/// S3-compatible storage backend using the `object_store` crate.
 pub struct S3Storage {
-    s3_url: String,
-    bucket: String,
-    region: String,
-    access_key: Option<String>,
-    secret_key: Option<String>,
-    client: reqwest::Client,
+    store: AmazonS3,
     /// Cached total size in bytes, refreshed by background task.
     cached_total_size: std::sync::atomic::AtomicU64,
     /// Whether cached_total_size has been initialized at least once.
@@ -26,7 +20,7 @@ pub struct S3Storage {
 }
 
 impl S3Storage {
-    /// Create new S3 storage with optional credentials
+    /// Create new S3 storage with optional credentials.
     pub fn new(
         s3_url: &str,
         bucket: &str,
@@ -34,462 +28,121 @@ impl S3Storage {
         access_key: Option<&str>,
         secret_key: Option<&str>,
     ) -> Self {
+        let url = s3_url.trim_end_matches('/');
+        let allow_http = url.starts_with("http://");
+
+        let mut builder = AmazonS3Builder::new()
+            .with_endpoint(url)
+            .with_bucket_name(bucket)
+            .with_region(region)
+            .with_allow_http(allow_http)
+            .with_virtual_hosted_style_request(false);
+
+        match (access_key, secret_key) {
+            (Some(ak), Some(sk)) => {
+                builder = builder.with_access_key_id(ak).with_secret_access_key(sk);
+            }
+            _ => {
+                builder = builder.with_skip_signature(true);
+            }
+        }
+
+        let store = builder.build().expect("Failed to build S3 client");
+
         Self {
-            s3_url: s3_url.trim_end_matches('/').to_string(),
-            bucket: bucket.to_string(),
-            region: region.to_string(),
-            access_key: access_key.map(String::from),
-            secret_key: secret_key.map(String::from),
-            client: reqwest::Client::new(),
+            store,
             cached_total_size: std::sync::atomic::AtomicU64::new(0),
             size_cache_initialized: std::sync::atomic::AtomicBool::new(false),
         }
     }
-
-    /// Sign a request using AWS Signature v4
-    fn sign_request(
-        &self,
-        method: &str,
-        path: &str,
-        payload_hash: &str,
-        timestamp: &str,
-        date: &str,
-    ) -> Option<String> {
-        let (access_key, secret_key) = match (&self.access_key, &self.secret_key) {
-            (Some(ak), Some(sk)) => (ak.as_str(), sk.as_str()),
-            _ => return None,
-        };
-
-        // Parse host from URL
-        let host = self
-            .s3_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
-
-        // Canonical request
-        // URI must be URL-encoded (except /)
-        let encoded_path = uri_encode(path);
-        let canonical_uri = format!("/{}/{}", self.bucket, encoded_path);
-        let canonical_query = "";
-        let canonical_headers = format!(
-            "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
-            host, payload_hash, timestamp
-        );
-        let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-
-        // AWS Signature v4 canonical request format:
-        // HTTPMethod\nCanonicalURI\nCanonicalQueryString\nCanonicalHeaders\n\nSignedHeaders\nHashedPayload
-        // Note: CanonicalHeaders already ends with \n, plus blank line before SignedHeaders
-        let canonical_request = format!(
-            "{}\n{}\n{}\n{}\n{}\n{}",
-            method, canonical_uri, canonical_query, canonical_headers, signed_headers, payload_hash
-        );
-
-        let canonical_request_hash =
-            hex::encode(sha2::Sha256::digest(canonical_request.as_bytes()));
-
-        // String to sign
-        let credential_scope = format!("{}/{}/s3/aws4_request", date, self.region);
-        let string_to_sign = format!(
-            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-            timestamp, credential_scope, canonical_request_hash
-        );
-
-        // Calculate signature
-        let k_date = hmac_sha256(format!("AWS4{}", secret_key).as_bytes(), date.as_bytes());
-        let k_region = hmac_sha256(&k_date, self.region.as_bytes());
-        let k_service = hmac_sha256(&k_region, b"s3");
-        let k_signing = hmac_sha256(&k_service, b"aws4_request");
-        let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
-
-        // Authorization header
-        Some(format!(
-            "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
-            access_key, credential_scope, signed_headers, signature
-        ))
-    }
-
-    /// Make a signed request
-    async fn signed_request(
-        &self,
-        method: reqwest::Method,
-        key: &str,
-        body: Option<&[u8]>,
-    ) -> std::result::Result<reqwest::Response, StorageError> {
-        let url = format!("{}/{}/{}", self.s3_url, self.bucket, key);
-        let now = Utc::now();
-        let timestamp = now.format("%Y%m%dT%H%M%SZ").to_string();
-        let date = now.format("%Y%m%d").to_string();
-
-        let payload_hash = match body {
-            Some(data) => hex::encode(Sha256::digest(data)),
-            None => hex::encode(Sha256::digest(b"")),
-        };
-
-        let mut request = self
-            .client
-            .request(method.clone(), &url)
-            .header("x-amz-date", &timestamp)
-            .header("x-amz-content-sha256", &payload_hash);
-
-        if let Some(auth) =
-            self.sign_request(method.as_str(), key, &payload_hash, &timestamp, &date)
-        {
-            request = request.header("Authorization", auth);
-        }
-
-        if let Some(data) = body {
-            request = request.body(data.to_vec());
-        }
-
-        request
-            .send()
-            .await
-            .map_err(|e| StorageError::Network(e.to_string()))
-    }
-
-    fn parse_s3_keys(xml: &str, prefix: &str) -> Vec<String> {
-        xml.split("<Key>")
-            .skip(1) // first element is the preamble before any <Key>
-            .filter_map(|part| part.split("</Key>").next())
-            .filter(|key| key.starts_with(prefix))
-            .map(String::from)
-            .collect()
-    }
-
-    /// Parse S3 ListObjectsV2 response, returning (keys, is_truncated, next_continuation_token).
-    fn parse_s3_list_response(xml: &str, prefix: &str) -> (Vec<String>, bool, Option<String>) {
-        let keys = Self::parse_s3_keys(xml, prefix);
-
-        let is_truncated = xml
-            .split("<IsTruncated>")
-            .nth(1)
-            .and_then(|part| part.split("</IsTruncated>").next())
-            .map(|v| v == "true")
-            .unwrap_or(false);
-
-        let next_token = xml
-            .split("<NextContinuationToken>")
-            .nth(1)
-            .and_then(|part| part.split("</NextContinuationToken>").next())
-            .map(String::from);
-
-        (keys, is_truncated, next_token)
-    }
-
-    /// Make a signed ListObjectsV2 request with optional continuation token.
-    async fn list_objects_page(
-        &self,
-        prefix: &str,
-        continuation_token: Option<&str>,
-    ) -> Option<String> {
-        let mut query = format!("list-type=2&prefix={}", uri_encode_query(prefix));
-        if let Some(token) = continuation_token {
-            query.push_str(&format!("&continuation-token={}", uri_encode_query(token)));
-        }
-        let url = format!("{}/{}?{}", self.s3_url, self.bucket, query);
-        let now = Utc::now();
-        let timestamp = now.format("%Y%m%dT%H%M%SZ").to_string();
-        let date = now.format("%Y%m%d").to_string();
-        let payload_hash = hex::encode(Sha256::digest(b""));
-
-        let host = self
-            .s3_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
-
-        let mut request = self
-            .client
-            .get(&url)
-            .header("x-amz-date", &timestamp)
-            .header("x-amz-content-sha256", &payload_hash);
-
-        if let (Some(access_key), Some(secret_key)) = (&self.access_key, &self.secret_key) {
-            let canonical_uri = format!("/{}", self.bucket);
-            let canonical_headers = format!(
-                "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
-                host, payload_hash, timestamp
-            );
-            let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-
-            // Canonical query string must be sorted by param name
-            let mut params: Vec<(&str, &str)> = vec![("list-type", "2")];
-            params.push(("prefix", prefix));
-            if let Some(token) = continuation_token {
-                params.push(("continuation-token", token));
-            }
-            params.sort_by_key(|(k, _)| *k);
-            let canonical_query: Vec<String> = params
-                .iter()
-                .map(|(k, v)| format!("{}={}", uri_encode_query(k), uri_encode_query(v)))
-                .collect();
-            let canonical_query_str = canonical_query.join("&");
-
-            let canonical_request = format!(
-                "GET\n{}\n{}\n{}\n{}\n{}",
-                canonical_uri, canonical_query_str, canonical_headers, signed_headers, payload_hash
-            );
-
-            let canonical_request_hash =
-                hex::encode(sha2::Sha256::digest(canonical_request.as_bytes()));
-            let credential_scope = format!("{}/{}/s3/aws4_request", date, self.region);
-            let string_to_sign = format!(
-                "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-                timestamp, credential_scope, canonical_request_hash
-            );
-
-            let k_date = hmac_sha256(format!("AWS4{}", secret_key).as_bytes(), date.as_bytes());
-            let k_region = hmac_sha256(&k_date, self.region.as_bytes());
-            let k_service = hmac_sha256(&k_region, b"s3");
-            let k_signing = hmac_sha256(&k_service, b"aws4_request");
-            let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
-
-            let auth = format!(
-                "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
-                access_key, credential_scope, signed_headers, signature
-            );
-            request = request.header("Authorization", auth);
-        }
-
-        match request.send().await {
-            Ok(response) if response.status().is_success() => response.text().await.ok(),
-            Ok(response) => {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                tracing::error!(
-                    %status,
-                    prefix = %prefix,
-                    bucket = %self.bucket,
-                    response_body = %body,
-                    "S3 ListObjectsV2 failed"
-                );
-                None
-            }
-            Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    prefix = %prefix,
-                    bucket = %self.bucket,
-                    s3_url = %self.s3_url,
-                    "S3 ListObjectsV2 request error"
-                );
-                None
-            }
-        }
-    }
 }
 
-/// URL-encode a string for S3 canonical URI (encode all except A-Za-z0-9-_.~/:)
-fn uri_encode(s: &str) -> String {
-    let mut result = String::with_capacity(s.len() * 3);
-    for c in s.chars() {
-        match c {
-            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' | '/' | ':' => result.push(c),
-            _ => {
-                for b in c.to_string().as_bytes() {
-                    result.push_str(&format!("%{:02X}", b));
-                }
-            }
-        }
-    }
-    result
+/// Encode `@` in S3 keys to `_at_` for SeaweedFS compatibility.
+///
+/// SeaweedFS returns 500 on GET/PUT for keys containing `@`
+/// (e.g. npm scoped packages like `npm/@babel/core/...`).
+fn encode_s3_key(key: &str) -> String {
+    key.replace('@', "_at_")
 }
 
-/// Encode a string for use in S3 query parameter values.
-/// Per AWS SigV4 spec, query values must percent-encode everything
-/// except unreserved characters (A-Za-z0-9 - _ . ~).
-/// Unlike `uri_encode`, this does NOT preserve `/` or `:`.
-fn uri_encode_query(s: &str) -> String {
-    let mut result = String::with_capacity(s.len() * 3);
-    for c in s.chars() {
-        match c {
-            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => result.push(c),
-            _ => {
-                for b in c.to_string().as_bytes() {
-                    result.push_str(&format!("%{:02X}", b));
-                }
-            }
-        }
-    }
-    result
+/// Decode `_at_` back to `@` in S3 keys.
+fn decode_s3_key(key: &str) -> String {
+    key.replace("_at_", "@")
 }
 
-fn hmac_sha256(key: &[u8], data: &[u8]) -> Vec<u8> {
-    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC can take key of any size");
-    mac.update(data);
-    mac.finalize().into_bytes().to_vec()
+/// Map object_store errors to StorageError.
+fn map_err(e: object_store::Error) -> StorageError {
+    match e {
+        object_store::Error::NotFound { .. } => StorageError::NotFound,
+        other => StorageError::Network(other.to_string()),
+    }
 }
 
 #[async_trait]
 impl StorageBackend for S3Storage {
     async fn put(&self, key: &str, data: &[u8]) -> Result<()> {
-        let response = self
-            .signed_request(reqwest::Method::PUT, key, Some(data))
-            .await?;
-
-        if response.status().is_success() {
-            Ok(())
-        } else {
-            Err(StorageError::Network(format!(
-                "PUT failed: {}",
-                response.status()
-            )))
-        }
+        let encoded = encode_s3_key(key);
+        let path = Path::from(encoded);
+        let payload = PutPayload::from(data.to_vec());
+        self.store.put(&path, payload).await.map_err(map_err)?;
+        Ok(())
     }
 
     async fn get(&self, key: &str) -> Result<Bytes> {
-        let response = self.signed_request(reqwest::Method::GET, key, None).await?;
-
-        if response.status().is_success() {
-            response
-                .bytes()
-                .await
-                .map_err(|e| StorageError::Network(e.to_string()))
-        } else if response.status().as_u16() == 404 {
-            Err(StorageError::NotFound)
-        } else {
-            Err(StorageError::Network(format!(
-                "GET failed: {}",
-                response.status()
-            )))
-        }
+        let encoded = encode_s3_key(key);
+        let path = Path::from(encoded);
+        let result = self.store.get(&path).await.map_err(map_err)?;
+        let bytes = result.bytes().await.map_err(map_err)?;
+        Ok(bytes)
     }
 
     async fn delete(&self, key: &str) -> Result<()> {
-        let response = self
-            .signed_request(reqwest::Method::DELETE, key, None)
-            .await?;
-
-        if response.status().is_success() || response.status().as_u16() == 204 {
-            Ok(())
-        } else if response.status().as_u16() == 404 {
-            Err(StorageError::NotFound)
-        } else {
-            Err(StorageError::Network(format!(
-                "DELETE failed: {}",
-                response.status()
-            )))
-        }
+        let encoded = encode_s3_key(key);
+        let path = Path::from(encoded);
+        self.store.delete(&path).await.map_err(map_err)?;
+        Ok(())
     }
 
     async fn list(&self, prefix: &str) -> Vec<String> {
-        let mut all_keys = Vec::new();
-        let mut continuation_token: Option<String> = None;
+        let encoded = encode_s3_key(prefix);
+        let prefix_path = Path::from(encoded);
+        let list_prefix = if prefix.is_empty() {
+            None
+        } else {
+            Some(&prefix_path)
+        };
 
-        loop {
-            let xml = match self
-                .list_objects_page(prefix, continuation_token.as_deref())
-                .await
-            {
-                Some(xml) => xml,
-                None => break,
-            };
+        // Collect all objects from the listing stream.
+        let result: std::result::Result<Vec<_>, _> =
+            self.store.list(list_prefix).try_collect().await;
 
-            let (keys, is_truncated, next_token) = Self::parse_s3_list_response(&xml, prefix);
-            all_keys.extend(keys);
-
-            if !is_truncated {
-                break;
-            }
-            continuation_token = next_token;
-            // Safety: if truncated but no token, break to avoid infinite loop
-            if continuation_token.is_none() {
-                break;
-            }
+        match result {
+            Ok(objects) => objects
+                .into_iter()
+                .map(|meta| decode_s3_key(meta.location.as_ref()))
+                .collect(),
+            Err(_) => Vec::new(),
         }
-
-        all_keys
     }
 
     async fn stat(&self, key: &str) -> Option<FileMeta> {
-        let response = self
-            .signed_request(reqwest::Method::HEAD, key, None)
-            .await
-            .ok()?;
+        let encoded = encode_s3_key(key);
+        let path = Path::from(encoded);
+        let meta = self.store.head(&path).await.ok()?;
 
-        if !response.status().is_success() {
-            return None;
-        }
+        let modified = meta.last_modified.timestamp().try_into().unwrap_or(0u64);
 
-        let size = response
-            .headers()
-            .get("content-length")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(0);
-
-        let modified = response
-            .headers()
-            .get("last-modified")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| httpdate::parse_http_date(v).ok())
-            .map(|t| {
-                t.duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs()
-            })
-            .unwrap_or(0);
-
-        Some(FileMeta { size, modified })
+        Some(FileMeta {
+            size: meta.size,
+            modified,
+        })
     }
 
     async fn health_check(&self) -> bool {
-        // Try HEAD on the bucket
-        let url = format!("{}/{}", self.s3_url, self.bucket);
-        let now = Utc::now();
-        let timestamp = now.format("%Y%m%dT%H%M%SZ").to_string();
-        let date = now.format("%Y%m%d").to_string();
-        let payload_hash = hex::encode(Sha256::digest(b""));
-
-        let host = self
-            .s3_url
-            .trim_start_matches("http://")
-            .trim_start_matches("https://");
-
-        let mut request = self
-            .client
-            .head(&url)
-            .header("x-amz-date", &timestamp)
-            .header("x-amz-content-sha256", &payload_hash);
-
-        if let (Some(access_key), Some(secret_key)) = (&self.access_key, &self.secret_key) {
-            let canonical_uri = format!("/{}", self.bucket);
-            let canonical_headers = format!(
-                "host:{}\nx-amz-content-sha256:{}\nx-amz-date:{}\n",
-                host, payload_hash, timestamp
-            );
-            let signed_headers = "host;x-amz-content-sha256;x-amz-date";
-
-            let canonical_request = format!(
-                "HEAD\n{}\n\n{}\n{}\n{}",
-                canonical_uri, canonical_headers, signed_headers, payload_hash
-            );
-
-            let canonical_request_hash =
-                hex::encode(sha2::Sha256::digest(canonical_request.as_bytes()));
-            let credential_scope = format!("{}/{}/s3/aws4_request", date, self.region);
-            let string_to_sign = format!(
-                "AWS4-HMAC-SHA256\n{}\n{}\n{}",
-                timestamp, credential_scope, canonical_request_hash
-            );
-
-            let k_date = hmac_sha256(format!("AWS4{}", secret_key).as_bytes(), date.as_bytes());
-            let k_region = hmac_sha256(&k_date, self.region.as_bytes());
-            let k_service = hmac_sha256(&k_region, b"s3");
-            let k_signing = hmac_sha256(&k_service, b"aws4_request");
-            let signature = hex::encode(hmac_sha256(&k_signing, string_to_sign.as_bytes()));
-
-            let auth = format!(
-                "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
-                access_key, credential_scope, signed_headers, signature
-            );
-            request = request.header("Authorization", auth);
-        }
-
-        match request.send().await {
-            Ok(response) => response.status().is_success() || response.status().as_u16() == 404,
-            Err(_) => false,
-        }
+        // Try listing with no prefix — if the store responds, it's healthy.
+        // Even an empty bucket or a 404 on prefix is fine.
+        let result: std::result::Result<Vec<_>, _> = self.store.list(None).try_collect().await;
+        result.is_ok()
     }
 
     async fn total_size(&self) -> u64 {
@@ -502,17 +155,15 @@ impl StorageBackend for S3Storage {
     }
 
     async fn refresh_total_size(&self) {
-        let keys = self.list("").await;
-        let mut total: u64 = 0;
-        for key in &keys {
-            if let Some(meta) = self.stat(key).await {
-                total += meta.size;
-            }
+        let result: std::result::Result<Vec<_>, _> = self.store.list(None).try_collect().await;
+
+        if let Ok(objects) = result {
+            let total: u64 = objects.iter().map(|m| m.size).sum();
+            self.cached_total_size
+                .store(total, std::sync::atomic::Ordering::Relaxed);
+            self.size_cache_initialized
+                .store(true, std::sync::atomic::Ordering::Relaxed);
         }
-        self.cached_total_size
-            .store(total, std::sync::atomic::Ordering::Relaxed);
-        self.size_cache_initialized
-            .store(true, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -545,53 +196,6 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_s3_keys() {
-        let xml = r#"<Key>docker/a</Key><Key>docker/b</Key><Key>maven/c</Key>"#;
-        let keys = S3Storage::parse_s3_keys(xml, "docker/");
-        assert_eq!(keys, vec!["docker/a", "docker/b"]);
-    }
-
-    #[test]
-    fn test_parse_s3_list_response_single_page() {
-        let xml = r#"<?xml version="1.0"?>
-        <ListBucketResult>
-            <IsTruncated>false</IsTruncated>
-            <Contents><Key>docker/a</Key></Contents>
-            <Contents><Key>docker/b</Key></Contents>
-        </ListBucketResult>"#;
-        let (keys, is_truncated, next_token) = S3Storage::parse_s3_list_response(xml, "docker/");
-        assert_eq!(keys, vec!["docker/a", "docker/b"]);
-        assert!(!is_truncated);
-        assert!(next_token.is_none());
-    }
-
-    #[test]
-    fn test_parse_s3_list_response_truncated() {
-        let xml = r#"<?xml version="1.0"?>
-        <ListBucketResult>
-            <IsTruncated>true</IsTruncated>
-            <NextContinuationToken>abc123</NextContinuationToken>
-            <Contents><Key>docker/a</Key></Contents>
-        </ListBucketResult>"#;
-        let (keys, is_truncated, next_token) = S3Storage::parse_s3_list_response(xml, "docker/");
-        assert_eq!(keys, vec!["docker/a"]);
-        assert!(is_truncated);
-        assert_eq!(next_token, Some("abc123".to_string()));
-    }
-
-    #[test]
-    fn test_parse_s3_list_response_empty() {
-        let xml = r#"<?xml version="1.0"?>
-        <ListBucketResult>
-            <IsTruncated>false</IsTruncated>
-        </ListBucketResult>"#;
-        let (keys, is_truncated, next_token) = S3Storage::parse_s3_list_response(xml, "");
-        assert!(keys.is_empty());
-        assert!(!is_truncated);
-        assert!(next_token.is_none());
-    }
-
-    #[test]
     fn test_s3_total_size_returns_zero_before_init() {
         let storage = S3Storage::new(
             "http://localhost:9000",
@@ -600,106 +204,71 @@ mod tests {
             Some("access"),
             Some("secret"),
         );
-        // Before any refresh, cached total_size is 0
         assert!(!storage
             .size_cache_initialized
             .load(std::sync::atomic::Ordering::Relaxed));
     }
 
     #[test]
-    fn test_hmac_sha256() {
-        let result = hmac_sha256(b"key", b"data");
-        assert!(!result.is_empty());
+    fn test_error_mapping_not_found() {
+        let err = object_store::Error::NotFound {
+            path: "test/key".to_string(),
+            source: "not found".into(),
+        };
+        match map_err(err) {
+            StorageError::NotFound => {}
+            other => panic!("Expected NotFound, got: {:?}", other),
+        }
     }
 
     #[test]
-    fn test_uri_encode_safe_chars() {
-        assert_eq!(uri_encode("hello"), "hello");
-        assert_eq!(uri_encode("foo/bar"), "foo/bar");
-        assert_eq!(uri_encode("test-file_v1.0"), "test-file_v1.0");
-        assert_eq!(uri_encode("a~b"), "a~b");
+    fn test_error_mapping_network() {
+        let err = object_store::Error::Generic {
+            store: "S3",
+            source: "connection refused".into(),
+        };
+        match map_err(err) {
+            StorageError::Network(msg) => {
+                assert!(msg.contains("connection refused"));
+            }
+            other => panic!("Expected Network, got: {:?}", other),
+        }
     }
 
     #[test]
-    fn test_uri_encode_special_chars() {
-        assert_eq!(uri_encode("hello world"), "hello%20world");
-        assert_eq!(uri_encode("file name.txt"), "file%20name.txt");
-    }
-
-    #[test]
-    fn test_uri_encode_query_chars() {
-        assert_eq!(uri_encode("key=value"), "key%3Dvalue");
-        assert_eq!(uri_encode("a&b"), "a%26b");
-        assert_eq!(uri_encode("a+b"), "a%2Bb");
-    }
-
-    #[test]
-    fn test_uri_encode_empty() {
-        assert_eq!(uri_encode(""), "");
-    }
-
-    #[test]
-    fn test_uri_encode_all_safe_ranges() {
-        // A-Z
-        assert_eq!(uri_encode("ABCXYZ"), "ABCXYZ");
-        // a-z
-        assert_eq!(uri_encode("abcxyz"), "abcxyz");
-        // 0-9
-        assert_eq!(uri_encode("0123456789"), "0123456789");
-        // Special safe: - _ . ~ /
-        assert_eq!(uri_encode("-_.~/"), "-_.~/");
-    }
-
-    #[test]
-    fn test_uri_encode_percent() {
-        assert_eq!(uri_encode("%"), "%25");
-        assert_eq!(uri_encode("100%done"), "100%25done");
-    }
-
-    #[test]
-    fn test_uri_encode_colon_for_docker_digests() {
-        // Colon must NOT be encoded — reqwest sends raw ':' in URL paths.
-        // Encoding ':' to '%3A' causes SigV4 signature mismatch with strict
-        // S3 implementations (e.g. Garage) that verify canonical URI byte-for-byte.
-        assert_eq!(uri_encode("sha256:abc123def"), "sha256:abc123def");
+    fn test_encode_s3_key() {
+        assert_eq!(encode_s3_key("npm/@scope/pkg"), "npm/_at_scope/pkg");
         assert_eq!(
-            uri_encode("docker/sha256:abc/blobs/sha256:def456"),
-            "docker/sha256:abc/blobs/sha256:def456"
+            encode_s3_key("npm/@babel/core/metadata.json"),
+            "npm/_at_babel/core/metadata.json"
         );
     }
 
     #[test]
-    fn test_uri_encode_query_encodes_slash() {
-        // Query values must encode '/' as %2F per AWS SigV4 spec.
-        // This is the fix for issue #255.
+    fn test_decode_s3_key() {
+        assert_eq!(decode_s3_key("npm/_at_scope/pkg"), "npm/@scope/pkg");
         assert_eq!(
-            uri_encode_query("maven/com/example"),
-            "maven%2Fcom%2Fexample"
-        );
-        assert_eq!(
-            uri_encode_query("docker/library/nginx"),
-            "docker%2Flibrary%2Fnginx"
+            decode_s3_key("npm/_at_babel/core/metadata.json"),
+            "npm/@babel/core/metadata.json"
         );
     }
 
     #[test]
-    fn test_uri_encode_query_encodes_colon() {
-        // Query values must also encode ':' — unlike path encoding.
-        assert_eq!(uri_encode_query("sha256:abc"), "sha256%3Aabc");
+    fn test_encode_decode_roundtrip() {
+        let keys = [
+            "npm/@scope/pkg",
+            "npm/@babel/core/metadata.json",
+            "simple/key/no-at",
+            "raw/@org/file.txt",
+        ];
+        for key in keys {
+            assert_eq!(decode_s3_key(&encode_s3_key(key)), key);
+        }
     }
 
     #[test]
-    fn test_uri_encode_query_preserves_unreserved() {
-        // Unreserved chars (A-Za-z0-9 - _ . ~) are NOT encoded.
-        assert_eq!(uri_encode_query("hello"), "hello");
-        assert_eq!(uri_encode_query("test-file_v1.0"), "test-file_v1.0");
-        assert_eq!(uri_encode_query("a~b"), "a~b");
-    }
-
-    #[test]
-    fn test_uri_encode_query_special_chars() {
-        assert_eq!(uri_encode_query("a=b"), "a%3Db");
-        assert_eq!(uri_encode_query("a&b"), "a%26b");
-        assert_eq!(uri_encode_query("hello world"), "hello%20world");
+    fn test_encode_no_at() {
+        let key = "npm/chalk/metadata.json";
+        assert_eq!(encode_s3_key(key), key);
     }
 }

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -6,6 +6,7 @@ use super::templates::encode_uri_component;
 use crate::activity_log::ActivityEntry;
 use crate::registry_type::RegistryType;
 use crate::repo_index::RepoInfo;
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use crate::Storage;
 use axum::{
@@ -325,7 +326,7 @@ pub async fn get_docker_detail(state: &AppState, name: &str) -> DockerDetail {
     let mut tags = Vec::new();
     for key in &keys {
         // Skip .meta.json files
-        if key.ends_with(".meta.json") {
+        if ends_with_ci(key, ".meta.json") {
             continue;
         }
 
@@ -567,7 +568,7 @@ pub async fn get_cargo_detail(storage: &Storage, name: &str) -> PackageDetail {
     let keys = storage.list(&prefix).await;
 
     let mut versions = Vec::new();
-    for key in keys.iter().filter(|k| k.ends_with(".crate")) {
+    for key in keys.iter().filter(|k| ends_with_ci(k, ".crate")) {
         if let Some(rest) = key.strip_prefix(&prefix) {
             let parts: Vec<_> = rest.split('/').collect();
             if !parts.is_empty() {
@@ -642,7 +643,7 @@ pub async fn get_go_detail(storage: &Storage, module: &str) -> PackageDetail {
 
     // Also scan for .zip files that might exist without being in the list
     let keys = storage.list(&prefix).await;
-    for key in keys.iter().filter(|k| k.ends_with(".zip")) {
+    for key in keys.iter().filter(|k| ends_with_ci(k, ".zip")) {
         if let Some(rest) = key.strip_prefix(&prefix) {
             if let Some(version) = rest.strip_suffix(".zip") {
                 if !known_versions.iter().any(|v| v == version) {
@@ -838,7 +839,7 @@ async fn get_conan_detail(storage: &Storage, name: &str) -> PackageDetail {
                 let entry = version_data
                     .entry(version.to_string())
                     .or_insert((0, 0, false));
-                let is_content = !key.ends_with("/revisions.json");
+                let is_content = !ends_with_ci(key, "/revisions.json");
                 if let Some(meta) = storage.stat(key).await {
                     if is_content {
                         entry.0 += meta.size;
@@ -927,7 +928,7 @@ async fn get_pub_detail(storage: &Storage, name: &str) -> PackageDetail {
     let mut versions = Vec::new();
 
     for key in &keys {
-        if key.ends_with(".sha256") {
+        if ends_with_ci(key, ".sha256") {
             continue;
         }
         if let Some(rest) = key.strip_prefix(&prefix) {
@@ -995,14 +996,14 @@ fn extract_pypi_version(name: &str, filename: &str) -> Option<String> {
     // Handle both .tar.gz and .whl files
     let clean_name = name.replace('-', "_");
 
-    if filename.ends_with(".tar.gz") {
+    if ends_with_ci(filename, ".tar.gz") {
         // package-1.0.0.tar.gz
         let base = filename.strip_suffix(".tar.gz")?;
         let version = base
             .strip_prefix(&format!("{}-", name))
             .or_else(|| base.strip_prefix(&format!("{}-", clean_name)))?;
         Some(version.to_string())
-    } else if filename.ends_with(".whl") {
+    } else if ends_with_ci(filename, ".whl") {
         // package-1.0.0-py3-none-any.whl
         let parts: Vec<_> = filename.split('-').collect();
         if parts.len() >= 2 {

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -6,6 +6,7 @@ use super::components::*;
 use super::i18n::{get_translations, Lang};
 use crate::repo_index::RepoInfo;
 use crate::tokens::TokenListEntry;
+use std::fmt::Write;
 
 /// Renders the main dashboard page with dark theme
 pub fn render_dashboard(data: &DashboardResponse, lang: Lang, auth_enabled: bool) -> String {
@@ -293,10 +294,13 @@ pub fn render_registry_list_paginated(
 
         // Previous button
         if page > 1 {
-            pages_html.push_str(&format!(
+            let _ = write!(
+                pages_html,
                 r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300">←</a>"##,
-                registry_type, page - 1, limit
-            ));
+                registry_type,
+                page - 1,
+                limit
+            );
         } else {
             pages_html.push_str(r##"<span class="px-3 py-1 rounded bg-slate-800 text-slate-600 cursor-not-allowed">←</span>"##);
         }
@@ -306,10 +310,11 @@ pub fn render_registry_list_paginated(
         let end_page = (start_page + 6).min(total_pages);
 
         if start_page > 1 {
-            pages_html.push_str(&format!(
+            let _ = write!(
+                pages_html,
                 r##"<a href="/ui/{}?page=1&limit={}" class="px-3 py-1 rounded hover:bg-slate-700 text-slate-400">1</a>"##,
                 registry_type, limit
-            ));
+            );
             if start_page > 2 {
                 pages_html.push_str(r##"<span class="px-2 text-slate-600">...</span>"##);
             }
@@ -317,15 +322,17 @@ pub fn render_registry_list_paginated(
 
         for p in start_page..=end_page {
             if p == page {
-                pages_html.push_str(&format!(
+                let _ = write!(
+                    pages_html,
                     r##"<span class="px-3 py-1 rounded bg-blue-600 text-white font-medium">{}</span>"##,
                     p
-                ));
+                );
             } else {
-                pages_html.push_str(&format!(
+                let _ = write!(
+                    pages_html,
                     r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded hover:bg-slate-700 text-slate-400">{}</a>"##,
                     registry_type, p, limit, p
-                ));
+                );
             }
         }
 
@@ -333,18 +340,22 @@ pub fn render_registry_list_paginated(
             if end_page < total_pages - 1 {
                 pages_html.push_str(r##"<span class="px-2 text-slate-600">...</span>"##);
             }
-            pages_html.push_str(&format!(
+            let _ = write!(
+                pages_html,
                 r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded hover:bg-slate-700 text-slate-400">{}</a>"##,
                 registry_type, total_pages, limit, total_pages
-            ));
+            );
         }
 
         // Next button
         if page < total_pages {
-            pages_html.push_str(&format!(
+            let _ = write!(
+                pages_html,
                 r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300">→</a>"##,
-                registry_type, page + 1, limit
-            ));
+                registry_type,
+                page + 1,
+                limit
+            );
         } else {
             pages_html.push_str(r##"<span class="px-3 py-1 rounded bg-slate-800 text-slate-600 cursor-not-allowed">→</span>"##);
         }
@@ -560,16 +571,18 @@ pub fn render_raw_dir(
             .collect::<Vec<_>>()
             .join("/");
         if i == segments.len() - 1 {
-            breadcrumbs.push_str(&format!(
+            let _ = write!(
+                breadcrumbs,
                 r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                 html_escape(seg)
-            ));
+            );
         } else {
-            breadcrumbs.push_str(&format!(
+            let _ = write!(
+                breadcrumbs,
                 r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/raw/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                 crumb_path,
                 html_escape(seg)
-            ));
+            );
         }
     }
 
@@ -676,16 +689,18 @@ pub fn render_maven_dir(
         for (i, seg) in segments.iter().enumerate() {
             let crumb_path = segments[..=i].join("/");
             if i == segments.len() - 1 {
-                breadcrumbs.push_str(&format!(
+                let _ = write!(
+                    breadcrumbs,
                     r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                     html_escape(seg)
-                ));
+                );
             } else {
-                breadcrumbs.push_str(&format!(
+                let _ = write!(
+                    breadcrumbs,
                     r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/maven/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                     crumb_path,
                     html_escape(seg)
-                ));
+                );
             }
         }
     }
@@ -907,16 +922,18 @@ pub fn render_package_detail(
                 .collect::<Vec<_>>()
                 .join("/");
             if i == segments.len() - 1 {
-                crumbs.push_str(&format!(
+                let _ = write!(
+                    crumbs,
                     r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                     html_escape(seg)
-                ));
+                );
             } else {
-                crumbs.push_str(&format!(
+                let _ = write!(
+                    crumbs,
                     r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/raw/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                     crumb_path,
                     html_escape(seg)
-                ));
+                );
             }
         }
         crumbs
@@ -1100,16 +1117,18 @@ pub fn render_maven_detail(
     for (i, seg) in segments.iter().enumerate() {
         let crumb_path = segments[..=i].join("/");
         if i == segments.len() - 1 {
-            breadcrumbs.push_str(&format!(
+            let _ = write!(
+                breadcrumbs,
                 r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                 html_escape(seg)
-            ));
+            );
         } else {
-            breadcrumbs.push_str(&format!(
+            let _ = write!(
+                breadcrumbs,
                 r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/maven/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                 crumb_path,
                 html_escape(seg)
-            ));
+            );
         }
     }
 
@@ -1442,7 +1461,7 @@ pub fn encode_uri_component(s: &str) -> String {
             'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~' => result.push(c),
             _ => {
                 for byte in c.to_string().as_bytes() {
-                    result.push_str(&format!("%{:02X}", byte));
+                    let _ = write!(result, "%{:02X}", byte);
                 }
             }
         }

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -45,6 +45,14 @@ impl fmt::Display for ValidationError {
 
 impl std::error::Error for ValidationError {}
 
+/// Case-insensitive suffix check for file extensions.
+///
+/// Avoids allocating a lowercased copy of the whole string.
+pub fn ends_with_ci(s: &str, suffix: &str) -> bool {
+    s.len() >= suffix.len()
+        && s.as_bytes()[s.len() - suffix.len()..].eq_ignore_ascii_case(suffix.as_bytes())
+}
+
 /// Maximum allowed storage key length
 const MAX_KEY_LENGTH: usize = 1024;
 

--- a/tests/s3-backends/docker-compose.yml
+++ b/tests/s3-backends/docker-compose.yml
@@ -1,0 +1,167 @@
+# S3-backends integration test environment
+# Usage: docker compose up -d && ./test.sh
+#
+# Three S3-compatible backends + three NORA instances:
+#   - RustFS     (MinIO image as stand-in, S3-compatible reference)
+#   - SeaweedFS  (distributed, known issue with @ in keys)
+#   - Garage     (lightweight, self-hosted)
+
+services:
+  # ============================================================
+  # S3 Backends
+  # ============================================================
+
+  rustfs:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  rustfs-init:
+    image: minio/mc:latest
+    depends_on:
+      rustfs:
+        condition: service_healthy
+    entrypoint: >
+      sh -c "
+        mc alias set local http://rustfs:9000 minioadmin minioadmin &&
+        mc mb --ignore-existing local/nora-test
+      "
+
+  seaweedfs:
+    image: chrislusf/seaweedfs:latest
+    command: server -s3 -s3.port=8333 -master.volumeSizeLimitMB=100
+    ports:
+      - "8333:8333"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9333/cluster/status"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  seaweedfs-init:
+    image: minio/mc:latest
+    depends_on:
+      seaweedfs:
+        condition: service_healthy
+    entrypoint: >
+      sh -c "
+        mc alias set sw http://seaweedfs:8333 '' '' --api S3v4 &&
+        mc mb --ignore-existing sw/nora-test
+      "
+
+  garage:
+    image: dxflrs/garage:v1.0.1
+    environment:
+      GARAGE_ALLOW_WORLD_READABLE_SECRETS: "true"
+    ports:
+      - "3900:3900"
+    volumes:
+      - garage-data:/var/lib/garage/data
+      - garage-meta:/var/lib/garage/meta
+      - ./garage.toml:/etc/garage.toml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3903/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  garage-init:
+    image: dxflrs/garage:v1.0.1
+    depends_on:
+      garage:
+        condition: service_healthy
+    volumes:
+      - ./garage.toml:/etc/garage.toml:ro
+    entrypoint: >
+      sh -c "
+        export GARAGE_RPC_HOST=garage:3901 &&
+        sleep 2 &&
+        NODE_ID=$$(garage node id 2>/dev/null | head -1 | cut -d@ -f1) &&
+        garage layout assign -z dc1 -c 1G $$NODE_ID &&
+        garage layout apply --version 1 &&
+        garage key create nora-test-key &&
+        garage bucket create nora-test &&
+        garage bucket allow --read --write --owner nora-test --key nora-test-key
+      "
+
+  # ============================================================
+  # NORA instances (one per backend)
+  # ============================================================
+
+  nora-rustfs:
+    image: nora:local
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      rustfs-init:
+        condition: service_completed_successfully
+    environment:
+      NORA_HOST: "0.0.0.0"
+      NORA_PORT: "5000"
+      NORA_STORAGE_MODE: s3
+      NORA_STORAGE_S3_URL: http://rustfs:9000
+      NORA_STORAGE_BUCKET: nora-test
+      NORA_STORAGE_S3_REGION: us-east-1
+      NORA_STORAGE_S3_ACCESS_KEY: minioadmin
+      NORA_STORAGE_S3_SECRET_KEY: minioadmin
+      NORA_RATE_LIMIT_ENABLED: "false"
+      NORA_PUBLIC_URL: http://localhost:15001
+    ports:
+      - "15001:5000"
+
+  nora-seaweedfs:
+    image: nora:local
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      seaweedfs-init:
+        condition: service_completed_successfully
+    environment:
+      NORA_HOST: "0.0.0.0"
+      NORA_PORT: "5000"
+      NORA_STORAGE_MODE: s3
+      NORA_STORAGE_S3_URL: http://seaweedfs:8333
+      NORA_STORAGE_BUCKET: nora-test
+      NORA_STORAGE_S3_REGION: us-east-1
+      NORA_RATE_LIMIT_ENABLED: "false"
+      NORA_PUBLIC_URL: http://localhost:15002
+    ports:
+      - "15002:5000"
+
+  nora-garage:
+    image: nora:local
+    build:
+      context: ../..
+      dockerfile: docker/Dockerfile
+    depends_on:
+      garage-init:
+        condition: service_completed_successfully
+    environment:
+      NORA_HOST: "0.0.0.0"
+      NORA_PORT: "5000"
+      NORA_STORAGE_MODE: s3
+      NORA_STORAGE_S3_URL: http://garage:3900
+      NORA_STORAGE_BUCKET: nora-test
+      NORA_STORAGE_S3_REGION: garage
+      # Garage credentials populated by garage-init; override here if needed
+      NORA_STORAGE_S3_ACCESS_KEY: ""
+      NORA_STORAGE_S3_SECRET_KEY: ""
+      NORA_RATE_LIMIT_ENABLED: "false"
+      NORA_PUBLIC_URL: http://localhost:15003
+    ports:
+      - "15003:5000"
+
+volumes:
+  garage-data:
+  garage-meta:

--- a/tests/s3-backends/garage.toml
+++ b/tests/s3-backends/garage.toml
@@ -1,0 +1,19 @@
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+
+replication_factor = 1
+
+[rpc]
+bind_addr = "[::]:3901"
+secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+[s3_api]
+s3_region = "garage"
+api_bind_addr = "[::]:3900"
+
+[s3_web]
+bind_addr = "[::]:3902"
+
+[admin]
+api_bind_addr = "[::]:3903"

--- a/tests/s3-backends/test.sh
+++ b/tests/s3-backends/test.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# S3 Backends E2E Test
+# Runs smoke tests against NORA instances backed by different S3 implementations.
+# Prerequisite: docker compose up -d (from this directory)
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+fail() {
+    echo "  FAIL: $1"
+    FAILED=$((FAILED + 1))
+}
+
+pass() {
+    echo "  PASS: $1"
+    PASSED=$((PASSED + 1))
+}
+
+skip() {
+    echo "  SKIP: $1"
+    SKIPPED=$((SKIPPED + 1))
+}
+
+# Wait for a NORA instance to be healthy (up to 30s)
+wait_healthy() {
+    local url="$1"
+    for _ in $(seq 1 30); do
+        if curl -sf "${url}/health" >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
+}
+
+# Run tests for one backend
+test_backend() {
+    local name="$1"
+    local base="$2"
+
+    echo ""
+    echo "=== ${name} (${base}) ==="
+
+    # 1. Health check
+    if ! wait_healthy "$base"; then
+        fail "${name}: health check (not reachable after 30s)"
+        return
+    fi
+    pass "${name}: health check"
+
+    # 2. Raw upload/download — simple key
+    local payload="s3-test-data-$(date +%s)"
+    local http_code
+    http_code=$(echo "$payload" | curl -s -o /dev/null -w "%{http_code}" \
+        -X PUT --data-binary @- "${base}/raw/s3test/simple.txt")
+    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+        pass "${name}: raw upload (simple key)"
+    else
+        fail "${name}: raw upload (simple key) returned ${http_code}"
+    fi
+
+    local content
+    content=$(curl -sf "${base}/raw/s3test/simple.txt" 2>/dev/null || echo "")
+    if [ "$content" = "$payload" ]; then
+        pass "${name}: raw download (simple key)"
+    else
+        fail "${name}: raw download (simple key) mismatch"
+    fi
+
+    # 3. Raw upload/download — key with @ (scoped package path)
+    local at_payload="at-test-data-$(date +%s)"
+    http_code=$(echo "$at_payload" | curl -s -o /dev/null -w "%{http_code}" \
+        -X PUT --data-binary @- "${base}/raw/@scope/test.txt")
+    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+        pass "${name}: raw upload (@ key)"
+    else
+        fail "${name}: raw upload (@ key) returned ${http_code}"
+    fi
+
+    content=$(curl -sf "${base}/raw/@scope/test.txt" 2>/dev/null || echo "")
+    if [ "$content" = "$at_payload" ]; then
+        pass "${name}: raw download (@ key)"
+    else
+        fail "${name}: raw download (@ key) mismatch"
+    fi
+
+    # 4. npm proxy — scoped package @babel/parser
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" "${base}/npm/@babel/parser")
+    if [ "$http_code" = "200" ]; then
+        pass "${name}: npm proxy @babel/parser"
+    else
+        # Some environments lack internet access for proxy
+        skip "${name}: npm proxy @babel/parser (HTTP ${http_code}, may need internet)"
+    fi
+
+    # 5. HEAD on existing object (stat)
+    http_code=$(curl -sf -o /dev/null -w "%{http_code}" --head "${base}/raw/s3test/simple.txt")
+    if [ "$http_code" = "200" ]; then
+        pass "${name}: HEAD existing object"
+    else
+        fail "${name}: HEAD existing object returned ${http_code}"
+    fi
+
+    # 6. 404 on nonexistent
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" "${base}/raw/nonexistent/does-not-exist.bin")
+    if [ "$http_code" = "404" ]; then
+        pass "${name}: 404 on nonexistent"
+    else
+        fail "${name}: nonexistent returned ${http_code}, expected 404"
+    fi
+
+    # 7. Delete
+    curl -sf -X DELETE "${base}/raw/s3test/simple.txt" >/dev/null 2>&1 || true
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" "${base}/raw/s3test/simple.txt")
+    if [ "$http_code" = "404" ]; then
+        pass "${name}: delete object"
+    else
+        fail "${name}: deleted object still returns ${http_code}"
+    fi
+
+    # 8. Binary upload
+    dd if=/dev/urandom bs=1024 count=8 2>/dev/null | \
+        curl -sf -X PUT --data-binary @- "${base}/raw/s3test/binary.bin" >/dev/null 2>&1
+    local bin_size
+    bin_size=$(curl -sf "${base}/raw/s3test/binary.bin" 2>/dev/null | wc -c)
+    if [ "$bin_size" -ge 8000 ]; then
+        pass "${name}: binary upload/download (${bin_size} bytes)"
+    else
+        fail "${name}: binary size expected ~8192, got ${bin_size}"
+    fi
+}
+
+echo "=============================="
+echo "NORA S3 Backends E2E Test"
+echo "=============================="
+
+# Define backends: name → localhost port
+declare -A BACKENDS=(
+    ["RustFS"]=15001
+    ["SeaweedFS"]=15002
+    ["Garage"]=15003
+)
+
+for name in RustFS SeaweedFS Garage; do
+    port="${BACKENDS[$name]}"
+    test_backend "$name" "http://localhost:${port}"
+done
+
+echo ""
+echo "=============================="
+echo "Results: ${PASSED} passed, ${FAILED} failed, ${SKIPPED} skipped"
+echo "=============================="
+
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **S3 key encoding** (#257): transparent `@` → `_at_` encoding in S3 keys for SeaweedFS compatibility. Applied in all StorageBackend methods (put/get/delete/stat/list) with decode on list results.
- **NuGet service index HTTPS** (#256): `rewrite_service_index()` hardcoded `http://` ignoring `public_url` scheme, causing NU1302 on .NET 8+. Replaced `extract_host()` with shared `nora_base_url()` that preserves scheme.
- **Shared `nora_base_url()`**: deduplicated from npm, pypi, cargo, pub_dart into `registry/mod.rs`.
- **S3 e2e test infra**: docker-compose with RustFS, SeaweedFS, Garage + test.sh smoke suite.
- **Repo health**: cargo-deny, CI gates, changelog automation, dependency updates.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 904 passed
- [x] `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- [ ] `cd tests/s3-backends && docker compose up -d && ./test.sh` — S3 backends e2e
- [ ] NuGet with `public_url=https://...` — verify service index uses HTTPS in @id

Closes #256
Closes #257