### PR TITLE
ci(release): notify helm-charts on new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,3 +332,12 @@ jobs:
             ## Changelog
 
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md)
+
+      - name: Notify helm-charts repo
+        if: success()
+        run: |
+          gh api repos/getnora-io/helm-charts/dispatches \
+            -f event_type=nora-release \
+            -f 'client_payload[version]=${{ steps.ver.outputs.tag }}'
+        env:
+          GH_TOKEN: ${{ secrets.HELM_CHARTS_PAT }}


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` step at the end of the release job that notifies `getnora-io/helm-charts` of a new version
- Uses `gh api` with `HELM_CHARTS_PAT` secret to send the dispatch event

## Setup required
Add a `HELM_CHARTS_PAT` secret to this repo — a PAT with `repo` scope that can dispatch to `getnora-io/helm-charts`.

## Test plan
- [ ] Add `HELM_CHARTS_PAT` secret to nora repo settings
- [ ] Verify on next `v*` tag push that helm-charts receives the dispatch