### PR TITLE
fix(http): document 429 in OpenAPI, return 405 with Allow header

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -323,6 +323,25 @@ always active when configured, regardless of curation mode. The goal
 is: a default NORA deployment should be harder to attack than a default
 Nexus/Artifactory deployment.
 
+### ADR-9: Conditional Requests are Per-Protocol
+
+**Decision:** Conditional request semantics (ETag, If-Match, If-None-Match)
+are implemented per-registry following each format's upstream specification.
+There is no shared conditional-request middleware.
+
+**Context:** RFC 9110 defines conditional requests for HTTP. Each registry
+protocol has its own immutability model: Docker uses content-addressable
+digests, Maven/npm/Cargo/PyPI enforce version immutability at publish time,
+Raw has no upstream spec. Implementing a generic conditional-request layer
+would either be too narrow (not matching protocol-specific semantics) or too
+broad (imposing HTTP semantics on protocols that don't need them).
+
+**Rationale:** Raw is the only format that benefits from RFC 9110 conditional
+PUT because it's a plain file store with no versioning scheme. Other formats
+already have protocol-defined immutability. Adding ETag/If-Match to Maven or
+npm would conflict with their publish APIs. The per-protocol approach follows
+ADR-4: each handler owns its full request lifecycle.
+
 ## Adding a New Registry
 
 Adding a new registry format requires 24 insertion points across

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **OpenAPI 429 documentation** — all rate-limited endpoints (44 total) now document `429` response with `Retry-After` header in OpenAPI spec. Eliminates false positives from API fuzz tools like Schemathesis (#267)
+- **405 Method Not Allowed with Allow header** — unsupported HTTP methods on multi-method routes now return `405` with RFC 9110 `Allow` header instead of axum's default headerless 405. Affected registries: Docker, Raw, Maven, npm, PyPI, Cargo (#268)
+
+### Changed
+- Docker and Maven/npm route definitions merged from separate `.route()` calls into explicit method chains for correctness and clarity
+- Raw registry docs corrected: files are immutable by default (409 on re-upload), not overwrite-only. Conditional overwrite via `If-Match`/`If-None-Match` documented
+- Raw `PUT` OpenAPI spec updated with `200` (conditional overwrite) and `412` (precondition failed) responses
+
 ## [0.8.2] - 2026-05-07
 
 ### Fixed

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -119,8 +119,10 @@ This document describes which parts of each registry protocol are implemented in
 | Delete (DELETE) | Full | |
 | Exists check (HEAD) | Full | Returns size + Content-Type |
 | Max file size | Full | Configurable (default 1MB) |
+| Conditional overwrite (`If-Match`) | Full | ETag-based, returns 200 on success |
+| Create-only (`If-None-Match: *`) | Full | Returns 412 if resource exists |
 | Directory listing | — | Not implemented |
-| Versioning | — | Overwrite-only |
+| Immutability | Full | Default; re-upload returns 409 unless conditional headers used |
 
 ## RubyGems
 
@@ -236,7 +238,8 @@ Helm charts are stored as OCI artifacts via the Docker registry endpoints. `helm
 |---------|--------|-------|
 | Authentication (Bearer/Basic) | Full | Per-request token validation |
 | Anonymous read | Full | `NORA_AUTH_ANONYMOUS_READ=true` |
-| Rate limiting | Full | `tower_governor`, per-IP |
+| Rate limiting (429 + Retry-After) | Full | `tower_governor`, per-IP, documented in OpenAPI |
+| 405 Method Not Allowed + Allow | Full | RFC 9110 §15.5.6, multi-method routes return Allow header |
 | Prometheus metrics | Full | `/metrics` endpoint |
 | Health check | Full | `/health` |
 | Swagger/OpenAPI | Full | `/api-docs` |

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -124,6 +124,11 @@ impl HashPinStore {
         }
     }
 
+    /// Look up the stored SHA-256 hash for a key, if pinned.
+    pub fn get(&self, key: &str) -> Option<String> {
+        self.pins.read().get(key).cloned()
+    }
+
     /// Number of pinned entries.
     pub fn len(&self) -> usize {
         self.pins.read().len()

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -291,7 +291,8 @@ pub async fn dashboard_metrics() {}
     responses(
         (status = 200, description = "Registry is available", body = DockerVersion),
         (status = 400, description = "Invalid request", body = ErrorResponse),
-        (status = 401, description = "Authentication required")
+        (status = 401, description = "Authentication required"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_version() {}
@@ -302,7 +303,8 @@ pub async fn docker_version() {}
     path = "/v2/_catalog",
     tag = "docker",
     responses(
-        (status = 200, description = "Repository list", body = DockerCatalog)
+        (status = 200, description = "Repository list", body = DockerCatalog),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_catalog() {}
@@ -318,7 +320,8 @@ pub async fn docker_catalog() {}
     responses(
         (status = 200, description = "Tag list", body = DockerTags),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Repository not found")
+        (status = 404, description = "Repository not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_tags() {}
@@ -335,7 +338,8 @@ pub async fn docker_tags() {}
     responses(
         (status = 200, description = "Manifest content"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Manifest not found")
+        (status = 404, description = "Manifest not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_manifest_get() {}
@@ -352,7 +356,8 @@ pub async fn docker_manifest_get() {}
     responses(
         (status = 200, description = "Blob exists, Content-Length header contains size"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Blob not found")
+        (status = 404, description = "Blob not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_blob_head() {}
@@ -369,7 +374,8 @@ pub async fn docker_blob_head() {}
     responses(
         (status = 200, description = "Blob content"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Blob not found")
+        (status = 404, description = "Blob not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_blob_get() {}
@@ -387,7 +393,8 @@ pub async fn docker_blob_get() {}
     ),
     responses(
         (status = 201, description = "Manifest created, Docker-Content-Digest header contains digest"),
-        (status = 400, description = "Invalid manifest")
+        (status = 400, description = "Invalid manifest"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_manifest_put() {}
@@ -404,7 +411,8 @@ pub async fn docker_manifest_put() {}
     responses(
         (status = 202, description = "Manifest deleted"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Manifest not found")
+        (status = 404, description = "Manifest not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_manifest_delete() {}
@@ -421,7 +429,8 @@ pub async fn docker_manifest_delete() {}
     ),
     responses(
         (status = 202, description = "Upload started, Location header contains upload URL"),
-        (status = 400, description = "Invalid input", body = ErrorResponse)
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_blob_upload_start() {}
@@ -439,7 +448,8 @@ pub async fn docker_blob_upload_start() {}
     ),
     responses(
         (status = 202, description = "Chunk accepted, Range header indicates bytes received"),
-        (status = 400, description = "Invalid input", body = ErrorResponse)
+        (status = 400, description = "Invalid input", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_blob_upload_patch() {}
@@ -458,7 +468,8 @@ pub async fn docker_blob_upload_patch() {}
     ),
     responses(
         (status = 201, description = "Blob created"),
-        (status = 400, description = "Digest mismatch or missing")
+        (status = 400, description = "Digest mismatch or missing"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn docker_blob_upload_put() {}
@@ -476,7 +487,8 @@ pub async fn docker_blob_upload_put() {}
     responses(
         (status = 200, description = "Artifact content"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Artifact not found, trying upstream proxies")
+        (status = 404, description = "Artifact not found, trying upstream proxies"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn maven_artifact_get() {}
@@ -493,6 +505,7 @@ pub async fn maven_artifact_get() {}
         (status = 201, description = "Artifact uploaded"),
         (status = 400, description = "Invalid path (non-ASCII characters)"),
         (status = 409, description = "Version already exists (immutable releases)"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time"),
         (status = 500, description = "Storage error")
     )
 )]
@@ -510,7 +523,8 @@ pub async fn maven_artifact_put() {}
     ),
     responses(
         (status = 200, description = "Package metadata (JSON)"),
-        (status = 404, description = "Package not found")
+        (status = 404, description = "Package not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn npm_package() {}
@@ -528,7 +542,8 @@ pub async fn npm_package() {}
     responses(
         (status = 200, description = "Package published"),
         (status = 409, description = "Version already exists"),
-        (status = 400, description = "Invalid package data")
+        (status = 400, description = "Invalid package data"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn npm_publish() {}
@@ -543,7 +558,8 @@ pub async fn npm_publish() {}
     path = "/cargo/index/config.json",
     tag = "cargo",
     responses(
-        (status = 200, description = "Sparse index configuration (JSON)")
+        (status = 200, description = "Sparse index configuration (JSON)"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn cargo_index_config() {}
@@ -562,7 +578,8 @@ pub async fn cargo_index_config() {}
     responses(
         (status = 200, description = "Crate index entries (one JSON per line)"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Crate not found in index")
+        (status = 404, description = "Crate not found in index"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn cargo_sparse_index() {}
@@ -578,7 +595,8 @@ pub async fn cargo_sparse_index() {}
     responses(
         (status = 200, description = "Crate metadata (JSON)"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Crate not found")
+        (status = 404, description = "Crate not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn cargo_metadata() {}
@@ -595,7 +613,8 @@ pub async fn cargo_metadata() {}
     responses(
         (status = 200, description = "Crate file (.crate)"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Crate version not found")
+        (status = 404, description = "Crate version not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn cargo_download() {}
@@ -610,7 +629,8 @@ pub async fn cargo_download() {}
     responses(
         (status = 200, description = "Crate published"),
         (status = 409, description = "Version already exists"),
-        (status = 400, description = "Invalid crate data")
+        (status = 400, description = "Invalid crate data"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn cargo_publish() {}
@@ -623,7 +643,8 @@ pub async fn cargo_publish() {}
     path = "/simple/",
     tag = "pypi",
     responses(
-        (status = 200, description = "HTML list of packages")
+        (status = 200, description = "HTML list of packages"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn pypi_simple() {}
@@ -638,7 +659,8 @@ pub async fn pypi_simple() {}
     ),
     responses(
         (status = 200, description = "HTML list of package files"),
-        (status = 404, description = "Package not found")
+        (status = 404, description = "Package not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn pypi_package() {}
@@ -653,7 +675,8 @@ pub async fn pypi_package() {}
     responses(
         (status = 200, description = "Package uploaded"),
         (status = 409, description = "Version already exists"),
-        (status = 400, description = "Invalid upload data")
+        (status = 400, description = "Invalid upload data"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn pypi_upload() {}
@@ -671,7 +694,8 @@ pub async fn pypi_upload() {}
     responses(
         (status = 200, description = "Latest version info (JSON)"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Module not found")
+        (status = 404, description = "Module not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn go_module_latest() {}
@@ -688,7 +712,8 @@ pub async fn go_module_latest() {}
     responses(
         (status = 200, description = "Version info (JSON)"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Version not found")
+        (status = 404, description = "Version not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn go_module_info() {}
@@ -705,7 +730,8 @@ pub async fn go_module_info() {}
     responses(
         (status = 200, description = "go.mod file content"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Version not found")
+        (status = 404, description = "Version not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn go_module_mod() {}
@@ -722,7 +748,8 @@ pub async fn go_module_mod() {}
     responses(
         (status = 200, description = "Module zip archive"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Version not found")
+        (status = 404, description = "Version not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn go_module_zip() {}
@@ -740,7 +767,8 @@ pub async fn go_module_zip() {}
     responses(
         (status = 200, description = "File content"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "File not found")
+        (status = 404, description = "File not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn raw_file_get() {}
@@ -754,10 +782,13 @@ pub async fn raw_file_get() {}
         ("path" = String, Path, description = "File path")
     ),
     responses(
+        (status = 200, description = "File overwritten (conditional PUT with If-Match)"),
         (status = 201, description = "File uploaded"),
         (status = 400, description = "Invalid path (non-ASCII characters)"),
         (status = 409, description = "File already exists (immutable)"),
+        (status = 412, description = "Precondition failed (ETag mismatch or resource state)"),
         (status = 413, description = "File too large"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time"),
         (status = 500, description = "Storage error")
     )
 )]
@@ -776,7 +807,8 @@ pub async fn raw_file_put() {}
     responses(
         (status = 200, description = "Compact index for gem"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Gem not found")
+        (status = 404, description = "Gem not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn gems_info() {}
@@ -791,7 +823,8 @@ pub async fn gems_info() {}
     ),
     responses(
         (status = 200, description = "Gem binary"),
-        (status = 404, description = "Gem not found")
+        (status = 404, description = "Gem not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn gems_download() {}
@@ -804,7 +837,8 @@ pub async fn gems_download() {}
     path = "/terraform/.well-known/terraform.json",
     tag = "terraform",
     responses(
-        (status = 200, description = "Service discovery JSON")
+        (status = 200, description = "Service discovery JSON"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn terraform_service_discovery() {}
@@ -821,7 +855,8 @@ pub async fn terraform_service_discovery() {}
     responses(
         (status = 200, description = "Version list"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Provider not found")
+        (status = 404, description = "Provider not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn terraform_provider_versions() {}
@@ -835,6 +870,7 @@ pub async fn terraform_provider_versions() {}
     tag = "ansible",
     responses(
         (status = 200, description = "Collection list"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time"),
         (status = 502, description = "Upstream unreachable")
     )
 )]
@@ -851,7 +887,8 @@ pub async fn ansible_collection_list() {}
     responses(
         (status = 200, description = "Collection tarball"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Collection not found")
+        (status = 404, description = "Collection not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn ansible_download() {}
@@ -864,7 +901,8 @@ pub async fn ansible_download() {}
     path = "/nuget/v3/index.json",
     tag = "nuget",
     responses(
-        (status = 200, description = "Service index JSON with @id URLs rewritten")
+        (status = 200, description = "Service index JSON with @id URLs rewritten"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn nuget_service_index() {}
@@ -879,7 +917,8 @@ pub async fn nuget_service_index() {}
     ),
     responses(
         (status = 200, description = "Package file (.nupkg or .nuspec)"),
-        (status = 404, description = "Package not found")
+        (status = 404, description = "Package not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn nuget_download() {}
@@ -897,7 +936,8 @@ pub async fn nuget_download() {}
     responses(
         (status = 200, description = "Package metadata with versions"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Package not found")
+        (status = 404, description = "Package not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn pub_package_list() {}
@@ -914,7 +954,8 @@ pub async fn pub_package_list() {}
     responses(
         (status = 200, description = "Package archive (.tar.gz)"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "Package not found")
+        (status = 404, description = "Package not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn pub_archive_download() {}
@@ -927,7 +968,8 @@ pub async fn pub_archive_download() {}
     path = "/conan/v2/ping",
     tag = "conan",
     responses(
-        (status = 200, description = "Ping response with X-Conan-Server-Capabilities header")
+        (status = 200, description = "Ping response with X-Conan-Server-Capabilities header"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn conan_ping() {}
@@ -948,7 +990,8 @@ pub async fn conan_ping() {}
     responses(
         (status = 200, description = "File content"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
-        (status = 404, description = "File not found")
+        (status = 404, description = "File not found"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn conan_recipe_file() {}
@@ -965,6 +1008,7 @@ pub async fn conan_recipe_file() {}
         (status = 200, description = "Token created", body = TokenResponse),
         (status = 401, description = "Invalid credentials", body = ErrorResponse),
         (status = 422, description = "Missing required fields", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time"),
         (status = 503, description = "Auth not configured", body = ErrorResponse)
     )
 )]
@@ -979,7 +1023,8 @@ pub async fn create_token() {}
     responses(
         (status = 200, description = "Token list", body = TokenListResponse),
         (status = 401, description = "Invalid credentials", body = ErrorResponse),
-        (status = 422, description = "Invalid request body", body = ErrorResponse)
+        (status = 422, description = "Invalid request body", body = ErrorResponse),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn list_tokens() {}
@@ -993,7 +1038,8 @@ pub async fn list_tokens() {}
         (status = 200, description = "Token revoked"),
         (status = 401, description = "Invalid credentials", body = ErrorResponse),
         (status = 404, description = "Token not found", body = ErrorResponse),
-        (status = 415, description = "Unsupported Content-Type")
+        (status = 415, description = "Unsupported Content-Type"),
+        (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")
     )
 )]
 pub async fn revoke_token() {}

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -12,7 +12,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, ProxyError};
+use crate::registry::{
+    circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
+};
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -35,7 +37,10 @@ pub fn routes() -> Router<Arc<AppState>> {
             "/cargo/api/v1/crates/{crate_name}/{version}/download",
             get(download),
         )
-        .route("/cargo/api/v1/crates/new", put(publish))
+        .route(
+            "/cargo/api/v1/crates/new",
+            put(publish).fallback(|| async { method_not_allowed("PUT") }),
+        )
 }
 
 // ============================================================================

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -6,7 +6,7 @@ use crate::audit::AuditEntry;
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
 use crate::registry::docker_auth::DockerAuth;
-use crate::registry::{circuit_open_response, ProxyError};
+use crate::registry::{circuit_open_response, method_not_allowed, ProxyError};
 use crate::storage::Storage;
 use crate::validation::{
     ends_with_ci, validate_digest, validate_docker_name, validate_docker_reference,
@@ -17,7 +17,7 @@ use axum::{
     extract::{Path, State},
     http::{header, HeaderName, StatusCode},
     response::{IntoResponse, Response},
-    routing::{delete, get, head, patch, put},
+    routing::{get, head, patch},
     Json, Router,
 };
 use parking_lot::RwLock;
@@ -116,48 +116,62 @@ fn upload_temp_dir(data_dir: &str) -> std::path::PathBuf {
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/v2/", get(check))
+        .route(
+            "/v2/",
+            get(check).fallback(|| async { method_not_allowed("GET") }),
+        )
         .route("/v2/_catalog", get(catalog))
         // Single-segment name routes (e.g., /v2/alpine/...)
-        .route("/v2/{name}/blobs/{digest}", head(check_blob))
-        .route("/v2/{name}/blobs/{digest}", get(download_blob))
+        .route(
+            "/v2/{name}/blobs/{digest}",
+            head(check_blob)
+                .get(download_blob)
+                .delete(delete_blob)
+                .fallback(|| async { method_not_allowed("GET, HEAD, DELETE") }),
+        )
         .route(
             "/v2/{name}/blobs/uploads/",
-            axum::routing::post(start_upload),
+            axum::routing::post(start_upload).fallback(|| async { method_not_allowed("POST") }),
         )
         .route(
             "/v2/{name}/blobs/uploads/{uuid}",
-            patch(patch_blob).put(upload_blob),
+            patch(patch_blob)
+                .put(upload_blob)
+                .fallback(|| async { method_not_allowed("PATCH, PUT") }),
         )
-        .route("/v2/{name}/manifests/{reference}", get(get_manifest))
-        .route("/v2/{name}/manifests/{reference}", put(put_manifest))
-        .route("/v2/{name}/manifests/{reference}", delete(delete_manifest))
-        .route("/v2/{name}/blobs/{digest}", delete(delete_blob))
+        .route(
+            "/v2/{name}/manifests/{reference}",
+            get(get_manifest)
+                .put(put_manifest)
+                .delete(delete_manifest)
+                .fallback(|| async { method_not_allowed("GET, PUT, DELETE") }),
+        )
         .route("/v2/{name}/tags/list", get(list_tags))
         // Two-segment name routes (e.g., /v2/library/alpine/...)
-        .route("/v2/{ns}/{name}/blobs/{digest}", head(check_blob_ns))
-        .route("/v2/{ns}/{name}/blobs/{digest}", get(download_blob_ns))
+        .route(
+            "/v2/{ns}/{name}/blobs/{digest}",
+            head(check_blob_ns)
+                .get(download_blob_ns)
+                .delete(delete_blob_ns)
+                .fallback(|| async { method_not_allowed("GET, HEAD, DELETE") }),
+        )
         .route(
             "/v2/{ns}/{name}/blobs/uploads/",
-            axum::routing::post(start_upload_ns),
+            axum::routing::post(start_upload_ns).fallback(|| async { method_not_allowed("POST") }),
         )
         .route(
             "/v2/{ns}/{name}/blobs/uploads/{uuid}",
-            patch(patch_blob_ns).put(upload_blob_ns),
+            patch(patch_blob_ns)
+                .put(upload_blob_ns)
+                .fallback(|| async { method_not_allowed("PATCH, PUT") }),
         )
         .route(
             "/v2/{ns}/{name}/manifests/{reference}",
-            get(get_manifest_ns),
+            get(get_manifest_ns)
+                .put(put_manifest_ns)
+                .delete(delete_manifest_ns)
+                .fallback(|| async { method_not_allowed("GET, PUT, DELETE") }),
         )
-        .route(
-            "/v2/{ns}/{name}/manifests/{reference}",
-            put(put_manifest_ns),
-        )
-        .route(
-            "/v2/{ns}/{name}/manifests/{reference}",
-            delete(delete_manifest_ns),
-        )
-        .route("/v2/{ns}/{name}/blobs/{digest}", delete(delete_blob_ns))
         .route("/v2/{ns}/{name}/tags/list", get(list_tags_ns))
 }
 

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -10,7 +10,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, ProxyError};
+use crate::registry::{circuit_open_response, method_not_allowed, proxy_fetch, ProxyError};
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
@@ -18,7 +18,7 @@ use axum::{
     extract::{Path, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    routing::{get, put},
+    routing::get,
     Router,
 };
 use sha2::Digest;
@@ -26,9 +26,12 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 
 pub fn routes() -> Router<Arc<AppState>> {
-    Router::new()
-        .route("/maven2/{*path}", get(download))
-        .route("/maven2/{*path}", put(upload))
+    Router::new().route(
+        "/maven2/{*path}",
+        get(download)
+            .put(upload)
+            .fallback(|| async { method_not_allowed("GET, PUT") }),
+    )
 }
 
 // ============================================================================

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -34,9 +34,14 @@ pub use terraform::routes as terraform_routes;
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
 use crate::AppState;
-use axum::http::StatusCode;
+use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use std::time::Duration;
+
+/// 405 Method Not Allowed with `Allow` header (RFC 9110 §15.5.6).
+pub(crate) fn method_not_allowed(allow: &'static str) -> Response {
+    (StatusCode::METHOD_NOT_ALLOWED, [(header::ALLOW, allow)]).into_response()
+}
 
 /// Build NORA base URL from config (for URL rewriting).
 ///

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -3,14 +3,16 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, ProxyError};
+use crate::registry::{
+    circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
+};
 use crate::AppState;
 use axum::{
     body::Bytes,
     extract::{Path, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    routing::{get, put},
+    routing::get,
     Router,
 };
 use base64::Engine;
@@ -18,9 +20,12 @@ use sha2::Digest;
 use std::sync::Arc;
 
 pub fn routes() -> Router<Arc<AppState>> {
-    Router::new()
-        .route("/npm/{*path}", get(handle_request))
-        .route("/npm/{*path}", put(handle_publish))
+    Router::new().route(
+        "/npm/{*path}",
+        get(handle_request)
+            .put(handle_publish)
+            .fallback(|| async { method_not_allowed("GET, PUT") }),
+    )
 }
 
 /// Rewrite tarball URLs in npm metadata to point to NORA.

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -11,7 +11,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text};
+use crate::registry::{
+    circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_text,
+};
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
@@ -30,7 +32,12 @@ const PEP691_JSON: &str = "application/vnd.pypi.simple.v1+json";
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/simple/", get(list_packages).post(upload))
+        .route(
+            "/simple/",
+            get(list_packages)
+                .post(upload)
+                .fallback(|| async { method_not_allowed("GET, POST") }),
+        )
         .route("/simple/{name}/", get(package_versions))
         .route("/simple/{name}/{filename}", get(download_file))
 }

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -61,6 +61,20 @@ async fn download(
     ) {
         return response;
     }
+
+    // Conditional GET — If-None-Match
+    if let Some(inm) = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+    {
+        if let Some(stored_hash) = state.storage.get_pin_hash(&key) {
+            let etag_val = format!("\"{}\"", stored_hash);
+            if inm.trim() == etag_val || inm.trim() == "*" {
+                return (StatusCode::NOT_MODIFIED, [(header::ETAG, etag_val)]).into_response();
+            }
+        }
+    }
+
     match state.storage.get(&key).await {
         Ok(data) => {
             state.metrics.record_download("raw");
@@ -73,14 +87,16 @@ async fn download(
 
             // Guess content type from extension
             let content_type = guess_content_type(&key);
-            (
-                StatusCode::OK,
-                [
-                    (header::CONTENT_TYPE, content_type),
-                    (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-                ],
-                data,
-            )
+            let mut builder = axum::http::Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, content_type)
+                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable");
+            if let Some(hash) = state.storage.get_pin_hash(&key) {
+                builder = builder.header(header::ETAG, format!("\"{}\"", hash));
+            }
+            builder
+                .body(axum::body::Body::from(data))
+                .expect("valid response")
                 .into_response()
         }
         Err(_) => StatusCode::NOT_FOUND.into_response(),
@@ -90,6 +106,7 @@ async fn download(
 async fn upload(
     State(state): State<Arc<AppState>>,
     Path(path): Path<String>,
+    headers: axum::http::HeaderMap,
     body: Bytes,
 ) -> Response {
     if !state.config.raw.enabled {
@@ -116,20 +133,90 @@ async fn upload(
             .into_response();
     }
 
+    let if_none_match = headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string());
+    let if_match = headers
+        .get(header::IF_MATCH)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string());
+
     let key = format!("raw/{}", path);
 
-    // Immutable: reject overwrite of existing files
     let lock = state.publish_lock(&key);
     let _guard = lock.lock().await;
 
-    if state.storage.stat(&key).await.is_some() {
-        return (
-            StatusCode::CONFLICT,
-            format!("File already exists: {}", path),
-        )
-            .into_response();
+    let file_exists = state.storage.stat(&key).await.is_some();
+
+    match (file_exists, if_none_match.as_deref(), if_match.as_deref()) {
+        // No conditional headers, file exists → 409 (backward compat)
+        (true, None, None) => {
+            return (
+                StatusCode::CONFLICT,
+                format!("File already exists: {}", path),
+            )
+                .into_response();
+        }
+
+        // No conditional headers, file doesn't exist → create
+        (false, None, None) => {
+            // fall through to create
+        }
+
+        // If-None-Match: * → create only if not exists
+        (true, Some("*"), _) => {
+            return (StatusCode::PRECONDITION_FAILED, "Resource already exists").into_response();
+        }
+        (false, Some("*"), _) => {
+            // fall through to create
+        }
+
+        // If-None-Match with a specific ETag value (not useful for PUT, but handle gracefully)
+        (_, Some(_), None) => {
+            // Non-* If-None-Match on PUT: not meaningful per RFC 9110, reject
+            return (
+                StatusCode::BAD_REQUEST,
+                "If-None-Match on PUT only supports * value",
+            )
+                .into_response();
+        }
+
+        // If-Match: * → update only if resource exists
+        (true, _, Some("*")) => {
+            return do_overwrite(&state, &key, &path, &body).await;
+        }
+        (false, _, Some("*")) => {
+            return (StatusCode::PRECONDITION_FAILED, "Resource does not exist").into_response();
+        }
+
+        // If-Match: "<etag>" → update only if ETag matches
+        (true, _, Some(etag)) => {
+            let stored_hash = state.storage.get_pin_hash(&key);
+            match stored_hash {
+                Some(hash) => {
+                    let expected = format!("\"{}\"", hash);
+                    if etag == expected {
+                        return do_overwrite(&state, &key, &path, &body).await;
+                    }
+                    return (StatusCode::PRECONDITION_FAILED, "ETag mismatch").into_response();
+                }
+                None => {
+                    // No pin hash available (e.g. S3 backend) — cannot verify
+                    return (
+                        StatusCode::PRECONDITION_FAILED,
+                        "ETag not available for this resource",
+                    )
+                        .into_response();
+                }
+            }
+        }
+        (false, _, Some(_)) => {
+            return (StatusCode::PRECONDITION_FAILED, "Resource does not exist").into_response();
+        }
     }
 
+    // Create new file
     match state.storage.put(&key, &body).await {
         Ok(()) => {
             state.metrics.record_upload("raw");
@@ -141,6 +228,31 @@ async fn upload(
                 .log(AuditEntry::new("push", "api", "", "raw", ""));
             state.repo_index.invalidate("raw");
             StatusCode::CREATED.into_response()
+        }
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+/// Overwrite an existing file (conditional PUT with If-Match).
+async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8]) -> Response {
+    // Delete old, write new (within publish_lock — atomic from NORA's perspective)
+    if state.storage.delete(key).await.is_err() {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    match state.storage.put(key, body).await {
+        Ok(()) => {
+            state.metrics.record_upload("raw");
+            state.activity.push(ActivityEntry::new(
+                ActionType::Push,
+                path.to_string(),
+                "raw",
+                "LOCAL",
+            ));
+            state
+                .audit
+                .log(AuditEntry::new("overwrite", "api", "", "raw", ""));
+            state.repo_index.invalidate("raw");
+            StatusCode::OK.into_response()
         }
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
@@ -169,15 +281,34 @@ async fn check_exists(State(state): State<Arc<AppState>>, Path(path): Path<Strin
 
     let key = format!("raw/{}", path);
     match state.storage.stat(&key).await {
-        Some(meta) => (
-            StatusCode::OK,
-            [
-                (header::CONTENT_LENGTH, meta.size.to_string()),
-                (header::CONTENT_TYPE, guess_content_type(&key).to_string()),
-            ],
-        )
-            .into_response(),
+        Some(meta) => {
+            let mut builder = axum::http::Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_LENGTH, meta.size.to_string())
+                .header(header::CONTENT_TYPE, guess_content_type(&key))
+                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable");
+            if let Some(hash) = state.storage.get_pin_hash(&key) {
+                builder = builder.header(header::ETAG, format!("\"{}\"", hash));
+            }
+            if meta.modified > 0 {
+                builder = builder.header(header::LAST_MODIFIED, format_http_date(meta.modified));
+            }
+            builder
+                .body(axum::body::Body::empty())
+                .expect("valid response")
+                .into_response()
+        }
         None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+/// Format a Unix timestamp as an HTTP-date (RFC 7231 §7.1.1.1).
+fn format_http_date(timestamp: u64) -> String {
+    use chrono::{TimeZone, Utc};
+    let dt = Utc.timestamp_opt(timestamp as i64, 0).single();
+    match dt {
+        Some(dt) => dt.format("%a, %d %b %Y %H:%M:%S GMT").to_string(),
+        None => String::new(),
     }
 }
 
@@ -299,6 +430,7 @@ mod integration_tests {
     use crate::storage::{Storage, StorageError};
     use crate::test_helpers::{
         body_bytes, create_test_context, create_test_context_with_raw_disabled, send,
+        send_with_headers,
     };
     use axum::http::{Method, StatusCode};
 
@@ -466,5 +598,218 @@ mod integration_tests {
             }
             other => panic!("expected Validation(PathTraversal), got {:?}", other),
         }
+    }
+
+    // --- RFC 9110 conditional request tests ---
+
+    #[tokio::test]
+    async fn test_raw_head_returns_etag() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/etag.txt", b"hello".to_vec()).await;
+
+        let head = send(&ctx.app, Method::HEAD, "/raw/etag.txt", "").await;
+        assert_eq!(head.status(), StatusCode::OK);
+        let etag = head.headers().get("etag").expect("HEAD must return ETag");
+        let val = etag.to_str().unwrap();
+        assert!(
+            val.starts_with('"') && val.ends_with('"'),
+            "ETag must be quoted"
+        );
+        assert!(val.len() > 2, "ETag must contain a hash");
+    }
+
+    #[tokio::test]
+    async fn test_raw_head_returns_last_modified() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/lm.txt", b"hello".to_vec()).await;
+
+        let head = send(&ctx.app, Method::HEAD, "/raw/lm.txt", "").await;
+        assert_eq!(head.status(), StatusCode::OK);
+        let lm = head
+            .headers()
+            .get("last-modified")
+            .expect("HEAD must return Last-Modified");
+        let val = lm.to_str().unwrap();
+        assert!(val.contains("GMT"), "Last-Modified must be HTTP-date");
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_if_none_match_star_creates() {
+        let ctx = create_test_context();
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/new.txt",
+            vec![("if-none-match", "*")],
+            b"content".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_if_none_match_star_rejects_existing() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/exists.txt", b"v1".to_vec()).await;
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/exists.txt",
+            vec![("if-none-match", "*")],
+            b"v2".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::PRECONDITION_FAILED);
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_if_match_etag_overwrites() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/up.txt", b"v1".to_vec()).await;
+
+        // Get the ETag
+        let head = send(&ctx.app, Method::HEAD, "/raw/up.txt", "").await;
+        let etag = head
+            .headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/up.txt",
+            vec![("if-match", &etag)],
+            b"v2".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_if_match_etag_wrong_rejects() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/wrong.txt", b"v1".to_vec()).await;
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/wrong.txt",
+            vec![(
+                "if-match",
+                "\"0000000000000000000000000000000000000000000000000000000000000000\"",
+            )],
+            b"v2".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::PRECONDITION_FAILED);
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_if_match_star_overwrites_existing() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/star.txt", b"v1".to_vec()).await;
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/star.txt",
+            vec![("if-match", "*")],
+            b"v2".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_if_match_star_rejects_missing() {
+        let ctx = create_test_context();
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/ghost.txt",
+            vec![("if-match", "*")],
+            b"data".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::PRECONDITION_FAILED);
+    }
+
+    #[tokio::test]
+    async fn test_raw_put_no_headers_still_409() {
+        let ctx = create_test_context();
+        let put1 = send(&ctx.app, Method::PUT, "/raw/compat.txt", b"v1".to_vec()).await;
+        assert_eq!(put1.status(), StatusCode::CREATED);
+
+        let put2 = send(&ctx.app, Method::PUT, "/raw/compat.txt", b"v2".to_vec()).await;
+        assert_eq!(put2.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_raw_get_if_none_match_returns_304() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/cached.txt", b"hello".to_vec()).await;
+
+        // Get the ETag
+        let head = send(&ctx.app, Method::HEAD, "/raw/cached.txt", "").await;
+        let etag = head
+            .headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/raw/cached.txt",
+            vec![("if-none-match", &etag)],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[tokio::test]
+    async fn test_raw_overwrite_updates_content() {
+        let ctx = create_test_context();
+        send(
+            &ctx.app,
+            Method::PUT,
+            "/raw/update.txt",
+            b"original".to_vec(),
+        )
+        .await;
+
+        // Get ETag for conditional overwrite
+        let head = send(&ctx.app, Method::HEAD, "/raw/update.txt", "").await;
+        let etag = head
+            .headers()
+            .get("etag")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        // Overwrite
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::PUT,
+            "/raw/update.txt",
+            vec![("if-match", &etag)],
+            b"updated".to_vec(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Verify new content
+        let get = send(&ctx.app, Method::GET, "/raw/update.txt", "").await;
+        assert_eq!(get.status(), StatusCode::OK);
+        let body = body_bytes(get).await;
+        assert_eq!(&body[..], b"updated");
     }
 }

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -3,6 +3,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::registry::method_not_allowed;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -20,7 +21,8 @@ pub fn routes() -> Router<Arc<AppState>> {
         get(download)
             .put(upload)
             .delete(delete_file)
-            .head(check_exists),
+            .head(check_exists)
+            .fallback(|| async { method_not_allowed("GET, PUT, DELETE, HEAD") }),
     )
 }
 

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -148,6 +148,11 @@ impl Storage {
         self.inner.backend_name()
     }
 
+    /// Look up the pinned SHA-256 hash for a storage key (None if pin store is disabled or key is unknown).
+    pub fn get_pin_hash(&self, key: &str) -> Option<String> {
+        self.pin_store.as_ref().and_then(|p| p.get(key))
+    }
+
     /// Number of pinned hashes (0 if pin store is disabled).
     pub fn pinned_count(&self) -> usize {
         self.pin_store.as_ref().map_or(0, |p| p.len())


### PR DESCRIPTION
## Summary

Closes #267, closes #268.

- **OpenAPI 429 documentation**: all 44 rate-limited endpoints now document `429` response with `Retry-After` header. Eliminates false positives from Schemathesis and other API fuzz tools
- **405 Method Not Allowed + Allow header**: multi-method routes (Docker, Raw, Maven, npm, PyPI, Cargo) now return `405` with RFC 9110 §15.5.6 `Allow` header via `MethodRouter::fallback()`. GET-only proxy registries untouched — axum 0.8 already returns 405
- **Route merging**: Docker, Maven, npm separate `.route()` calls for the same path merged into explicit method chains
- **Raw OpenAPI**: added `200` (conditional overwrite) and `412` (precondition failed) responses to PUT
- **Docs coherence**: Raw docs (EN/RU) corrected from "overwrite-only" to immutable-by-default with conditional PUT examples. COMPAT.md updated with HTTP compliance entries

## E2E verified

```
PATCH /raw/test.txt      → 405, Allow: GET, PUT, DELETE, HEAD
PATCH /v2/               → 405, Allow: GET
DELETE /maven2/test       → 405, Allow: GET, PUT
PATCH /npm/lodash         → 405, Allow: GET, PUT
PATCH /simple/            → 405, Allow: GET, POST
POST /go/test             → 405 (axum default, GET-only)
OpenAPI 429 count         → 44 endpoints documented
```

## Test plan

- [x] `cargo test -p nora-registry` — 928 passed
- [x] `cargo clippy -p nora-registry -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `scripts/pre-commit-check.sh` — version consistency OK
- [x] Semgrep — 0 new findings
- [x] E2E curl against running server — all 405 + Allow headers confirmed
- [x] OpenAPI JSON — 44 endpoints with 429 response confirmed