### PR TITLE
fix: unified TTL semantics and repo_index invalidation race condition

### DIFF
--- a/dist/nora.env.example
+++ b/dist/nora.env.example
@@ -19,13 +19,55 @@ NORA_STORAGE_PATH=/var/lib/nora
 # Rate limiting
 # NORA_RATE_LIMIT_ENABLED=true
 
+# Registry selection (comma-separated list; overrides per-registry ENABLED flags)
+# NORA_REGISTRIES_ENABLE=docker,npm,maven,pypi,cargo,go,raw,gems,terraform,ansible,nuget,pub,conan
+
+# Docker proxy
+# NORA_DOCKER_PROXIES=https://registry-1.docker.io
+
 # npm proxy
 # NORA_NPM_PROXY=https://registry.npmjs.org
 # NORA_NPM_METADATA_TTL=300
-# NORA_NPM_PROXY_AUTH=user:pass
 
 # PyPI proxy
 # NORA_PYPI_PROXY=https://pypi.org/simple/
 
-# Docker upstreams
-# NORA_DOCKER_UPSTREAMS=https://registry-1.docker.io
+# Maven proxy
+# NORA_MAVEN_PROXIES=https://repo1.maven.org/maven2
+
+# Go proxy
+# NORA_GO_PROXY=https://proxy.golang.org
+
+# Cargo proxy
+# NORA_CARGO_PROXY=https://index.crates.io
+
+# RubyGems proxy
+# NORA_GEMS_PROXY=https://rubygems.org
+# NORA_GEMS_METADATA_TTL=300
+
+# Terraform proxy
+# NORA_TERRAFORM_PROXY=https://registry.terraform.io
+# NORA_TERRAFORM_METADATA_TTL=300
+
+# Ansible Galaxy proxy
+# NORA_ANSIBLE_PROXY=https://galaxy.ansible.com
+
+# NuGet proxy
+# NORA_NUGET_PROXY=https://api.nuget.org/v3/index.json
+# NORA_NUGET_METADATA_TTL=300
+
+# Conan proxy
+# NORA_CONAN_PROXY=https://center2.conan.io
+# NORA_CONAN_METADATA_TTL=300
+
+# Pub (Dart) proxy
+# NORA_PUB_PROXY=https://pub.dev
+
+# Metadata cache TTL semantics (applies to all *_METADATA_TTL vars):
+#   -1 = cache forever (never refetch from upstream)
+#    0 = always refetch (disable metadata cache)
+#   >0 = TTL in seconds (default: 300 = 5 min)
+
+# Curation (optional)
+# NORA_CURATION_MODE=enforce
+# NORA_CURATION_BLOCKLIST_FILE=/etc/nora/blocklist.json

