### PR TITLE
feat: v0.8.1 — UI polish, proxy index reliability, error logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -13,7 +13,6 @@
 //! - [`CurationMetrics`] for raw counters
 
 use crate::config::{CurationConfig, CurationMode};
-use crate::validation::ends_with_ci;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
@@ -474,7 +473,7 @@ pub fn parse_pypi_version(normalized_name: &str, filename: &str) -> Option<Strin
     // For sdist: rest is just "VERSION"
     // Heuristic: version chars are digits, dots, letters (rc, alpha, beta, post, dev)
     // Split at first '-' followed by non-digit (wheel tags like py3, cp39)
-    let version = if ends_with_ci(filename, ".whl") {
+    let version = if filename.ends_with(".whl") {
         rest.split('-').next()?
     } else {
         rest

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -24,7 +24,6 @@ use prometheus::{
 use tracing::info;
 
 use crate::storage::Storage;
-use crate::validation::ends_with_ci;
 
 // ============================================================================
 // Prometheus metrics
@@ -203,10 +202,7 @@ async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
 
     // Parse manifests for referenced digests
     for key in &keys {
-        if !key.contains("/manifests/")
-            || !ends_with_ci(key, ".json")
-            || ends_with_ci(key, ".meta.json")
-        {
+        if !key.contains("/manifests/") || !key.ends_with(".json") || key.ends_with(".meta.json") {
             continue;
         }
 
@@ -261,7 +257,7 @@ async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
 const CHECKSUM_EXTENSIONS: &[&str] = &[".md5", ".sha1", ".sha256", ".sha512"];
 
 fn is_checksum_sidecar(key: &str) -> bool {
-    CHECKSUM_EXTENSIONS.iter().any(|ext| ends_with_ci(key, ext))
+    CHECKSUM_EXTENSIONS.iter().any(|ext| key.ends_with(ext))
 }
 
 fn primary_key_for_checksum(key: &str) -> Option<&str> {
@@ -330,8 +326,8 @@ async fn detect_go_incomplete_versions(storage: &Storage) -> DetectionResult {
     let mut orphans = Vec::new();
     for (version_key, files) in &versions {
         // A complete version has at least .info and .zip (.mod is optional for some modules)
-        let has_info = files.iter().any(|f| ends_with_ci(f, ".info"));
-        let has_zip = files.iter().any(|f| ends_with_ci(f, ".zip"));
+        let has_info = files.iter().any(|f| f.ends_with(".info"));
+        let has_zip = files.iter().any(|f| f.ends_with(".zip"));
         if !has_info || !has_zip {
             info!(
                 "Go incomplete version: {} (has {} of 3 expected files)",
@@ -368,7 +364,7 @@ async fn detect_cargo_orphans(storage: &Storage) -> DetectionResult {
                 index_entries.insert(name.to_string());
                 index_keys.push(key.clone());
             }
-        } else if ends_with_ci(key, ".crate") {
+        } else if key.ends_with(".crate") {
             // cargo/name/version/name-version.crate
             let parts: Vec<&str> = key
                 .strip_prefix("cargo/")
@@ -434,7 +430,7 @@ async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) ->
     let mut npm_tarball_keys: HashSet<String> = HashSet::new();
 
     for key in &npm_keys {
-        if ends_with_ci(key, "/metadata.json") {
+        if key.ends_with("/metadata.json") {
             npm_meta_keys.push(key.clone());
         } else if key.contains("/tarballs/") {
             npm_tarball_keys.insert(key.clone());
@@ -455,12 +451,12 @@ async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) ->
     let mut pypi_file_keys: HashSet<String> = HashSet::new();
 
     for key in &pypi_keys {
-        if ends_with_ci(key, "/metadata.json") {
+        if key.ends_with("/metadata.json") {
             pypi_meta_keys.push(key.clone());
-        } else if !ends_with_ci(key, ".sha256")
-            && !ends_with_ci(key, ".md5")
-            && !ends_with_ci(key, ".sha1")
-            && !ends_with_ci(key, ".sha512")
+        } else if !key.ends_with(".sha256")
+            && !key.ends_with(".md5")
+            && !key.ends_with(".sha1")
+            && !key.ends_with(".sha512")
         {
             pypi_file_keys.insert(key.clone());
         }

--- a/nora-registry/src/mirror/npm.rs
+++ b/nora-registry/src/mirror/npm.rs
@@ -200,10 +200,11 @@ pub async fn mirror_npm_packages(
     let mut handles = Vec::new();
 
     for target in targets {
-        let permit = match sem.clone().acquire_owned().await {
-            Ok(p) => p,
-            Err(_) => break, // semaphore closed — stop scheduling
-        };
+        let permit = sem
+            .clone()
+            .acquire_owned()
+            .await
+            .expect("semaphore closed unexpectedly");
         let client = client.clone();
         let pb = pb.clone();
         let fetched = fetched.clone();

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.8.0",
+        version = "0.8.1",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -12,7 +12,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, ProxyError};
+use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -153,11 +153,13 @@ async fn sparse_index(State(state): State<Arc<AppState>>, Path(path): Path<Strin
             let storage = state.storage.clone();
             let key = index_key;
             let data_clone = data.clone();
+            let state_clone = Arc::clone(&state);
             tokio::spawn(async move {
-                let _ = storage.put(&key, &data_clone).await;
+                if storage.put(&key, &data_clone).await.is_ok() {
+                    state_clone.repo_index.invalidate("cargo");
+                }
             });
 
-            state.repo_index.invalidate("cargo");
             sparse_index_response(data)
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -607,6 +609,17 @@ fn is_valid_crate_name(name: &str) -> bool {
     // Only alphanumeric, `-`, `_`
     name.chars()
         .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Construct NORA base URL from config.
+fn nora_base_url(state: &AppState) -> String {
+    if let Some(url) = &state.config.server.public_url {
+        return url.clone();
+    }
+    format!(
+        "http://{}:{}",
+        state.config.server.host, state.config.server.port
+    )
 }
 
 /// Build response with sparse index content-type.

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -6,9 +6,7 @@ use crate::audit::AuditEntry;
 use crate::config::basic_auth_header;
 use crate::registry::docker_auth::DockerAuth;
 use crate::storage::Storage;
-use crate::validation::{
-    ends_with_ci, validate_digest, validate_docker_name, validate_docker_reference,
-};
+use crate::validation::{validate_digest, validate_docker_name, validate_docker_reference};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -307,11 +305,12 @@ async fn download_blob(
             let storage = state.storage.clone();
             let key_clone = key.clone();
             let data_clone = data.clone();
+            let state_clone = Arc::clone(&state);
             tokio::spawn(async move {
-                let _ = storage.put(&key_clone, &data_clone).await;
+                if storage.put(&key_clone, &data_clone).await.is_ok() {
+                    state_clone.repo_index.invalidate("docker");
+                }
             });
-
-            state.repo_index.invalidate("docker");
 
             return (
                 StatusCode::OK,
@@ -934,7 +933,7 @@ async fn list_tags(State(state): State<Arc<AppState>>, Path(name): Path<String>)
                 .and_then(|t| t.strip_suffix(".json"))
                 .map(String::from)
         })
-        .filter(|t| !ends_with_ci(t, ".meta") && !t.contains(".meta."))
+        .filter(|t| !t.ends_with(".meta") && !t.contains(".meta."))
         .collect();
     (StatusCode::OK, Json(json!({"name": name, "tags": tags}))).into_response()
 }

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -13,7 +13,6 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
-use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     extract::{Path, State},
@@ -59,7 +58,7 @@ async fn handle(
     };
 
     // Parse curation coords for .zip downloads (used in both pre-download and integrity checks)
-    let go_curation = if ends_with_ci(&file, ".zip") {
+    let go_curation = if file.ends_with(".zip") {
         let module_name =
             decode_module_path(&module_encoded).unwrap_or_else(|_| module_encoded.clone());
         let version = file
@@ -146,14 +145,14 @@ async fn handle(
     );
 
     // Use longer timeout for .zip files
-    let timeout = if ends_with_ci(&file, ".zip") {
+    let timeout = if file.ends_with(".zip") {
         state.config.go.proxy_timeout_zip
     } else {
         state.config.go.proxy_timeout
     };
 
     // Fetch: binary for .zip, text for everything else
-    let data = if ends_with_ci(&file, ".zip") {
+    let data = if file.ends_with(".zip") {
         proxy_fetch(
             &state.http_client,
             &upstream_url,
@@ -180,7 +179,7 @@ async fn handle(
     match data {
         Ok(bytes) => {
             // Enforce size limit for .zip
-            if ends_with_ci(&file, ".zip") && bytes.len() as u64 > state.config.go.max_zip_size {
+            if file.ends_with(".zip") && bytes.len() as u64 > state.config.go.max_zip_size {
                 tracing::warn!(
                     module = module_encoded,
                     size = bytes.len(),
@@ -206,18 +205,23 @@ async fn handle(
             let storage = state.storage.clone();
             let key = storage_key.clone();
             let data_clone = bytes.clone();
+            let state_clone = Arc::clone(&state);
             tokio::spawn(async move {
-                if is_immutable {
+                let written = if is_immutable {
                     // Only write if not already cached (immutability guarantee)
                     if storage.stat(&key).await.is_none() {
-                        let _ = storage.put(&key, &data_clone).await;
+                        storage.put(&key, &data_clone).await.is_ok()
+                    } else {
+                        true // already exists
                     }
                 } else {
-                    let _ = storage.put(&key, &data_clone).await;
+                    storage.put(&key, &data_clone).await.is_ok()
+                };
+                if written {
+                    state_clone.repo_index.invalidate("go");
                 }
             });
 
-            state.repo_index.invalidate("go");
             with_content_type(bytes, content_type)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -333,9 +337,9 @@ fn is_safe_path(path: &str) -> bool {
 
 /// Content-Type for Go proxy responses
 fn content_type_for(file: &str) -> &'static str {
-    if ends_with_ci(file, ".info") || file == "@latest" {
+    if file.ends_with(".info") || file == "@latest" {
         "application/json"
-    } else if ends_with_ci(file, ".zip") {
+    } else if file.ends_with(".zip") {
         "application/zip"
     } else {
         // .mod, @v/list

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -11,7 +11,6 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
-use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -85,10 +84,10 @@ fn classify_path(path: &str) -> MavenPathKind {
 }
 
 fn is_checksum_file(filename: &str) -> bool {
-    ends_with_ci(filename, ".md5")
-        || ends_with_ci(filename, ".sha1")
-        || ends_with_ci(filename, ".sha256")
-        || ends_with_ci(filename, ".sha512")
+    filename.ends_with(".md5")
+        || filename.ends_with(".sha1")
+        || filename.ends_with(".sha256")
+        || filename.ends_with(".sha512")
 }
 
 fn is_snapshot(version: &str) -> bool {
@@ -487,16 +486,16 @@ fn with_content_type(
     path: &str,
     data: Bytes,
 ) -> (StatusCode, [(header::HeaderName, &'static str); 2], Bytes) {
-    let content_type = if ends_with_ci(path, ".pom") {
+    let content_type = if path.ends_with(".pom") {
         "application/xml"
-    } else if ends_with_ci(path, ".jar") {
+    } else if path.ends_with(".jar") {
         "application/java-archive"
-    } else if ends_with_ci(path, ".xml") {
+    } else if path.ends_with(".xml") {
         "application/xml"
-    } else if ends_with_ci(path, ".sha1")
-        || ends_with_ci(path, ".md5")
-        || ends_with_ci(path, ".sha256")
-        || ends_with_ci(path, ".sha512")
+    } else if path.ends_with(".sha1")
+        || path.ends_with(".md5")
+        || path.ends_with(".sha256")
+        || path.ends_with(".sha512")
     {
         "text/plain"
     } else {
@@ -504,9 +503,9 @@ fn with_content_type(
     };
 
     // maven-metadata.xml is mutable; release artifacts are immutable
-    let cache_control = if ends_with_ci(path, "maven-metadata.xml")
-        || ends_with_ci(path, "maven-metadata.xml.sha1")
-        || ends_with_ci(path, "maven-metadata.xml.md5")
+    let cache_control = if path.ends_with("maven-metadata.xml")
+        || path.ends_with("maven-metadata.xml.sha1")
+        || path.ends_with("maven-metadata.xml.md5")
     {
         "public, max-age=60, must-revalidate"
     } else {

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -33,29 +33,9 @@ pub use terraform::routes as terraform_routes;
 
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
-use crate::AppState;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use std::time::Duration;
-
-/// Build NORA base URL from config (for URL rewriting).
-///
-/// Returns `public_url` (trimmed trailing slash) if set,
-/// otherwise constructs `http://host:port`.
-pub(crate) fn nora_base_url(state: &AppState) -> String {
-    state
-        .config
-        .server
-        .public_url
-        .as_deref()
-        .map(|u| u.trim_end_matches('/').to_string())
-        .unwrap_or_else(|| {
-            format!(
-                "http://{}:{}",
-                state.config.server.host, state.config.server.port
-            )
-        })
-}
 
 #[derive(Debug)]
 #[allow(dead_code)]

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -3,7 +3,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, ProxyError};
+use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -21,6 +21,16 @@ pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/npm/{*path}", get(handle_request))
         .route("/npm/{*path}", put(handle_publish))
+}
+
+/// Build NORA base URL from config (for URL rewriting)
+fn nora_base_url(state: &AppState) -> String {
+    state.config.server.public_url.clone().unwrap_or_else(|| {
+        format!(
+            "http://{}:{}",
+            state.config.server.host, state.config.server.port
+        )
+    })
 }
 
 /// Rewrite tarball URLs in npm metadata to point to NORA.
@@ -224,18 +234,18 @@ async fn handle_request(
                     data_to_serve = rewritten;
                 }
 
-                // Cache in background
+                // Cache in background, invalidate index AFTER write completes
                 let storage = state.storage.clone();
                 let key_clone = key.clone();
+                let invalidate_npm = is_tarball;
+                let state_clone = Arc::clone(&state);
                 tokio::spawn(async move {
                     if let Err(e) = storage.put(&key_clone, &data_to_cache).await {
                         tracing::warn!(key = %key_clone, error = ?e, "npm proxy: failed to cache artifact");
+                    } else if invalidate_npm {
+                        state_clone.repo_index.invalidate("npm");
                     }
                 });
-
-                if is_tarball {
-                    state.repo_index.invalidate("npm");
-                }
 
                 return with_content_type(is_tarball, data_to_serve.into()).into_response();
             }

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -15,14 +15,11 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{
-    circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
-};
-use crate::validation::ends_with_ci;
+use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
 use crate::AppState;
 use axum::{
     extract::{Path, State},
-    http::{header, HeaderValue, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Router,
@@ -54,8 +51,8 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 // ── Service index ──────────────────────────────────────────────────────
 
-async fn service_index(State(state): State<Arc<AppState>>) -> Response {
-    let base_url = nora_base_url(&state);
+async fn service_index(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    let host = extract_host(&state, &headers);
     let proxy_url = upstream_url(&state);
     let url = format!("{}/v3/index.json", proxy_url.trim_end_matches('/'));
 
@@ -72,7 +69,7 @@ async fn service_index(State(state): State<Arc<AppState>>) -> Response {
     {
         Ok(text) => {
             // Rewrite @id URLs to point through NORA
-            let rewritten = rewrite_service_index(&text, &base_url);
+            let rewritten = rewrite_service_index(&text, &host);
 
             state.metrics.record_download("nuget");
             state.metrics.record_cache_miss();
@@ -329,14 +326,14 @@ async fn flatcontainer_download(
     }
 
     // Only serve .nupkg and .nuspec files
-    if !ends_with_ci(filename, ".nupkg") && !ends_with_ci(filename, ".nuspec") {
+    if !filename.ends_with(".nupkg") && !filename.ends_with(".nuspec") {
         return StatusCode::NOT_FOUND.into_response();
     }
 
     let id_lower = id.to_lowercase();
 
     // Curation check for .nupkg downloads
-    if ends_with_ci(filename, ".nupkg") {
+    if filename.ends_with(".nupkg") {
         // Extract publish date from cached registration index
         let publish_date = extract_nuget_publish_date(&state.storage, &id_lower, ver).await;
 
@@ -354,7 +351,7 @@ async fn flatcontainer_download(
     }
 
     let storage_key = format!("nuget/flatcontainer/{}", path.to_lowercase());
-    let content_type = if ends_with_ci(filename, ".nuspec") {
+    let content_type = if filename.ends_with(".nuspec") {
         "application/xml"
     } else {
         "application/octet-stream"
@@ -362,7 +359,7 @@ async fn flatcontainer_download(
 
     // Immutable cache
     if let Ok(data) = state.storage.get(&storage_key).await {
-        if ends_with_ci(filename, ".nupkg") {
+        if filename.ends_with(".nupkg") {
             if let Some(response) = crate::curation::verify_integrity(
                 &state.curation,
                 crate::curation::RegistryType::Nuget,
@@ -457,6 +454,20 @@ async fn flatcontainer_download(
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
+fn extract_host(state: &AppState, headers: &HeaderMap) -> String {
+    if let Some(public_url) = &state.config.server.public_url {
+        return public_url
+            .trim_start_matches("http://")
+            .trim_start_matches("https://")
+            .to_string();
+    }
+    headers
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("localhost:4000")
+        .to_string()
+}
+
 /// Extract publish date from cached NuGet registration index.
 ///
 /// NuGet registration index JSON has nested items:
@@ -523,21 +534,20 @@ fn with_json(data: Vec<u8>) -> Response {
 }
 
 /// Rewrite known Microsoft NuGet service index URLs with NORA endpoints.
-/// `base_url` is the full NORA base URL including scheme (e.g. `https://artifact.company.local`).
 /// Targets api.nuget.org and azuresearch-{usnc,ussc}.nuget.org specifically.
-fn rewrite_service_index(json_text: &str, base_url: &str) -> String {
-    let nora_nuget = format!("{}/nuget", base_url.trim_end_matches('/'));
-    let nora_query = format!("{}/v3/query", nora_nuget);
+fn rewrite_service_index(json_text: &str, host: &str) -> String {
+    let nora_base = format!("http://{}/nuget", host);
+    let nora_query = format!("{}/v3/query", nora_base);
 
     // Rewrite major service URLs to route through NORA
     json_text
         .replace(
             "https://api.nuget.org/v3-flatcontainer/",
-            &format!("{}/v3/flatcontainer/", nora_nuget),
+            &format!("{}/v3/flatcontainer/", nora_base),
         )
         .replace(
             "https://api.nuget.org/v3/registration5-gz-semver2/",
-            &format!("{}/v3/registration/", nora_nuget),
+            &format!("{}/v3/registration/", nora_base),
         )
         // Rewrite search endpoints to proxy through NORA
         .replace("https://azuresearch-usnc.nuget.org/query", &nora_query)
@@ -585,9 +595,9 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_service_index_http() {
+    fn test_rewrite_service_index() {
         let input = r#"{"resources":[{"@id":"https://api.nuget.org/v3-flatcontainer/","@type":"PackageBaseAddress/3.0.0"}]}"#;
-        let result = rewrite_service_index(input, "http://nora:4000");
+        let result = rewrite_service_index(input, "nora:4000");
         assert!(result.contains("http://nora:4000/nuget/v3/flatcontainer/"));
         assert!(!result.contains("api.nuget.org/v3-flatcontainer/"));
     }
@@ -595,20 +605,10 @@ mod tests {
     #[test]
     fn test_rewrite_service_index_search_urls() {
         let input = r#"{"resources":[{"@id":"https://azuresearch-usnc.nuget.org/query","@type":"SearchQueryService"},{"@id":"https://azuresearch-ussc.nuget.org/query","@type":"SearchQueryService"}]}"#;
-        let result = rewrite_service_index(input, "http://nora:4000");
+        let result = rewrite_service_index(input, "nora:4000");
         assert!(result.contains("http://nora:4000/nuget/v3/query"));
         assert!(!result.contains("azuresearch-usnc.nuget.org"));
         assert!(!result.contains("azuresearch-ussc.nuget.org"));
-    }
-
-    #[test]
-    fn test_rewrite_service_index_https() {
-        let input = r#"{"resources":[{"@id":"https://api.nuget.org/v3-flatcontainer/","@type":"PackageBaseAddress/3.0.0"},{"@id":"https://api.nuget.org/v3/registration5-gz-semver2/","@type":"RegistrationsBaseUrl/3.6.0"}]}"#;
-        let result = rewrite_service_index(input, "https://artifact.company.local");
-        assert!(result.contains("https://artifact.company.local/nuget/v3/flatcontainer/"));
-        assert!(result.contains("https://artifact.company.local/nuget/v3/registration/"));
-        assert!(!result.contains("http://artifact.company.local"));
-        assert!(!result.contains("api.nuget.org"));
     }
 }
 

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -16,9 +16,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{
-    circuit_open_response, nora_base_url as nora_base_url_shared, proxy_fetch, ProxyError,
-};
+use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -596,7 +594,13 @@ fn nora_version_url(nora_base: &str, package: &str, version: &str) -> String {
 
 /// Build NORA base URL with /pub prefix for URL rewriting.
 fn nora_base_url(state: &AppState) -> String {
-    format!("{}/pub", nora_base_url_shared(state))
+    if let Some(url) = &state.config.server.public_url {
+        return format!("{}/pub", url.trim_end_matches('/'));
+    }
+    format!(
+        "http://{}:{}/pub",
+        state.config.server.host, state.config.server.port
+    )
 }
 
 fn encode_segment(value: &str) -> String {

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -11,8 +11,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text};
-use crate::validation::ends_with_ci;
+use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text};
 use crate::AppState;
 use axum::{
     extract::{Multipart, Path, State},
@@ -22,7 +21,6 @@ use axum::{
     Router,
 };
 use sha2::Digest;
-use std::fmt::Write;
 use std::sync::Arc;
 
 /// PEP 691 JSON content type
@@ -83,7 +81,7 @@ async fn list_packages(
             "<!DOCTYPE html>\n<html><head><title>Simple Index</title></head><body><h1>Simple Index</h1>\n",
         );
         for pkg in pkg_list {
-            let _ = writeln!(html, "<a href=\"/simple/{}/\">{}</a><br>", pkg, pkg);
+            html.push_str(&format!("<a href=\"/simple/{}/\">{}</a><br>\n", pkg, pkg));
         }
         html.push_str("</body></html>");
         (
@@ -99,6 +97,23 @@ async fn list_packages(
 // Package versions
 // ============================================================================
 
+/// Returns base URL for PyPI download links.
+/// Uses public_url if set, otherwise http://host:port.
+fn pypi_base_url(state: &AppState) -> String {
+    state
+        .config
+        .server
+        .public_url
+        .as_deref()
+        .map(|u| u.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| {
+            format!(
+                "http://{}:{}",
+                state.config.server.host, state.config.server.port
+            )
+        })
+}
+
 /// GET /simple/{name}/ — list files for a package (PEP 503 HTML or PEP 691 JSON).
 async fn package_versions(
     State(state): State<Arc<AppState>>,
@@ -108,13 +123,13 @@ async fn package_versions(
     let normalized = normalize_name(&name);
     let prefix = format!("pypi/{}/", normalized);
     let keys = state.storage.list(&prefix).await;
-    let base_url = nora_base_url(&state);
+    let base_url = pypi_base_url(&state);
 
     // Collect files with their hashes
     let mut files: Vec<FileEntry> = Vec::new();
     for key in &keys {
         if let Some(filename) = key.strip_prefix(&prefix) {
-            if !filename.is_empty() && !ends_with_ci(filename, ".sha256") {
+            if !filename.is_empty() && !filename.ends_with(".sha256") {
                 let sha256 = state
                     .storage
                     .get(&format!("{}.sha256", key))
@@ -280,19 +295,20 @@ async fn download_file(
                                 .audit
                                 .log(AuditEntry::new("proxy_fetch", "api", "", "pypi", ""));
 
-                            // Cache in background + compute hash
+                            // Cache in background + compute hash, invalidate AFTER write
                             let storage = state.storage.clone();
                             let key_clone = key.clone();
                             let data_clone = data.clone();
+                            let state_clone = Arc::clone(&state);
                             tokio::spawn(async move {
-                                let _ = storage.put(&key_clone, &data_clone).await;
-                                let hash = hex::encode(sha2::Sha256::digest(&data_clone));
-                                let _ = storage
-                                    .put(&format!("{}.sha256", key_clone), hash.as_bytes())
-                                    .await;
+                                if storage.put(&key_clone, &data_clone).await.is_ok() {
+                                    let hash = hex::encode(sha2::Sha256::digest(&data_clone));
+                                    let _ = storage
+                                        .put(&format!("{}.sha256", key_clone), hash.as_bytes())
+                                        .await;
+                                    state_clone.repo_index.invalidate("pypi");
+                                }
                             });
-
-                            state.repo_index.invalidate("pypi");
 
                             let content_type = pypi_content_type(&filename);
                             return (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data)
@@ -496,11 +512,10 @@ fn versions_html_response(normalized: &str, files: &[FileEntry], base_url: &str)
             .as_ref()
             .map(|h| format!("#sha256={}", h))
             .unwrap_or_default();
-        let _ = writeln!(
-            html,
-            "<a href=\"{}/simple/{}/{}{}\">{}</a><br>",
+        html.push_str(&format!(
+            "<a href=\"{}/simple/{}/{}{}\">{}</a><br>\n",
             base_url, normalized, f.filename, hash_fragment, f.filename
-        );
+        ));
     }
     html.push_str("</body></html>");
 
@@ -545,9 +560,9 @@ fn wants_json(headers: &HeaderMap) -> bool {
 
 /// Content-type for PyPI files.
 fn pypi_content_type(filename: &str) -> &'static str {
-    if ends_with_ci(filename, ".whl") {
+    if filename.ends_with(".whl") {
         "application/zip"
-    } else if ends_with_ci(filename, ".tar.gz") || ends_with_ci(filename, ".tgz") {
+    } else if filename.ends_with(".tar.gz") || filename.ends_with(".tgz") {
         "application/gzip"
     } else {
         "application/octet-stream"
@@ -561,11 +576,11 @@ fn is_valid_pypi_filename(name: &str) -> bool {
         && !name.contains('/')
         && !name.contains('\\')
         && !name.contains('\0')
-        && (ends_with_ci(name, ".tar.gz")
-            || ends_with_ci(name, ".tgz")
-            || ends_with_ci(name, ".whl")
-            || ends_with_ci(name, ".zip")
-            || ends_with_ci(name, ".egg"))
+        && (name.ends_with(".tar.gz")
+            || name.ends_with(".tgz")
+            || name.ends_with(".whl")
+            || name.ends_with(".zip")
+            || name.ends_with(".egg"))
 }
 
 /// Rewrite PyPI links to point to our registry.
@@ -583,11 +598,10 @@ fn rewrite_pypi_links(html: &str, package_name: &str, base_url: &str) -> String 
             if let Some(filename) = extract_filename(url) {
                 // Extract hash fragment from original URL
                 let hash_fragment = url.find('#').map(|pos| &url[pos..]).unwrap_or("");
-                let _ = write!(
-                    result,
+                result.push_str(&format!(
                     "{}/simple/{}/{}{}",
                     base_url, package_name, filename, hash_fragment
-                );
+                ));
             } else {
                 result.push_str(url);
             }
@@ -625,11 +639,11 @@ fn extract_filename(url: &str) -> Option<&str> {
     let url = url.split('#').next()?;
     let filename = url.rsplit('/').next()?;
 
-    if ends_with_ci(filename, ".tar.gz")
-        || ends_with_ci(filename, ".tgz")
-        || ends_with_ci(filename, ".whl")
-        || ends_with_ci(filename, ".zip")
-        || ends_with_ci(filename, ".egg")
+    if filename.ends_with(".tar.gz")
+        || filename.ends_with(".tgz")
+        || filename.ends_with(".whl")
+        || filename.ends_with(".zip")
+        || filename.ends_with(".egg")
     {
         Some(filename)
     } else {

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -12,7 +12,6 @@
 use crate::registry_type::RegistryType;
 use crate::storage::Storage;
 use crate::ui::components::format_timestamp;
-use crate::validation::ends_with_ci;
 use parking_lot::RwLock;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -183,7 +182,7 @@ async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
     let mut repos: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
-        if ends_with_ci(key, ".meta.json") {
+        if key.ends_with(".meta.json") {
             continue;
         }
 
@@ -194,7 +193,7 @@ async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
             let parts: Vec<_> = rest.split('/').collect();
             let manifest_pos = parts.iter().position(|&p| p == "manifests");
             if let Some(pos) = manifest_pos {
-                if pos >= 1 && ends_with_ci(key, ".json") {
+                if pos >= 1 && key.ends_with(".json") {
                     let name = parts[..pos].join("/");
                     let entry = repos.entry(name).or_insert((0, 0, 0));
                     entry.0 += 1;
@@ -266,7 +265,7 @@ async fn build_npm_index(storage: &Storage) -> Vec<RepoInfo> {
         if let Some(rest) = key.strip_prefix("npm/") {
             // Pattern: npm/{package}/tarballs/{file}.tgz
             // Scoped:  npm/@scope/package/tarballs/{file}.tgz
-            if rest.contains("/tarballs/") && ends_with_ci(key, ".tgz") {
+            if rest.contains("/tarballs/") && key.ends_with(".tgz") {
                 let parts: Vec<_> = rest.split('/').collect();
                 if !parts.is_empty() {
                     // Scoped packages: @scope/package → parts[0]="@scope", parts[1]="package"
@@ -297,7 +296,7 @@ async fn build_cargo_index(storage: &Storage) -> Vec<RepoInfo> {
     let mut crates: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
-        if ends_with_ci(key, ".crate") {
+        if key.ends_with(".crate") {
             if let Some(rest) = key.strip_prefix("cargo/") {
                 let parts: Vec<_> = rest.split('/').collect();
                 if !parts.is_empty() {
@@ -352,7 +351,7 @@ async fn build_go_index(storage: &Storage) -> Vec<RepoInfo> {
         if let Some(rest) = key.strip_prefix("go/") {
             // Pattern: go/{module}/@v/{version}.zip
             // Count .zip files as versions (authoritative artifacts)
-            if rest.contains("/@v/") && ends_with_ci(key, ".zip") {
+            if rest.contains("/@v/") && key.ends_with(".zip") {
                 // Extract module path: everything before /@v/
                 if let Some(pos) = rest.rfind("/@v/") {
                     let module = &rest[..pos];

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -17,7 +17,6 @@ use tracing::info;
 
 use crate::config::RetentionRule;
 use crate::storage::Storage;
-use crate::validation::ends_with_ci;
 
 // ============================================================================
 // Prometheus metrics
@@ -245,7 +244,7 @@ async fn collect_docker_versions(storage: &Storage) -> Vec<(String, Vec<VersionE
             if let Some(idx) = rest.find("/manifests/") {
                 let repo = &rest[..idx];
                 let tag_file = &rest[idx + "/manifests/".len()..];
-                if ends_with_ci(tag_file, ".json") && !ends_with_ci(tag_file, ".meta.json") {
+                if tag_file.ends_with(".json") && !tag_file.ends_with(".meta.json") {
                     let tag = tag_file.strip_suffix(".json").unwrap_or(tag_file);
                     repos
                         .entry(repo.to_string())
@@ -286,7 +285,7 @@ async fn collect_npm_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntr
     for key in &all_keys {
         // npm/{package}/tarballs/{file} — each tarball is a "version"
         if let Some(rest) = key.strip_prefix("npm/") {
-            if rest.contains("/tarballs/") && !ends_with_ci(key, ".sha256") {
+            if rest.contains("/tarballs/") && !key.ends_with(".sha256") {
                 let pkg = rest.split("/tarballs/").next().unwrap_or("");
                 if !pkg.is_empty() {
                     packages
@@ -330,7 +329,7 @@ async fn collect_pypi_versions(storage: &Storage) -> Vec<(String, Vec<VersionEnt
 
     for key in &all_keys {
         if let Some(rest) = key.strip_prefix("pypi/") {
-            if !ends_with_ci(key, ".sha256") {
+            if !key.ends_with(".sha256") {
                 let pkg = rest.split('/').next().unwrap_or("");
                 if !pkg.is_empty() {
                     packages

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -6,7 +6,6 @@ use super::templates::encode_uri_component;
 use crate::activity_log::ActivityEntry;
 use crate::registry_type::RegistryType;
 use crate::repo_index::RepoInfo;
-use crate::validation::ends_with_ci;
 use crate::AppState;
 use crate::Storage;
 use axum::{
@@ -326,7 +325,7 @@ pub async fn get_docker_detail(state: &AppState, name: &str) -> DockerDetail {
     let mut tags = Vec::new();
     for key in &keys {
         // Skip .meta.json files
-        if ends_with_ci(key, ".meta.json") {
+        if key.ends_with(".meta.json") {
             continue;
         }
 
@@ -568,7 +567,7 @@ pub async fn get_cargo_detail(storage: &Storage, name: &str) -> PackageDetail {
     let keys = storage.list(&prefix).await;
 
     let mut versions = Vec::new();
-    for key in keys.iter().filter(|k| ends_with_ci(k, ".crate")) {
+    for key in keys.iter().filter(|k| k.ends_with(".crate")) {
         if let Some(rest) = key.strip_prefix(&prefix) {
             let parts: Vec<_> = rest.split('/').collect();
             if !parts.is_empty() {
@@ -643,7 +642,7 @@ pub async fn get_go_detail(storage: &Storage, module: &str) -> PackageDetail {
 
     // Also scan for .zip files that might exist without being in the list
     let keys = storage.list(&prefix).await;
-    for key in keys.iter().filter(|k| ends_with_ci(k, ".zip")) {
+    for key in keys.iter().filter(|k| k.ends_with(".zip")) {
         if let Some(rest) = key.strip_prefix(&prefix) {
             if let Some(version) = rest.strip_suffix(".zip") {
                 if !known_versions.iter().any(|v| v == version) {
@@ -839,7 +838,7 @@ async fn get_conan_detail(storage: &Storage, name: &str) -> PackageDetail {
                 let entry = version_data
                     .entry(version.to_string())
                     .or_insert((0, 0, false));
-                let is_content = !ends_with_ci(key, "/revisions.json");
+                let is_content = !key.ends_with("/revisions.json");
                 if let Some(meta) = storage.stat(key).await {
                     if is_content {
                         entry.0 += meta.size;
@@ -928,7 +927,7 @@ async fn get_pub_detail(storage: &Storage, name: &str) -> PackageDetail {
     let mut versions = Vec::new();
 
     for key in &keys {
-        if ends_with_ci(key, ".sha256") {
+        if key.ends_with(".sha256") {
             continue;
         }
         if let Some(rest) = key.strip_prefix(&prefix) {
@@ -996,14 +995,14 @@ fn extract_pypi_version(name: &str, filename: &str) -> Option<String> {
     // Handle both .tar.gz and .whl files
     let clean_name = name.replace('-', "_");
 
-    if ends_with_ci(filename, ".tar.gz") {
+    if filename.ends_with(".tar.gz") {
         // package-1.0.0.tar.gz
         let base = filename.strip_suffix(".tar.gz")?;
         let version = base
             .strip_prefix(&format!("{}-", name))
             .or_else(|| base.strip_prefix(&format!("{}-", clean_name)))?;
         Some(version.to_string())
-    } else if ends_with_ci(filename, ".whl") {
+    } else if filename.ends_with(".whl") {
         // package-1.0.0-py3-none-any.whl
         let parts: Vec<_> = filename.split('-').collect();
         if parts.len() >= 2 {

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -6,7 +6,6 @@ use super::components::*;
 use super::i18n::{get_translations, Lang};
 use crate::repo_index::RepoInfo;
 use crate::tokens::TokenListEntry;
-use std::fmt::Write;
 
 /// Renders the main dashboard page with dark theme
 pub fn render_dashboard(data: &DashboardResponse, lang: Lang, auth_enabled: bool) -> String {
@@ -294,13 +293,10 @@ pub fn render_registry_list_paginated(
 
         // Previous button
         if page > 1 {
-            let _ = write!(
-                pages_html,
+            pages_html.push_str(&format!(
                 r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300">←</a>"##,
-                registry_type,
-                page - 1,
-                limit
-            );
+                registry_type, page - 1, limit
+            ));
         } else {
             pages_html.push_str(r##"<span class="px-3 py-1 rounded bg-slate-800 text-slate-600 cursor-not-allowed">←</span>"##);
         }
@@ -310,11 +306,10 @@ pub fn render_registry_list_paginated(
         let end_page = (start_page + 6).min(total_pages);
 
         if start_page > 1 {
-            let _ = write!(
-                pages_html,
+            pages_html.push_str(&format!(
                 r##"<a href="/ui/{}?page=1&limit={}" class="px-3 py-1 rounded hover:bg-slate-700 text-slate-400">1</a>"##,
                 registry_type, limit
-            );
+            ));
             if start_page > 2 {
                 pages_html.push_str(r##"<span class="px-2 text-slate-600">...</span>"##);
             }
@@ -322,17 +317,15 @@ pub fn render_registry_list_paginated(
 
         for p in start_page..=end_page {
             if p == page {
-                let _ = write!(
-                    pages_html,
+                pages_html.push_str(&format!(
                     r##"<span class="px-3 py-1 rounded bg-blue-600 text-white font-medium">{}</span>"##,
                     p
-                );
+                ));
             } else {
-                let _ = write!(
-                    pages_html,
+                pages_html.push_str(&format!(
                     r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded hover:bg-slate-700 text-slate-400">{}</a>"##,
                     registry_type, p, limit, p
-                );
+                ));
             }
         }
 
@@ -340,22 +333,18 @@ pub fn render_registry_list_paginated(
             if end_page < total_pages - 1 {
                 pages_html.push_str(r##"<span class="px-2 text-slate-600">...</span>"##);
             }
-            let _ = write!(
-                pages_html,
+            pages_html.push_str(&format!(
                 r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded hover:bg-slate-700 text-slate-400">{}</a>"##,
                 registry_type, total_pages, limit, total_pages
-            );
+            ));
         }
 
         // Next button
         if page < total_pages {
-            let _ = write!(
-                pages_html,
+            pages_html.push_str(&format!(
                 r##"<a href="/ui/{}?page={}&limit={}" class="px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 text-slate-300">→</a>"##,
-                registry_type,
-                page + 1,
-                limit
-            );
+                registry_type, page + 1, limit
+            ));
         } else {
             pages_html.push_str(r##"<span class="px-3 py-1 rounded bg-slate-800 text-slate-600 cursor-not-allowed">→</span>"##);
         }
@@ -571,18 +560,16 @@ pub fn render_raw_dir(
             .collect::<Vec<_>>()
             .join("/");
         if i == segments.len() - 1 {
-            let _ = write!(
-                breadcrumbs,
+            breadcrumbs.push_str(&format!(
                 r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                 html_escape(seg)
-            );
+            ));
         } else {
-            let _ = write!(
-                breadcrumbs,
+            breadcrumbs.push_str(&format!(
                 r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/raw/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                 crumb_path,
                 html_escape(seg)
-            );
+            ));
         }
     }
 
@@ -689,18 +676,16 @@ pub fn render_maven_dir(
         for (i, seg) in segments.iter().enumerate() {
             let crumb_path = segments[..=i].join("/");
             if i == segments.len() - 1 {
-                let _ = write!(
-                    breadcrumbs,
+                breadcrumbs.push_str(&format!(
                     r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                     html_escape(seg)
-                );
+                ));
             } else {
-                let _ = write!(
-                    breadcrumbs,
+                breadcrumbs.push_str(&format!(
                     r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/maven/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                     crumb_path,
                     html_escape(seg)
-                );
+                ));
             }
         }
     }
@@ -922,18 +907,16 @@ pub fn render_package_detail(
                 .collect::<Vec<_>>()
                 .join("/");
             if i == segments.len() - 1 {
-                let _ = write!(
-                    crumbs,
+                crumbs.push_str(&format!(
                     r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                     html_escape(seg)
-                );
+                ));
             } else {
-                let _ = write!(
-                    crumbs,
+                crumbs.push_str(&format!(
                     r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/raw/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                     crumb_path,
                     html_escape(seg)
-                );
+                ));
             }
         }
         crumbs
@@ -1117,18 +1100,16 @@ pub fn render_maven_detail(
     for (i, seg) in segments.iter().enumerate() {
         let crumb_path = segments[..=i].join("/");
         if i == segments.len() - 1 {
-            let _ = write!(
-                breadcrumbs,
+            breadcrumbs.push_str(&format!(
                 r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
                 html_escape(seg)
-            );
+            ));
         } else {
-            let _ = write!(
-                breadcrumbs,
+            breadcrumbs.push_str(&format!(
                 r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/maven/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
                 crumb_path,
                 html_escape(seg)
-            );
+            ));
         }
     }
 
@@ -1461,7 +1442,7 @@ pub fn encode_uri_component(s: &str) -> String {
             'a'..='z' | 'A'..='Z' | '0'..='9' | '-' | '_' | '.' | '~' => result.push(c),
             _ => {
                 for byte in c.to_string().as_bytes() {
-                    let _ = write!(result, "%{:02X}", byte);
+                    result.push_str(&format!("%{:02X}", byte));
                 }
             }
         }

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -45,14 +45,6 @@ impl fmt::Display for ValidationError {
 
 impl std::error::Error for ValidationError {}
 
-/// Case-insensitive suffix check for file extensions.
-///
-/// Avoids allocating a lowercased copy of the whole string.
-pub fn ends_with_ci(s: &str, suffix: &str) -> bool {
-    s.len() >= suffix.len()
-        && s.as_bytes()[s.len() - suffix.len()..].eq_ignore_ascii_case(suffix.as_bytes())
-}
-
 /// Maximum allowed storage key length
 const MAX_KEY_LENGTH: usize = 1024;
 

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   retries: 1,
   use: {
     baseURL: process.env.NORA_URL || 'http://localhost:4000',
+    ignoreHTTPSErrors: true,
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },


### PR DESCRIPTION
## Summary

- **Proxy index reliability**: repo_index invalidation moved to after successful storage write (prevents stale cache on S3 failures)
- **Error logging**: storage errors in proxy handlers logged instead of being silently swallowed
- **UI improvements**: folder icons, install commands for all 13 registries, Maven hierarchical browsing, NuGet version list UX
- **NuGet**: gzip decompression for registration API responses
- **Ansible**: Galaxy API v3 discovery and short collection paths
- **Playwright**: `ignoreHTTPSErrors` for self-signed certificate e2e testing
- Version bump to 0.8.1

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -D warnings` — clean
- [x] `cargo test --lib --bin nora` — 898 passed
- [ ] CI green