### PR TITLE
feat(raw): add POST /raw/-/reindex endpoint

### DIFF
--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -9,19 +9,30 @@ use axum::{
     extract::{Path, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
     Router,
 };
 use std::sync::Arc;
 
 pub fn routes() -> Router<Arc<AppState>> {
-    Router::new().route(
+    Router::new().route("/raw/-/reindex", post(reindex)).route(
         "/raw/{*path}",
         get(download)
             .put(upload)
             .delete(delete_file)
             .head(check_exists),
     )
+}
+
+/// Invalidate the raw index so it rebuilds on next read.
+/// Useful after uploading files directly to S3/storage bypassing the API.
+async fn reindex(State(state): State<Arc<AppState>>) -> Response {
+    if !state.config.raw.enabled {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    state.repo_index.invalidate("raw");
+    tracing::info!("raw index invalidated via API");
+    StatusCode::OK.into_response()
 }
 
 async fn download(
@@ -393,6 +404,20 @@ mod integration_tests {
         assert_eq!(get.status(), StatusCode::NOT_FOUND);
         let put = send(&ctx.app, Method::PUT, "/raw/test.txt", b"data".to_vec()).await;
         assert_eq!(put.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_raw_reindex_endpoint() {
+        let ctx = create_test_context();
+        let resp = send(&ctx.app, Method::POST, "/raw/-/reindex", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_raw_reindex_disabled() {
+        let ctx = create_test_context_with_raw_disabled();
+        let resp = send(&ctx.app, Method::POST, "/raw/-/reindex", "").await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     #[tokio::test]

--- a/tests/e2e/tests/raw-reindex.spec.ts
+++ b/tests/e2e/tests/raw-reindex.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Raw Reindex', () => {
+  const authHeader = process.env.NORA_AUTH
+    ? { Authorization: `Basic ${Buffer.from(process.env.NORA_AUTH).toString('base64')}` }
+    : {};
+
+  test('reindex endpoint returns 200', async ({ request }) => {
+    const resp = await request.post('/raw/-/reindex');
+    expect(resp.status()).toBe(200);
+  });
+
+  test('files uploaded via API appear in UI after reindex', async ({ request, page }) => {
+    // 1. Upload file via NORA API
+    const filename = `reindex-e2e-${Date.now()}`;
+    const putResp = await request.put(`/raw/${filename}/data.txt`, {
+      data: 'reindex-test',
+      headers: authHeader,
+    });
+    expect(putResp.status()).toBe(201);
+
+    // 2. POST /raw/-/reindex to force index rebuild
+    const reindexResp = await request.post('/raw/-/reindex');
+    expect(reindexResp.status()).toBe(200);
+
+    // 3. Check API listing contains the new file
+    const listResp = await request.get('/api/ui/raw/list');
+    expect(listResp.ok()).toBeTruthy();
+    const list = await listResp.json();
+    const found = list.some((r: any) => r.name === filename);
+    expect(found).toBe(true);
+
+    // 4. Check UI shows the file
+    await page.goto('/ui/raw');
+    await expect(page.locator(`text=${filename}`)).toBeVisible();
+  });
+});

--- a/tests/s3-backends/docker-compose.yml
+++ b/tests/s3-backends/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     ports:
       - "8333:8333"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9333/cluster/status"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:9333/cluster/status"]
       interval: 5s
       timeout: 5s
       retries: 10
@@ -69,29 +69,20 @@ services:
       - garage-meta:/var/lib/garage/meta
       - ./garage.toml:/etc/garage.toml:ro
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3903/health"]
+      test: ["CMD", "/garage", "stats", "-a"]
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 5s
 
   garage-init:
-    image: dxflrs/garage:v1.0.1
+    image: alpine:latest
     depends_on:
       garage:
         condition: service_healthy
     volumes:
-      - ./garage.toml:/etc/garage.toml:ro
-    entrypoint: >
-      sh -c "
-        export GARAGE_RPC_HOST=garage:3901 &&
-        sleep 2 &&
-        NODE_ID=$$(garage node id 2>/dev/null | head -1 | cut -d@ -f1) &&
-        garage layout assign -z dc1 -c 1G $$NODE_ID &&
-        garage layout apply --version 1 &&
-        garage key create nora-test-key &&
-        garage bucket create nora-test &&
-        garage bucket allow --read --write --owner nora-test --key nora-test-key
-      "
+      - ./garage-init.sh:/garage-init.sh:ro
+    entrypoint: ["/bin/sh", "/garage-init.sh"]
 
   # ============================================================
   # NORA instances (one per backend)
@@ -101,7 +92,7 @@ services:
     image: nora:local
     build:
       context: ../..
-      dockerfile: docker/Dockerfile
+      dockerfile: Dockerfile
     depends_on:
       rustfs-init:
         condition: service_completed_successfully
@@ -123,7 +114,7 @@ services:
     image: nora:local
     build:
       context: ../..
-      dockerfile: docker/Dockerfile
+      dockerfile: Dockerfile
     depends_on:
       seaweedfs-init:
         condition: service_completed_successfully
@@ -143,7 +134,7 @@ services:
     image: nora:local
     build:
       context: ../..
-      dockerfile: docker/Dockerfile
+      dockerfile: Dockerfile
     depends_on:
       garage-init:
         condition: service_completed_successfully
@@ -161,6 +152,24 @@ services:
       NORA_PUBLIC_URL: http://localhost:15003
     ports:
       - "15003:5000"
+
+  # ============================================================
+  # S3 tools (for direct S3 upload in reindex tests)
+  # ============================================================
+
+  s3-tools:
+    image: minio/mc:latest
+    entrypoint: >
+      sh -c "
+        mc alias set rustfs http://rustfs:9000 minioadmin minioadmin &&
+        mc alias set seaweedfs http://seaweedfs:8333 '' '' --api S3v4 &&
+        sleep infinity
+      "
+    depends_on:
+      rustfs-init:
+        condition: service_completed_successfully
+      seaweedfs-init:
+        condition: service_completed_successfully
 
 volumes:
   garage-data:

--- a/tests/s3-backends/garage-init.sh
+++ b/tests/s3-backends/garage-init.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+
+apk add --no-cache curl jq >/dev/null 2>&1
+
+ADMIN=http://garage:3903
+AUTH="Authorization: Bearer testtoken"
+CT="Content-Type: application/json"
+
+sleep 2
+
+# Get node ID
+NODE_ID=$(curl -sf -H "$AUTH" "$ADMIN/v1/status" | jq -r '.node')
+echo "Node ID: $NODE_ID"
+
+# Assign layout
+curl -sf -X POST -H "$AUTH" -H "$CT" "$ADMIN/v1/layout" \
+  -d "[{\"id\":\"$NODE_ID\",\"zone\":\"dc1\",\"capacity\":1073741824,\"tags\":[]}]"
+
+# Get next layout version
+LAYOUT_VER=$(curl -sf -H "$AUTH" "$ADMIN/v1/layout" | jq '.version + 1')
+echo "Layout version: $LAYOUT_VER"
+
+# Apply layout
+curl -sf -X POST -H "$AUTH" -H "$CT" "$ADMIN/v1/layout/apply" \
+  -d "{\"version\":$LAYOUT_VER}"
+
+# Create key and capture access key ID
+KEY_RESP=$(curl -sf -X POST -H "$AUTH" -H "$CT" "$ADMIN/v1/key" \
+  -d '{"name":"nora-test-key"}')
+KEY_ID=$(echo "$KEY_RESP" | jq -r '.accessKeyId')
+echo "Key ID: $KEY_ID"
+
+# Create bucket and capture bucket ID
+BUCKET_RESP=$(curl -sf -X POST -H "$AUTH" -H "$CT" "$ADMIN/v1/bucket" \
+  -d '{"globalAlias":"nora-test"}')
+BUCKET_ID=$(echo "$BUCKET_RESP" | jq -r '.id')
+echo "Bucket ID: $BUCKET_ID"
+
+# Allow key on bucket
+curl -sf -X POST -H "$AUTH" -H "$CT" "$ADMIN/v1/bucket/allow" \
+  -d "{\"bucketId\":\"$BUCKET_ID\",\"accessKeyId\":\"$KEY_ID\",\"permissions\":{\"read\":true,\"write\":true,\"owner\":true}}"
+
+echo "Garage init complete"

--- a/tests/s3-backends/garage.toml
+++ b/tests/s3-backends/garage.toml
@@ -3,10 +3,8 @@ data_dir = "/var/lib/garage/data"
 db_engine = "sqlite"
 
 replication_factor = 1
-
-[rpc]
-bind_addr = "[::]:3901"
-secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+rpc_bind_addr = "[::]:3901"
+rpc_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
 [s3_api]
 s3_region = "garage"
@@ -14,6 +12,8 @@ api_bind_addr = "[::]:3900"
 
 [s3_web]
 bind_addr = "[::]:3902"
+root_domain = ".web.garage.localhost"
 
 [admin]
 api_bind_addr = "[::]:3903"
+admin_token = "testtoken"

--- a/tests/s3-backends/test.sh
+++ b/tests/s3-backends/test.sh
@@ -131,6 +131,79 @@ test_backend() {
     else
         fail "${name}: binary size expected ~8192, got ${bin_size}"
     fi
+
+    # 9. Reindex after direct S3 upload
+    # Upload a file directly to S3 (bypassing NORA API), then verify
+    # that POST /raw/-/reindex makes it appear in the index listing.
+    # Note: NORA encodes @ → _at_ in S3 keys (SeaweedFS compat), so we
+    # use a plain path without @ for this test.
+    local reindex_key="raw/s3-direct/reindex-test.txt"
+    local reindex_data="direct-upload-$(date +%s)"
+    local uploaded=false
+
+    case "$name" in
+        RustFS)
+            # Upload via mc in s3-tools container
+            if echo "$reindex_data" | docker compose exec -T s3-tools \
+                mc pipe "rustfs/nora-test/${reindex_key}" >/dev/null 2>&1; then
+                uploaded=true
+            fi
+            ;;
+        SeaweedFS)
+            # SeaweedFS allows anonymous PUT via mapped port
+            if echo "$reindex_data" | curl -sf -T - \
+                "http://localhost:8333/nora-test/${reindex_key}" >/dev/null 2>&1; then
+                uploaded=true
+            fi
+            ;;
+        Garage)
+            # Garage requires dynamic credentials from garage-init; skip
+            skip "${name}: reindex (direct S3 upload requires dynamic Garage credentials)"
+            uploaded=""
+            ;;
+    esac
+
+    if [ "$uploaded" = "" ]; then
+        # Already handled (skipped)
+        :
+    elif [ "$uploaded" = "true" ]; then
+        # 9a. File should be readable via NORA storage (direct read, no index needed)
+        content=$(curl -sf "${base}/raw/s3-direct/reindex-test.txt" 2>/dev/null || echo "")
+        if [ "$content" = "$reindex_data" ]; then
+            pass "${name}: direct S3 file readable via NORA"
+        else
+            fail "${name}: direct S3 file not readable via NORA (got '${content}')"
+        fi
+
+        # 9b. File should NOT be in the index listing yet (index is stale)
+        local list_before
+        list_before=$(curl -sf "${base}/api/ui/raw/list" 2>/dev/null || echo "[]")
+        if echo "$list_before" | grep -q "s3-direct"; then
+            # Index may have been rebuilt already (lazy rebuild); not a hard failure
+            skip "${name}: reindex pre-check (index already contains s3-direct, lazy rebuild)"
+        else
+            pass "${name}: reindex pre-check (s3-direct not in stale index)"
+        fi
+
+        # 9c. POST /raw/-/reindex → 200
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "${base}/raw/-/reindex")
+        if [ "$http_code" = "200" ]; then
+            pass "${name}: POST /raw/-/reindex returns 200"
+        else
+            fail "${name}: POST /raw/-/reindex returned ${http_code}"
+        fi
+
+        # 9d. After reindex, file should appear in the index listing
+        local list_after
+        list_after=$(curl -sf "${base}/api/ui/raw/list" 2>/dev/null || echo "[]")
+        if echo "$list_after" | grep -q "s3-direct"; then
+            pass "${name}: reindex updated index (s3-direct found in listing)"
+        else
+            fail "${name}: reindex did not update index (s3-direct not in listing)"
+        fi
+    else
+        fail "${name}: direct S3 upload failed"
+    fi
 }
 
 echo "=============================="


### PR DESCRIPTION
## Summary

- Added `POST /raw/-/reindex` endpoint to invalidate raw registry index after direct S3 uploads
- Fixed `docker-compose.yml` Dockerfile path (`docker/Dockerfile` → `Dockerfile`)
- Added `s3-tools` service to docker-compose for direct S3 upload in tests
- Added reindex section (9) to `tests/s3-backends/test.sh` — direct S3 upload → reindex → verify listing (RustFS, SeaweedFS; Garage skipped due to dynamic credentials)
- Added `tests/e2e/tests/raw-reindex.spec.ts` Playwright test

## Test plan

- [ ] `cargo test` — unit tests for reindex endpoint (200 when enabled, 404 when disabled)
- [ ] `cd tests/s3-backends && docker compose up -d --build && ./test.sh` — section 9 covers reindex flow on RustFS and SeaweedFS
- [ ] `cd tests/e2e && NORA_URL=http://localhost:15001 npx playwright test raw-reindex` — UI verification