--- a/nora-registry/src/cache_ttl.rs
+++ b/nora-registry/src/cache_ttl.rs
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+
+//! Unified cache TTL logic for all proxy registries.
+//!
+//! Semantics:
+//! - `-1` — cache forever, never refetch from upstream
+//! - `0`  — always refetch (disable cache for metadata)
+//! - `>0` — TTL in seconds; refetch after this many seconds
+
+/// Check if a cached entry is still fresh.
+///
+/// # Arguments
+/// - `modified_unix` — file modification time (Unix epoch seconds)
+/// - `ttl_secs` — TTL value from config (`-1` = forever, `0` = always stale, `>0` = seconds)
+///
+/// Returns `true` if the entry should be served from cache (fresh),
+/// `false` if it should be refetched from upstream (stale).
+pub fn is_within_ttl(modified_unix: u64, ttl_secs: i64) -> bool {
+    match ttl_secs {
+        // -1: cache forever — always fresh
+        ..=-1 => true,
+        // 0: always refetch — always stale
+        0 => false,
+        // >0: check age
+        ttl => {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            now.saturating_sub(modified_unix) < ttl as u64
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn now_secs() -> u64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
+    #[test]
+    fn ttl_minus_one_always_fresh() {
+        // Even ancient entries are fresh with ttl=-1
+        assert!(is_within_ttl(0, -1));
+        assert!(is_within_ttl(1_000_000, -1));
+    }
+
+    #[test]
+    fn ttl_zero_always_stale() {
+        // Even just-modified entries are stale with ttl=0
+        assert!(!is_within_ttl(now_secs(), 0));
+        assert!(!is_within_ttl(now_secs() + 100, 0));
+    }
+
+    #[test]
+    fn ttl_positive_fresh() {
+        // Modified 10 seconds ago, TTL is 300 → fresh
+        assert!(is_within_ttl(now_secs() - 10, 300));
+    }
+
+    #[test]
+    fn ttl_positive_stale() {
+        // Modified 600 seconds ago, TTL is 300 → stale
+        assert!(!is_within_ttl(now_secs() - 600, 300));
+    }
+
+    #[test]
+    fn ttl_positive_boundary() {
+        // Modified exactly TTL seconds ago — stale (< not <=)
+        let now = now_secs();
+        assert!(!is_within_ttl(now - 300, 300));
+        // One second less — still fresh
+        assert!(is_within_ttl(now - 299, 300));
+    }
+}

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -166,9 +166,10 @@ pub struct NpmConfig {
     pub proxy_auth: Option<String>, // "user:pass" for basic auth
     #[serde(default = "default_timeout")]
     pub proxy_timeout: u64,
-    /// Metadata cache TTL in seconds (default: 300 = 5 min). Set to 0 to cache forever.
+    /// Metadata cache TTL in seconds (default: 300 = 5 min).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
-    pub metadata_ttl: u64,
+    pub metadata_ttl: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -328,9 +329,10 @@ pub struct GemsConfig {
     pub proxy_auth: Option<String>,
     #[serde(default = "default_timeout")]
     pub proxy_timeout: u64,
-    /// Index cache TTL in seconds (default: 300 = 5 min)
+    /// Metadata cache TTL in seconds (default: 300 = 5 min).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
-    pub index_ttl: u64,
+    pub metadata_ttl: i64,
 }
 
 fn default_gems_proxy() -> Option<String> {
@@ -344,7 +346,7 @@ impl Default for GemsConfig {
             proxy: default_gems_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
-            index_ttl: 300,
+            metadata_ttl: 300,
         }
     }
 }
@@ -364,6 +366,10 @@ pub struct TerraformConfig {
     /// Separate timeout for binary downloads (default: 120s)
     #[serde(default = "default_go_zip_timeout")]
     pub proxy_timeout_download: u64,
+    /// Metadata cache TTL in seconds (default: 300 = 5 min).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
+    #[serde(default = "default_metadata_ttl")]
+    pub metadata_ttl: i64,
 }
 
 fn default_terraform_proxy() -> Option<String> {
@@ -378,6 +384,7 @@ impl Default for TerraformConfig {
             proxy_auth: None,
             proxy_timeout: 30,
             proxy_timeout_download: 120,
+            metadata_ttl: 300,
         }
     }
 }
@@ -423,9 +430,10 @@ pub struct NugetConfig {
     pub proxy_auth: Option<String>,
     #[serde(default = "default_timeout")]
     pub proxy_timeout: u64,
-    /// Metadata cache TTL in seconds (default: 300 = 5 min)
+    /// Metadata cache TTL in seconds (default: 300 = 5 min).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
-    pub metadata_ttl: u64,
+    pub metadata_ttl: i64,
     /// Upstream NuGet search service URL
     #[serde(default = "default_nuget_search")]
     pub search_service: String,
@@ -504,9 +512,10 @@ pub struct ConanConfig {
     /// Separate timeout for binary downloads (default: 120s)
     #[serde(default = "default_go_zip_timeout")]
     pub proxy_timeout_download: u64,
-    /// Metadata cache TTL in seconds (default: 300 = 5 min)
+    /// Metadata cache TTL in seconds (default: 300 = 5 min).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
-    pub metadata_ttl: u64,
+    pub metadata_ttl: i64,
 }
 
 fn default_conan_proxy() -> Option<String> {
@@ -686,8 +695,8 @@ fn default_timeout() -> u64 {
     30
 }
 
-fn default_metadata_ttl() -> u64 {
-    300 // 5 minutes
+fn default_metadata_ttl() -> i64 {
+    300 // 5 minutes; -1 = cache forever, 0 = always refetch
 }
 
 impl Default for MavenConfig {
@@ -1886,9 +1895,9 @@ impl Config {
                 self.gems.proxy_timeout = timeout;
             }
         }
-        if let Ok(val) = env::var("NORA_GEMS_INDEX_TTL") {
+        if let Ok(val) = env::var("NORA_GEMS_METADATA_TTL") {
             if let Ok(ttl) = val.parse() {
-                self.gems.index_ttl = ttl;
+                self.gems.metadata_ttl = ttl;
             }
         }
 
@@ -1907,6 +1916,11 @@ impl Config {
         if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_TIMEOUT_DOWNLOAD") {
             if let Ok(timeout) = val.parse() {
                 self.terraform.proxy_timeout_download = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_TERRAFORM_METADATA_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.terraform.metadata_ttl = ttl;
             }
         }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -6,6 +6,7 @@ mod activity_log;
 mod audit;
 mod auth;
 mod backup;
+mod cache_ttl;
 mod circuit_breaker;
 mod config;
 mod curation;
@@ -33,7 +34,7 @@ mod validation;
 #[cfg(test)]
 mod test_helpers;
 
-use axum::{extract::DefaultBodyLimit, http::HeaderValue, middleware, Router};
+use axum::{body::Bytes, extract::DefaultBodyLimit, http::HeaderValue, middleware, Router};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -170,6 +171,37 @@ impl AppState {
             .entry(key.to_string())
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
+    }
+
+    /// Background-cache proxy data and invalidate the registry index.
+    ///
+    /// Use for ALL proxy caching instead of manual `tokio::spawn` + `storage.put`.
+    /// Guarantees that `repo_index.invalidate()` is called AFTER the write completes,
+    /// avoiding the race condition where invalidation fires before the file lands on S3.
+    pub fn spawn_cache(self: &Arc<Self>, registry: &'static str, key: String, data: Bytes) {
+        let state = Arc::clone(self);
+        tokio::spawn(async move {
+            if state.storage.put(&key, &data).await.is_ok() {
+                state.repo_index.invalidate(registry);
+            }
+        });
+    }
+
+    /// Like [`spawn_cache`], but skips the write if the key already exists (immutable artifacts).
+    pub fn spawn_cache_immutable(
+        self: &Arc<Self>,
+        registry: &'static str,
+        key: String,
+        data: Bytes,
+    ) {
+        let state = Arc::clone(self);
+        tokio::spawn(async move {
+            if state.storage.stat(&key).await.is_none() {
+                if state.storage.put(&key, &data).await.is_ok() {
+                    state.repo_index.invalidate(registry);
+                }
+            }
+        });
     }
 }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -196,10 +196,10 @@ impl AppState {
     ) {
         let state = Arc::clone(self);
         tokio::spawn(async move {
-            if state.storage.stat(&key).await.is_none() {
-                if state.storage.put(&key, &data).await.is_ok() {
-                    state.repo_index.invalidate(registry);
-                }
+            if state.storage.stat(&key).await.is_none()
+                && state.storage.put(&key, &data).await.is_ok()
+            {
+                state.repo_index.invalidate(registry);
             }
         });
     }

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -290,6 +290,7 @@ pub async fn dashboard_metrics() {}
     tag = "docker",
     responses(
         (status = 200, description = "Registry is available", body = DockerVersion),
+        (status = 400, description = "Invalid request", body = ErrorResponse),
         (status = 401, description = "Authentication required")
     )
 )]
@@ -316,6 +317,7 @@ pub async fn docker_catalog() {}
     ),
     responses(
         (status = 200, description = "Tag list", body = DockerTags),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Repository not found")
     )
 )]
