### PR TITLE
docs: add reverse proxy setup guide

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -67,6 +67,42 @@ cd nora/deploy
 docker compose up -d
 ```
 
+### Reverse Proxy
+
+When running NORA behind a reverse proxy (Caddy, Traefik, Nginx, etc.),
+set `NORA_PUBLIC_URL` to your external domain. Without it, NORA generates
+download URLs pointing to `http://0.0.0.0:4000`, which clients cannot reach.
+
+```yaml
+# docker-compose.yml
+environment:
+  - NORA_PUBLIC_URL=https://registry.example.com
+```
+
+**PyPI index URL** — use `/simple/`, not `/pypi/simple/`:
+
+```bash
+pip install --index-url https://registry.example.com/simple/ requests
+```
+
+**Self-signed TLS** — pip silently fails with "No matching distribution found"
+unless you specify `--trusted-host` or `--cert`:
+
+```bash
+pip install \
+  --index-url https://registry.example.com/simple/ \
+  --trusted-host registry.example.com \
+  requests
+```
+
+To make these settings permanent, create `~/.pip/pip.conf`:
+
+```ini
+[global]
+index-url = https://registry.example.com/simple/
+trusted-host = registry.example.com
+```
+
 ### URLs
 
 | URL | Description |
@@ -148,6 +184,42 @@ pip install --index-url http://localhost:4000/simple/ requests
 git clone https://github.com/getnora-io/nora.git
 cd nora/deploy
 docker compose up -d
+```
+
+### Reverse Proxy
+
+При работе NORA за reverse proxy (Caddy, Traefik, Nginx и др.)
+установите `NORA_PUBLIC_URL` на ваш внешний домен. Без этой переменной NORA
+генерирует download-ссылки с `http://0.0.0.0:4000`, которые клиенты не могут достичь.
+
+```yaml
+# docker-compose.yml
+environment:
+  - NORA_PUBLIC_URL=https://registry.example.com
+```
+
+**URL для PyPI** — используйте `/simple/`, а не `/pypi/simple/`:
+
+```bash
+pip install --index-url https://registry.example.com/simple/ requests
+```
+
+**Самоподписанный TLS** — pip молча падает с ошибкой "No matching distribution found",
+если не указать `--trusted-host` или `--cert`:
+
+```bash
+pip install \
+  --index-url https://registry.example.com/simple/ \
+  --trusted-host registry.example.com \
+  requests
+```
+
+Для постоянной настройки создайте `~/.pip/pip.conf`:
+
+```ini
+[global]
+index-url = https://registry.example.com/simple/
+trusted-host = registry.example.com
 ```
 
 ### Эндпоинты

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - NORA_HOST=0.0.0.0
       - NORA_PORT=4000
       - NORA_AUTH_ENABLED=false
+      # Required when behind reverse proxy — used for download URLs
+      - NORA_PUBLIC_URL=https://demo.getnora.io
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/health"]
       interval: 10s

--- a/dist/nora.env.example
+++ b/dist/nora.env.example
@@ -4,6 +4,8 @@
 # Server
 NORA_HOST=0.0.0.0
 NORA_PORT=4000
+# Public URL — REQUIRED when behind reverse proxy (Caddy/Traefik/Nginx).
+# Used to generate correct download URLs for pip, npm, cargo, etc.
 # NORA_PUBLIC_URL=https://registry.example.com
 
 # Storage


### PR DESCRIPTION
## Summary

- Add `NORA_PUBLIC_URL` to `deploy/docker-compose.yml` with explanatory comment
- Add "Reverse Proxy" section to `deploy/README.md` (EN + RU) covering:
  - `NORA_PUBLIC_URL` requirement (without it download URLs point to `0.0.0.0:4000`)
  - Correct PyPI endpoint: `/simple/`, not `/pypi/simple/`
  - Self-signed TLS workaround (`--trusted-host`) and permanent `pip.conf`
- Expand `NORA_PUBLIC_URL` comment in `dist/nora.env.example`

No code changes — purely documentation.

## Test plan

- [ ] `grep -n PUBLIC_URL deploy/docker-compose.yml` shows the new variable
- [ ] `grep -n "simple/" deploy/README.md` — all references use `/simple/`, none use `/pypi/simple/`
- [ ] `grep -A2 PUBLIC_URL dist/nora.env.example` shows expanded comment
- [ ] `bash scripts/coherence-check.sh` passes