### PR TITLE
ci(release): decouple Trivy scan from release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,7 @@ jobs:
 
       - name: Trivy — image scan (${{ matrix.name }})
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        timeout-minutes: 15
         with:
           scan-type: image
           image-ref: ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}${{ matrix.suffix }}
@@ -213,7 +214,7 @@ jobs:
 
       - name: Upload Trivy image results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@a60c4df7a135c7317c1e9ddf9b5a9b07a910dda9 # v4
-        if: always()
+        if: always() && hashFiles(format('trivy-image-{0}.sarif', matrix.name))
         with:
           sarif_file: trivy-image-${{ matrix.name }}.sarif
           category: trivy-image-${{ matrix.name }}
@@ -233,7 +234,7 @@ jobs:
   release:
     name: GitHub Release
     runs-on: [self-hosted, nora]
-    needs: [build, scan, provenance]
+    needs: [build, provenance]
     permissions:
       contents: write
       id-token: write  # Sigstore cosign keyless signing


### PR DESCRIPTION
## Summary

- Remove `scan` from `release` job dependencies — Trivy scan failures no longer block binary publishing
- Add `timeout-minutes: 15` for Trivy image scans
- Guard SARIF upload with `hashFiles()` check to prevent cascading failure when Trivy exits before producing output

## Root cause of #264

The v0.8.1 release pipeline failed because:

1. **Scan (redos)** — Trivy binary download timed out (exit code 28, network issue on self-hosted runner)
2. **Scan (astra)** — Trivy scan timed out analyzing `usr/bin/partx` in the Astra image (`context deadline exceeded`)
3. Both scans failed to produce SARIF files → `upload-sarif` also failed
4. `GitHub Release` job had `needs: [build, scan, provenance]` → **skipped** due to scan failure
5. Result: release created with only SLSA provenance attestation, no binary/SBOM/checksum

## What changed

| Before | After |
|--------|-------|
| `release.needs: [build, scan, provenance]` | `release.needs: [build, provenance]` |
| Trivy uses default timeout | Trivy has explicit `timeout-minutes: 15` |
| `upload-sarif` runs with `if: always()` even if no SARIF exists | `upload-sarif` checks `hashFiles()` first |

Scan jobs still run in parallel and upload results to the Security tab — they just don't gate the release anymore.

## Test plan

- [ ] Tag a release — binary, SBOM, checksum all published regardless of scan status
- [ ] Simulate Trivy timeout — release still completes, scan shows as failed independently
- [ ] Verify Security tab still receives SARIF when scans succeed

Fixes #264