@@ -332,6 +334,7 @@ pub async fn docker_tags() {}
     ),
     responses(
         (status = 200, description = "Manifest content"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Manifest not found")
     )
 )]
@@ -348,6 +351,7 @@ pub async fn docker_manifest_get() {}
     ),
     responses(
         (status = 200, description = "Blob exists, Content-Length header contains size"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Blob not found")
     )
 )]
@@ -364,6 +368,7 @@ pub async fn docker_blob_head() {}
     ),
     responses(
         (status = 200, description = "Blob content"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Blob not found")
     )
 )]
@@ -398,6 +403,7 @@ pub async fn docker_manifest_put() {}
     ),
     responses(
         (status = 202, description = "Manifest deleted"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Manifest not found")
     )
 )]
@@ -414,7 +420,8 @@ pub async fn docker_manifest_delete() {}
         ("name" = String, Path, description = "Repository name")
     ),
     responses(
-        (status = 202, description = "Upload started, Location header contains upload URL")
+        (status = 202, description = "Upload started, Location header contains upload URL"),
+        (status = 400, description = "Invalid input", body = ErrorResponse)
     )
 )]
 pub async fn docker_blob_upload_start() {}
@@ -431,7 +438,8 @@ pub async fn docker_blob_upload_start() {}
         ("uuid" = String, Path, description = "Upload session UUID")
     ),
     responses(
-        (status = 202, description = "Chunk accepted, Range header indicates bytes received")
+        (status = 202, description = "Chunk accepted, Range header indicates bytes received"),
+        (status = 400, description = "Invalid input", body = ErrorResponse)
     )
 )]
 pub async fn docker_blob_upload_patch() {}
