### PR TITLE
ci: fix post-release gate trigger to workflow_run

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,8 +1,9 @@
 name: Post-Release Gate
 
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
 
 permissions: read-all
 
@@ -10,6 +11,7 @@ jobs:
   verify:
     name: Post-Release Verification
     runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       packages: read
@@ -17,9 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Extract version from tag
+      - name: Extract version from triggering tag
         id: ver
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v3


### PR DESCRIPTION
## Summary
- Switch post-release gate trigger from `release: published` to `workflow_run: Release completed`
- `release: published` events created by `GITHUB_TOKEN` don't trigger other workflows (GitHub recursion protection)
- Version extracted from `workflow_run.head_branch` (the `v*` tag)
- Only runs when Release workflow succeeds (`conclusion == 'success'`)

## Test plan
- [ ] Verify on next release that post-release gate triggers automatically