### PR TITLE
fix(nuget): gallery URL rewrite, rate limit fix, e2e test paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 ## [Unreleased]
 
+## [0.8.2] - 2026-05-07
+
+### Fixed
+- **NuGet autocomplete leak** — `SearchAutocompleteService` URLs in service index now rewrite to NORA instead of leaking to `azuresearch-*.nuget.org`. New `/nuget/v3/autocomplete` proxy endpoint with graceful fallback (#262)
+- **NuGet gallery leak** — `SearchGalleryQueryService` root URLs (`azuresearch-{usnc,ussc}.nuget.org/`) now rewrite to NORA. Zero azuresearch URLs remain in service index
+- **NuGet 429 during cache warming** — registry proxy routes no longer double-limited by `general_limiter` + `upload_limiter`. Removes 429 errors during `dotnet restore` with many packages while keeping auth rate limiting active
+- **E2E test paths** — NuGet smoke tests used wrong paths (`/v3/flat/` → `/v3/flatcontainer/`, `/v3/search` → `/v3/query`)
+
+### Added
+- **NuGet search fallback** — local search from repo index when upstream is unavailable, download tracking for proxied packages (#261)
+- **Env var naming guideline** — `CONTRIBUTING.md` documents `NORA_{SECTION}_{FIELD}` pattern with abbreviation convention (`NORA_CB_*`)
+- 910 total tests (up from 909)
+
+### Changed
+- Docker base images switched to real RED OS and Astra Linux images (#260)
+- NuGet autocomplete config: env var `NORA_NUGET_AUTOCOMPLETE`, config field `autocomplete`
+
+## [0.8.1] - 2026-05-06
+
+### Fixed
+- **UI polish** — improved dashboard layout and proxy index reliability
+- **Error logging** — better error messages for proxy failures (#259)
+
 ## [0.8.0] - 2026-05-02
 
 ### Added

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -839,13 +839,16 @@ async fn run_server(config: Config, storage: Storage) {
         let upload_limiter = rate_limit::upload_rate_limiter(&config.rate_limit);
         let general_limiter = rate_limit::general_rate_limiter(&config.rate_limit);
 
-        let auth_routes = auth::token_routes().layer(auth_limiter);
+        // Auth routes: auth_limiter (strict 1rps) + general_limiter
+        let auth_routes = auth::token_routes()
+            .layer(auth_limiter)
+            .layer(general_limiter);
+        // Registry routes: upload_limiter only (200rps/500burst)
+        // No general_limiter — avoids double-limiting that causes 429
+        // during cache warming (dotnet restore with many packages)
         let limited_registry = registry_routes.layer(upload_limiter);
 
-        Router::new()
-            .merge(auth_routes)
-            .merge(limited_registry)
-            .layer(general_limiter)
+        Router::new().merge(auth_routes).merge(limited_registry)
     } else {
         info!("Rate limiting DISABLED");
         Router::new()

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -760,6 +760,16 @@ fn rewrite_service_index(json_text: &str, base_url: &str) -> String {
             "https://azuresearch-ussc.nuget.org/autocomplete",
             &nora_autocomplete,
         )
+        // Rewrite remaining azuresearch root URLs (SearchGalleryQueryService)
+        // Must come AFTER query/autocomplete replaces to avoid partial matches
+        .replace(
+            "https://azuresearch-usnc.nuget.org/",
+            &format!("{}/v3/", nora_nuget),
+        )
+        .replace(
+            "https://azuresearch-ussc.nuget.org/",
+            &format!("{}/v3/", nora_nuget),
+        )
 }
 
 fn is_valid_package_id(id: &str) -> bool {
@@ -836,6 +846,17 @@ mod tests {
         assert!(result.contains("http://nora:4000/nuget/v3/autocomplete"));
         assert!(!result.contains("azuresearch-usnc.nuget.org/autocomplete"));
         assert!(!result.contains("azuresearch-ussc.nuget.org/autocomplete"));
+    }
+
+    #[test]
+    fn test_rewrite_service_index_gallery_urls() {
+        let input = r#"{"resources":[{"@id":"https://azuresearch-usnc.nuget.org/query","@type":"SearchQueryService"},{"@id":"https://azuresearch-usnc.nuget.org/autocomplete","@type":"SearchAutocompleteService"},{"@id":"https://azuresearch-usnc.nuget.org/","@type":"SearchGalleryQueryService/3.0.0-rc"},{"@id":"https://azuresearch-ussc.nuget.org/","@type":"SearchGalleryQueryService/3.0.0-rc"}]}"#;
+        let result = rewrite_service_index(input, "http://nora:4000");
+        assert!(!result.contains("azuresearch-usnc.nuget.org"));
+        assert!(!result.contains("azuresearch-ussc.nuget.org"));
+        assert!(result.contains("http://nora:4000/nuget/v3/query"));
+        assert!(result.contains("http://nora:4000/nuget/v3/autocomplete"));
+        assert!(result.contains("http://nora:4000/nuget/v3/"));
     }
 }
 

--- a/tests/e2e-full/registries/nuget.sh
+++ b/tests/e2e-full/registries/nuget.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# nuget.sh — NuGet V3 registry tests
+# Usage: source registries/nuget.sh; test_nuget "$BASE_URL"
+
+test_nuget() {
+    local base="$1"
+    set_registry "nuget"
+    echo ""
+    echo "--- NuGet ---"
+
+    # Service index (/v3/index.json)
+    local svc_code
+    svc_code=$(curl -s -o /dev/null -w "%{http_code}" "$base/nuget/v3/index.json")
+    if [ "$svc_code" = "200" ]; then
+        pass "service_index"
+    else
+        fail "service_index" "got $svc_code"
+        return  # other tests depend on service index
+    fi
+
+    # URL rewrite — service index should reference NORA base URL
+    local svc_body
+    svc_body=$(curl -sf "$base/nuget/v3/index.json" 2>/dev/null || echo "")
+    if echo "$svc_body" | grep -q "/nuget"; then
+        pass "url_rewrite"
+    else
+        fail "url_rewrite" "service index does not reference /nuget paths"
+    fi
+
+    # Scheme preservation — rewritten URLs must NOT hardcode http:// when PUBLIC_URL is https://
+    # Bug #256: old code stripped scheme and hardcoded http://, breaking HTTPS deployments
+    # Strategy: extract all rewritten @id URLs, verify they don't mix schemes.
+    # If NORA_PUBLIC_URL starts with https, rewritten URLs must also use https.
+    local rewritten_urls
+    rewritten_urls=$(echo "$svc_body" | python3 -c "
+import sys,json
+try:
+    data = json.load(sys.stdin)
+    for r in data.get('resources', []):
+        url = r.get('@id', '')
+        if '/nuget/' in url:
+            print(url)
+except: pass
+" 2>/dev/null || echo "")
+    if [ -n "$rewritten_urls" ]; then
+        # Get the scheme actually used by NORA in rewritten URLs
+        local first_url
+        first_url=$(echo "$rewritten_urls" | head -1)
+        local actual_scheme
+        actual_scheme=$(echo "$first_url" | grep -oP '^https?')
+
+        # All rewritten URLs must use the same scheme
+        local scheme_ok=true
+        while IFS= read -r url; do
+            [ -z "$url" ] && continue
+            local url_scheme
+            url_scheme=$(echo "$url" | grep -oP '^https?')
+            if [ "$url_scheme" != "$actual_scheme" ]; then
+                scheme_ok=false
+                fail "url_scheme_consistent" "mixed schemes: $actual_scheme vs $url_scheme in: $url"
+                break
+            fi
+        done <<< "$rewritten_urls"
+        if [ "$scheme_ok" = true ]; then
+            pass "url_scheme_consistent"
+        fi
+
+        # If PUBLIC_URL is https, verify NORA doesn't downgrade to http
+        # (This catches Bug #256: extract_host() stripped scheme, hardcoded http://)
+        if [ "${NORA_PUBLIC_URL:-}" != "" ]; then
+            local public_scheme
+            public_scheme=$(echo "$NORA_PUBLIC_URL" | grep -oP '^https?' || echo "")
+            if [ "$public_scheme" = "https" ] && [ "$actual_scheme" = "http" ]; then
+                fail "url_scheme_preserved" "PUBLIC_URL is https but rewritten URLs use http (Bug #256)"
+            elif [ -n "$public_scheme" ]; then
+                pass "url_scheme_preserved"
+            fi
+        else
+            pass "url_scheme_preserved"
+        fi
+    else
+        skip "url_scheme_consistent" "no rewritten URLs in service index"
+        skip "url_scheme_preserved" "no rewritten URLs in service index"
+    fi
+
+    # Registration — package metadata for Newtonsoft.Json
+    local reg_code
+    reg_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        "$base/nuget/v3/registration/newtonsoft.json/index.json")
+    if [ "$reg_code" = "200" ]; then
+        pass "registration"
+    else
+        skip "registration" "returned $reg_code (may need upstream)"
+    fi
+
+    # Flat container — version list
+    local flat_code
+    flat_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        "$base/nuget/v3/flatcontainer/newtonsoft.json/index.json")
+    if [ "$flat_code" = "200" ]; then
+        pass "flatcontainer"
+    else
+        skip "flatcontainer" "returned $flat_code (may need upstream)"
+    fi
+
+    # .nupkg download
+    local nupkg_code
+    nupkg_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        "$base/nuget/v3/flatcontainer/newtonsoft.json/13.0.3/newtonsoft.json.13.0.3.nupkg")
+    if [ "$nupkg_code" = "200" ]; then
+        pass "nupkg_download"
+    else
+        skip "nupkg_download" "returned $nupkg_code (may need upstream)"
+    fi
+
+    # Search
+    local search_code
+    search_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        "$base/nuget/v3/query?q=newtonsoft&take=5")
+    if [ "$search_code" = "200" ]; then
+        pass "search"
+    else
+        skip "search" "returned $search_code (may need upstream)"
+    fi
+}


### PR DESCRIPTION
## Summary

- Rewrite `SearchGalleryQueryService` root URLs — zero `azuresearch-*` URLs remain in service index
- Fix 429 during cache warming: remove `general_limiter` from registry proxy routes (auth rate limiting unchanged)
- Fix e2e test paths: `/v3/flat/` → `/v3/flatcontainer/`, `/v3/search` → `/v3/query`
- CHANGELOG entries for 0.8.1 and 0.8.2

## Test plan

- [x] `cargo fmt --check && cargo clippy -- -D warnings && cargo test --lib --bin nora` (910 pass)
- [x] A/B test 0.8.1 vs 0.8.2-rc: 429 reproduced (100/300), fixed (0/300), auth still blocks (25/30)
- [x] Zero azuresearch URLs in rewritten service index
- [x] flatcontainer + query paths return 200