@@ -467,6 +475,7 @@ pub async fn docker_blob_upload_put() {}
     ),
     responses(
         (status = 200, description = "Artifact content"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Artifact not found, trying upstream proxies")
     )
 )]
@@ -552,6 +561,7 @@ pub async fn cargo_index_config() {}
     ),
     responses(
         (status = 200, description = "Crate index entries (one JSON per line)"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Crate not found in index")
     )
 )]
@@ -567,6 +577,7 @@ pub async fn cargo_sparse_index() {}
     ),
     responses(
         (status = 200, description = "Crate metadata (JSON)"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Crate not found")
     )
 )]
@@ -583,6 +594,7 @@ pub async fn cargo_metadata() {}
     ),
     responses(
         (status = 200, description = "Crate file (.crate)"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Crate version not found")
     )
 )]
@@ -658,6 +670,7 @@ pub async fn pypi_upload() {}
     ),
     responses(
         (status = 200, description = "Latest version info (JSON)"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Module not found")
     )
 )]
@@ -674,6 +687,7 @@ pub async fn go_module_latest() {}
     ),
     responses(
         (status = 200, description = "Version info (JSON)"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Version not found")
     )
 )]
@@ -690,6 +704,7 @@ pub async fn go_module_info() {}
     ),
     responses(
         (status = 200, description = "go.mod file content"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Version not found")
     )
 )]
@@ -706,6 +721,7 @@ pub async fn go_module_mod() {}
     ),
     responses(
         (status = 200, description = "Module zip archive"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Version not found")
     )
 )]
@@ -723,6 +739,7 @@ pub async fn go_module_zip() {}
     ),
     responses(
         (status = 200, description = "File content"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "File not found")
     )
 )]
@@ -758,6 +775,7 @@ pub async fn raw_file_put() {}
     ),
     responses(
         (status = 200, description = "Compact index for gem"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Gem not found")
     )
 )]
@@ -802,6 +820,7 @@ pub async fn terraform_service_discovery() {}
     ),
     responses(
         (status = 200, description = "Version list"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Provider not found")
     )
 )]
@@ -831,6 +850,7 @@ pub async fn ansible_collection_list() {}
     ),
     responses(
         (status = 200, description = "Collection tarball"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Collection not found")
     )
 )]
@@ -876,6 +896,7 @@ pub async fn nuget_download() {}
     ),
     responses(
         (status = 200, description = "Package metadata with versions"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Package not found")
     )
 )]
@@ -892,6 +913,7 @@ pub async fn pub_package_list() {}
     ),
     responses(
         (status = 200, description = "Package archive (.tar.gz)"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "Package not found")
     )
 )]
@@ -925,6 +947,7 @@ pub async fn conan_ping() {}
     ),
     responses(
         (status = 200, description = "File content"),
+        (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 404, description = "File not found")
     )
 )]
@@ -955,7 +978,8 @@ pub async fn create_token() {}
     request_body = TokenRequest,
     responses(
         (status = 200, description = "Token list", body = TokenListResponse),
-        (status = 401, description = "Invalid credentials", body = ErrorResponse)
+        (status = 401, description = "Invalid credentials", body = ErrorResponse),
+        (status = 422, description = "Invalid request body", body = ErrorResponse)
     )
 )]
 pub async fn list_tokens() {}
@@ -968,7 +992,8 @@ pub async fn list_tokens() {}
     responses(
         (status = 200, description = "Token revoked"),
         (status = 401, description = "Invalid credentials", body = ErrorResponse),
-        (status = 404, description = "Token not found", body = ErrorResponse)
+        (status = 404, description = "Token not found", body = ErrorResponse),
+        (status = 415, description = "Unsupported Content-Type")
     )
 )]
 pub async fn revoke_token() {}

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -18,6 +18,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
 use crate::AppState;
 use axum::{
+    body::Bytes,
     extract::{Path, State},
     http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
@@ -276,16 +277,7 @@ async fn download_tarball(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "ansible", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
-
-            state.repo_index.invalidate("ansible");
+            state.spawn_cache_immutable("ansible", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -330,12 +330,7 @@ async fn download(
     .await
     {
         Ok(data) => {
-            let storage = state.storage.clone();
-            let key_clone = key.clone();
-            let data_clone = data.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key_clone, &data_clone).await;
-            });
+            state.spawn_cache("cargo", key.clone(), Bytes::from(data.clone()));
             state.metrics.record_download("cargo");
             state.metrics.record_cache_miss();
             state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -740,7 +740,11 @@ async fn fetch_and_cache_immutable_json(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
 
-            state.spawn_cache_immutable("conan", storage_key.to_string(), Bytes::from(text.clone()));
+            state.spawn_cache_immutable(
+                "conan",
+                storage_key.to_string(),
+                Bytes::from(text.clone()),
+            );
             with_json(text.into_bytes())
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -30,6 +30,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
 use crate::AppState;
 use axum::{
+    body::Bytes,
     extract::{Path, Query, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
@@ -38,7 +39,6 @@ use axum::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const UPSTREAM_DEFAULT: &str = "https://center2.conan.io";
 
@@ -376,16 +376,7 @@ async fn recipe_file_download(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
 
             // Immutable cache: put_if_absent
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
-
-            state.repo_index.invalidate("conan");
+            state.spawn_cache_immutable("conan", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes)
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -661,16 +652,7 @@ async fn package_file_download(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
 
             // Immutable cache
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
-
-            state.repo_index.invalidate("conan");
+            state.spawn_cache_immutable("conan", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes)
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -686,7 +668,7 @@ async fn package_file_download(
 
 /// Fetch JSON from upstream, cache with TTL (mutable content).
 async fn fetch_and_cache_json(
-    state: &AppState,
+    state: &Arc<AppState>,
     url: &str,
     storage_key: &str,
     artifact: &str,
@@ -715,14 +697,7 @@ async fn fetch_and_cache_json(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key.to_string();
-            let data = text.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("conan");
+            state.spawn_cache("conan", storage_key.to_string(), Bytes::from(text.clone()));
             with_json(text.into_bytes())
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -736,7 +711,7 @@ async fn fetch_and_cache_json(
 
 /// Fetch JSON from upstream, cache immutably (content scoped to revision, never changes).
 async fn fetch_and_cache_immutable_json(
-    state: &AppState,
+    state: &Arc<AppState>,
     url: &str,
     storage_key: &str,
     artifact: &str,
@@ -765,16 +740,7 @@ async fn fetch_and_cache_immutable_json(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "conan", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key.to_string();
-            let data = text.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, data.as_bytes()).await;
-                }
-            });
-
-            state.repo_index.invalidate("conan");
+            state.spawn_cache_immutable("conan", storage_key.to_string(), Bytes::from(text.clone()));
             with_json(text.into_bytes())
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -819,13 +785,7 @@ fn upstream_url(state: &AppState) -> String {
         .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
 }
 
-fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    now.saturating_sub(modified_unix) < ttl_secs
-}
+use crate::cache_ttl::is_within_ttl;
 
 fn with_json(data: Vec<u8>) -> Response {
     (
@@ -901,6 +861,7 @@ fn is_valid_filename(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_valid_refs() {

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -347,14 +347,7 @@ async fn download_blob(
             .await
             {
                 Ok(data) => {
-                    let storage = state.storage.clone();
-                    let key_clone = key.clone();
-                    let data_clone = data.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = storage.put(&key_clone, &data_clone).await {
-                            tracing::warn!(key = %key_clone, error = %e, "Failed to cache blob in storage");
-                        }
-                    });
+                    state.spawn_cache("docker", key.clone(), Bytes::from(data.clone()));
 
                     return (
                         StatusCode::OK,
@@ -386,14 +379,7 @@ async fn download_blob(
             .await
             {
                 Ok(data) => {
-                    let storage = state.storage.clone();
-                    let key_clone = key.clone();
-                    let data_clone = data.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = storage.put(&key_clone, &data_clone).await {
-                            tracing::warn!(key = %key_clone, error = %e, "Failed to cache blob in storage");
-                        }
-                    });
+                    state.spawn_cache("docker", key.clone(), Bytes::from(data.clone()));
 
                     return (
                         StatusCode::OK,
@@ -817,6 +803,7 @@ async fn get_manifest(
                 let name_clone = name.clone();
                 let reference_clone = reference.clone();
                 let digest_clone = digest.clone();
+                let state_clone = Arc::clone(&state);
                 tokio::spawn(async move {
                     // Store manifest by tag and digest
                     let _ = storage.put(&key_clone, &data_clone).await;
@@ -837,9 +824,8 @@ async fn get_manifest(
                             format!("docker/{}/manifests/{}.meta.json", name_clone, digest_clone);
                         let _ = storage.put(&digest_meta_key, &meta_json).await;
                     }
+                    state_clone.repo_index.invalidate("docker");
                 });
-
-                state.repo_index.invalidate("docker");
 
                 return (
                     StatusCode::OK,

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -19,6 +19,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
 use crate::AppState;
 use axum::{
+    body::Bytes,
     extract::{Path, State},
     http::{header, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
@@ -26,7 +27,6 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 const UPSTREAM_DEFAULT: &str = "https://rubygems.org";
 
@@ -47,14 +47,7 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/gems/quick/Marshal.4.8/{filename}", get(download_gemspec))
 }
 
-/// Check if a cached entry is within TTL based on unix timestamp
-fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    now.saturating_sub(modified_unix) < ttl_secs
-}
+use crate::cache_ttl::is_within_ttl;
 
 // ── Index endpoints (mutable, TTL cached) ─────────────────────────────
 
@@ -70,13 +63,13 @@ async fn prerelease_specs_index(State(state): State<Arc<AppState>>) -> Response 
     fetch_index(&state, "prerelease_specs.4.8.gz").await
 }
 
-async fn fetch_index(state: &AppState, filename: &str) -> Response {
+async fn fetch_index(state: &Arc<AppState>, filename: &str) -> Response {
     let storage_key = format!("gems/{}", filename);
 
     // Check TTL: if cached and fresh, serve from cache
     if let Ok(data) = state.storage.get(&storage_key).await {
         if let Some(meta) = state.storage.stat(&storage_key).await {
-            if is_within_ttl(meta.modified, state.config.gems.index_ttl) {
+            if is_within_ttl(meta.modified, state.config.gems.metadata_ttl) {
                 state.metrics.record_download("gems");
                 state.metrics.record_cache_hit();
                 state.activity.push(ActivityEntry::new(
@@ -118,14 +111,7 @@ async fn fetch_index(state: &AppState, filename: &str) -> Response {
                 .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
 
             // Cache in background (overwrite — mutable content)
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, &data).await;
-            });
-
-            state.repo_index.invalidate("gems");
+            state.spawn_cache("gems", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes, "application/gzip")
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -166,7 +152,7 @@ async fn compact_index(
     // Check TTL cache
     if let Ok(data) = state.storage.get(&storage_key).await {
         if let Some(meta) = state.storage.stat(&storage_key).await {
-            if is_within_ttl(meta.modified, state.config.gems.index_ttl) {
+            if is_within_ttl(meta.modified, state.config.gems.metadata_ttl) {
                 state.metrics.record_download("gems");
                 state.metrics.record_cache_hit();
                 state.activity.push(ActivityEntry::new(
@@ -207,14 +193,7 @@ async fn compact_index(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = text.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("gems");
+            state.spawn_cache("gems", storage_key, Bytes::from(text.clone()));
             with_text(text.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -321,16 +300,7 @@ async fn download_gem(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
 
             // Immutable cache: put_if_absent
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
-
-            state.repo_index.invalidate("gems");
+            state.spawn_cache_immutable("gems", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes, "application/octet-stream")
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -407,16 +377,7 @@ async fn download_gemspec(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
-
-            state.repo_index.invalidate("gems");
+            state.spawn_cache_immutable("gems", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes, "application/octet-stream")
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -529,6 +490,7 @@ fn is_valid_version(version: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn test_valid_gem_names() {
@@ -712,7 +674,7 @@ mod integration_tests {
     async fn test_gems_cached_compact_index() {
         let ctx = create_test_context_with_config(|cfg| {
             cfg.gems.enabled = true;
-            cfg.gems.index_ttl = 3600; // 1 hour
+            cfg.gems.metadata_ttl = 3600; // 1 hour
         });
 
         ctx.state

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -204,14 +204,7 @@ async fn download(
                     .audit
                     .log(AuditEntry::new("proxy_fetch", "api", "", "maven", ""));
 
-                let storage = state.storage.clone();
-                let key_clone = key.clone();
-                let data_clone = data.clone();
-                tokio::spawn(async move {
-                    let _ = storage.put(&key_clone, &data_clone).await;
-                });
-
-                state.repo_index.invalidate("maven");
+                state.spawn_cache("maven", key.clone(), Bytes::from(data.clone()));
 
                 return with_content_type(&path, data.into()).into_response();
             }

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -112,18 +112,12 @@ async fn handle_request(
         // Metadata TTL: if stale, try to refetch from upstream
         if !is_tarball {
             let ttl = state.config.npm.metadata_ttl;
-            if ttl > 0 {
-                if let Some(meta) = state.storage.stat(&key).await {
-                    let now = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0);
-                    if now.saturating_sub(meta.modified) > ttl {
-                        if let Some(fresh) = refetch_metadata(&state, &path, &key).await {
-                            return with_content_type(false, fresh.into()).into_response();
-                        }
-                        // Upstream failed — serve stale cache
+            if let Some(meta) = state.storage.stat(&key).await {
+                if !crate::cache_ttl::is_within_ttl(meta.modified, ttl) {
+                    if let Some(fresh) = refetch_metadata(&state, &path, &key).await {
+                        return with_content_type(false, fresh.into()).into_response();
                     }
+                    // Upstream failed — serve stale cache
                 }
             }
             return with_content_type(false, data).into_response();

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -21,6 +21,7 @@ use crate::registry::{
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
+    body::Bytes,
     extract::{Path, Query, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
@@ -272,14 +273,7 @@ async fn registration_index(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "nuget", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = text.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("nuget");
+            state.spawn_cache("nuget", storage_key, Bytes::from(text.clone()));
             with_json(text.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -363,14 +357,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "nuget", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = text.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("nuget");
+            state.spawn_cache("nuget", storage_key, Bytes::from(text.clone()));
             with_json(text.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -509,14 +496,7 @@ async fn flatcontainer_download(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "nuget", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
+            state.spawn_cache_immutable("nuget", storage_key, Bytes::from(bytes.clone()));
 
             // Best-effort: fetch flatcontainer index.json if missing (for local search)
             if ends_with_ci(filename, ".nupkg") {
@@ -553,8 +533,6 @@ async fn flatcontainer_download(
                     let _ = storage3.put(&meta_key, meta.as_bytes()).await;
                 });
             }
-
-            state.repo_index.invalidate("nuget");
             (
                 StatusCode::OK,
                 [
@@ -615,13 +593,7 @@ fn upstream_url(state: &AppState) -> String {
         .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
 }
 
-fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    now.saturating_sub(modified_unix) < ttl_secs
-}
+use crate::cache_ttl::is_within_ttl;
 
 fn with_json(data: Vec<u8>) -> Response {
     (

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -22,6 +22,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
 use crate::AppState;
 use axum::{
+    body::Bytes,
     extract::{Path, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
@@ -110,7 +111,7 @@ async fn provider_versions(
     // TTL cache
     if let Ok(data) = state.storage.get(&storage_key).await {
         if let Some(meta) = state.storage.stat(&storage_key).await {
-            if is_within_ttl(meta.modified, 300) {
+            if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
                 state.metrics.record_cache_hit();
                 return with_json(data.to_vec());
@@ -150,14 +151,7 @@ async fn provider_versions(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = text.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("terraform");
+            state.spawn_cache("terraform", storage_key, Bytes::from(text.clone()));
             with_json(text.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -212,7 +206,7 @@ async fn provider_download_meta(
     // TTL cache for metadata
     if let Ok(data) = state.storage.get(&storage_key).await {
         if let Some(meta) = state.storage.stat(&storage_key).await {
-            if is_within_ttl(meta.modified, 300) {
+            if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
                 state.metrics.record_cache_hit();
                 return with_json(data.to_vec());
@@ -258,14 +252,7 @@ async fn provider_download_meta(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = rewritten.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("terraform");
+            state.spawn_cache("terraform", storage_key, Bytes::from(rewritten.clone()));
             with_json(rewritten.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -342,16 +329,7 @@ async fn provider_download_binary(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
 
             // Immutable cache
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = bytes.clone();
-            tokio::spawn(async move {
-                if storage.stat(&key).await.is_none() {
-                    let _ = storage.put(&key, &data).await;
-                }
-            });
-
-            state.repo_index.invalidate("terraform");
+            state.spawn_cache_immutable("terraform", storage_key, Bytes::from(bytes.clone()));
             with_binary(bytes)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -381,7 +359,7 @@ async fn module_versions(
     // TTL cache
     if let Ok(data) = state.storage.get(&storage_key).await {
         if let Some(meta) = state.storage.stat(&storage_key).await {
-            if is_within_ttl(meta.modified, 300) {
+            if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
                 state.metrics.record_cache_hit();
                 return with_json(data.to_vec());
@@ -422,14 +400,7 @@ async fn module_versions(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
 
-            let storage = state.storage.clone();
-            let key = storage_key;
-            let data = text.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key, data.as_bytes()).await;
-            });
-
-            state.repo_index.invalidate("terraform");
+            state.spawn_cache("terraform", storage_key, Bytes::from(text.clone()));
             with_json(text.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -566,13 +537,7 @@ fn upstream_url(state: &AppState) -> String {
         .unwrap_or_else(|| UPSTREAM_DEFAULT.to_string())
 }
 
-fn is_within_ttl(modified_unix: u64, ttl_secs: u64) -> bool {
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
-    now.saturating_sub(modified_unix) < ttl_secs
-}
+use crate::cache_ttl::is_within_ttl;
 
 fn with_json(data: Vec<u8>) -> Response {
     (

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -98,7 +98,7 @@ fn build_context(
             proxy: None,
             proxy_auth: None,
             proxy_timeout: 5,
-            metadata_ttl: 0,
+            metadata_ttl: -1,
         },
         pypi: PypiConfig {
             enabled: true,


### PR DESCRIPTION
## Summary
- **TTL semantics unified** across all 13 registries: `-1` = cache forever, `0` = always refetch, `>0` = TTL in seconds. Shared `is_within_ttl()` in new `cache_ttl` module replaces 4 duplicate implementations.
- **repo_index.invalidate() race condition fixed** in 9/13 registries — `spawn_cache()` / `spawn_cache_immutable()` helpers ensure invalidation happens after storage write completes, not before.
- **Terraform metadata_ttl** added to config (was hardcoded 300), with `NORA_TERRAFORM_METADATA_TTL` env var.
- **Gems `index_ttl` → `metadata_ttl`** renamed for consistency.
- **`nora.env.example`** updated with all 13 registry proxy vars, 5 TTL vars, and TTL semantics documentation.

## Test plan
- [x] `cargo build --release` — clean, 0 warnings
- [x] `cargo test` — 915 unit tests pass
- [x] e2e Part 06 (UI Dashboard) — 84 tests pass
- [ ] CI status checks