### PR TITLE
fix: log all silent storage and proxy errors across registries

### DIFF
--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -231,7 +231,10 @@ async fn get_metadata(
             (StatusCode::OK, data).into_response()
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, crate_name = %crate_name, "Cargo metadata proxy fetch failed");
+            StatusCode::NOT_FOUND.into_response()
+        }
     }
 }
 
@@ -364,7 +367,10 @@ async fn download(
                 .into_response()
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::debug!(error = ?e, crate_name = %crate_name, version = %version, "Cargo crate proxy fetch failed");
+            StatusCode::NOT_FOUND.into_response()
+        }
     }
 }
 

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -234,7 +234,11 @@ async fn check_blob(
             [(header::CONTENT_LENGTH, data.len().to_string())],
         )
             .into_response(),
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Err(crate::storage::StorageError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, "Failed to check blob existence");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 
@@ -340,38 +344,9 @@ async fn download_blob(
                     .into_response();
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-            Err(_) => continue,
-        }
-    }
-
-    // Auto-prepend library/ for single-segment names (Docker Hub official images)
-    if !name.contains('/') {
-        let library_name = format!("library/{}", name);
-        for upstream in &state.config.docker.upstreams {
-            match fetch_blob_from_upstream(
-                &state.http_client,
-                &upstream.url,
-                &library_name,
-                &digest,
-                &state.docker_auth,
-                state.config.docker.proxy_timeout,
-                upstream.auth.as_deref(),
-                &state.circuit_breaker,
-            )
-            .await
-            {
-                Ok(data) => {
-                    state.spawn_cache("docker", key.clone(), Bytes::from(data.clone()));
-
-                    return (
-                        StatusCode::OK,
-                        [(header::CONTENT_TYPE, "application/octet-stream")],
-                        Bytes::from(data),
-                    )
-                        .into_response();
-                }
-                Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-                Err(_) => continue,
+            Err(e) => {
+                tracing::debug!(error = ?e, upstream = %upstream.url, name = %name, "Docker blob proxy fetch failed, trying next");
+                continue;
             }
         }
     }
@@ -403,7 +378,45 @@ async fn download_blob(
                         .into_response();
                 }
                 Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-                Err(_) => continue,
+                Err(e) => {
+                    tracing::debug!(error = ?e, upstream = %upstream.url, name = %library_name, "Docker blob proxy fetch failed, trying next");
+                    continue;
+                }
+            }
+        }
+    }
+
+    // Auto-prepend library/ for single-segment names (Docker Hub official images)
+    if !name.contains('/') {
+        let library_name = format!("library/{}", name);
+        for upstream in &state.config.docker.upstreams {
+            match fetch_blob_from_upstream(
+                &state.http_client,
+                &upstream.url,
+                &library_name,
+                &digest,
+                &state.docker_auth,
+                state.config.docker.proxy_timeout,
+                upstream.auth.as_deref(),
+                &state.circuit_breaker,
+            )
+            .await
+            {
+                Ok(data) => {
+                    state.spawn_cache("docker", key.clone(), Bytes::from(data.clone()));
+
+                    return (
+                        StatusCode::OK,
+                        [(header::CONTENT_TYPE, "application/octet-stream")],
+                        Bytes::from(data),
+                    )
+                        .into_response();
+                }
+                Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
+                Err(e) => {
+                    tracing::debug!(error = ?e, upstream = %upstream.url, name = %library_name, "Docker blob proxy fetch failed, trying next");
+                    continue;
+                }
             }
         }
     }
@@ -855,7 +868,10 @@ async fn get_manifest(
                     .into_response();
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!(error = ?e, upstream = %upstream.url, name = %name, reference = %reference, "Docker manifest proxy fetch failed, trying next");
+                continue;
+            }
         }
     }
 
@@ -912,7 +928,10 @@ async fn get_manifest(
                         .into_response();
                 }
                 Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-                Err(_) => continue,
+                Err(e) => {
+                    tracing::debug!(error = ?e, upstream = %upstream.url, name = %library_name, reference = %reference, "Docker manifest proxy fetch failed, trying next");
+                    continue;
+                }
             }
         }
     }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -687,7 +687,10 @@ async fn upload_blob(
             )
                 .into_response()
         }
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, name = %name, "Failed to store blob");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 
@@ -1061,7 +1064,10 @@ async fn delete_manifest(
             })),
         )
             .into_response(),
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, name = %name, reference = %reference, "Failed to delete manifest");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 
@@ -1101,7 +1107,10 @@ async fn delete_blob(
             })),
         )
             .into_response(),
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, name = %name, digest = %digest, "Failed to delete blob");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -212,7 +212,10 @@ async fn download(
                 return with_content_type(&path, data.into()).into_response();
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!(error = ?e, upstream = %proxy.url(), path = %path, "Maven proxy fetch failed, trying next");
+                continue;
+            }
         }
     }
 
@@ -268,7 +271,10 @@ async fn upload(
             }
             match state.storage.put(&key, &body).await {
                 Ok(()) => StatusCode::CREATED.into_response(),
-                Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                Err(e) => {
+                    tracing::error!(error = %e, key = %key, "Failed to store Maven checksum");
+                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                }
             }
         }
 
@@ -300,7 +306,8 @@ async fn upload(
                     .into_response();
             }
 
-            if state.storage.put(&key, &body).await.is_err() {
+            if let Err(e) = state.storage.put(&key, &body).await {
+                tracing::error!(error = %e, key = %key, "Failed to store Maven artifact");
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
 
@@ -331,7 +338,10 @@ async fn upload(
                     state.metrics.record_upload("maven");
                     StatusCode::CREATED.into_response()
                 }
-                Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+                Err(e) => {
+                    tracing::error!(error = %e, key = %key, "Failed to store Maven metadata");
+                    StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                }
             }
         }
 
@@ -350,7 +360,10 @@ async fn upload(
                 state.repo_index.invalidate("maven");
                 StatusCode::CREATED.into_response()
             }
-            Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            Err(e) => {
+                tracing::error!(error = %e, key = %key, "Failed to store Maven artifact");
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            }
         },
     }
 }

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -239,7 +239,9 @@ async fn handle_request(
                 return with_content_type(is_tarball, data_to_serve.into()).into_response();
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-            Err(_) => {}
+            Err(e) => {
+                tracing::debug!(error = ?e, path = %path, "npm proxy fetch failed");
+            }
         }
     }
 

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -173,7 +173,9 @@ async fn package_versions(
             Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
                 return circuit_open_response(&reg)
             }
-            Err(_) => {} // Upstream unavailable — fall through to local-only
+            Err(e) => {
+                tracing::debug!(error = ?e, package = %normalized, "PyPI versions proxy fetch failed, falling through to local-only");
+            }
         }
     }
 
@@ -325,14 +327,18 @@ async fn download_file(
                         Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
                             return circuit_open_response(&reg)
                         }
-                        Err(_) => {}
+                        Err(e) => {
+                            tracing::debug!(error = ?e, package = %normalized, filename = %filename, "PyPI file proxy fetch failed");
+                        }
                     }
                 }
             }
             Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
                 return circuit_open_response(&reg)
             }
-            Err(_) => {}
+            Err(e) => {
+                tracing::debug!(error = ?e, package = %normalized, "PyPI page proxy fetch failed");
+            }
         }
     }
 

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -101,7 +101,11 @@ async fn download(
                 .expect("valid response")
                 .into_response()
         }
-        Err(_) => StatusCode::NOT_FOUND.into_response(),
+        Err(crate::storage::StorageError::NotFound) => StatusCode::NOT_FOUND.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, "Failed to read raw artifact");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 
@@ -231,14 +235,18 @@ async fn upload(
             state.repo_index.invalidate("raw");
             StatusCode::CREATED.into_response()
         }
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, "Failed to store raw artifact");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 
-/// Overwrite an existing file (conditional PUT with If-Match).
+/// Overwrite an existing file (conditional PUT with `If-Match`).
 async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8]) -> Response {
     // Delete old, write new (within publish_lock — atomic from NORA's perspective)
-    if state.storage.delete(key).await.is_err() {
+    if let Err(e) = state.storage.delete(key).await {
+        tracing::error!(error = %e, key = %key, "Failed to delete raw artifact before overwrite");
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
     match state.storage.put(key, body).await {
@@ -256,7 +264,10 @@ async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8])
             state.repo_index.invalidate("raw");
             StatusCode::OK.into_response()
         }
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, "Failed to store raw artifact");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 
@@ -272,7 +283,10 @@ async fn delete_file(State(state): State<Arc<AppState>>, Path(path): Path<String
             StatusCode::NO_CONTENT.into_response()
         }
         Err(crate::storage::StorageError::NotFound) => StatusCode::NOT_FOUND.into_response(),
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, "Failed to delete raw artifact");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Audited all registry handlers for silently swallowed errors (`Err(_) =>`)
- Added `tracing::error\!` for storage failures (put/get/delete) — these return 500 and need immediate visibility
- Added `tracing::debug\!` for proxy fetch failures in upstream loops — expected during failover, useful for troubleshooting
- **20 locations fixed** across 6 files: docker, maven, raw, npm, pypi, cargo

### Storage errors (error level) — 10 locations
| Registry | Handler | Operation |
|----------|---------|-----------|
| docker | `upload_blob` | blob put |
| docker | `delete_manifest` | manifest delete |
| docker | `delete_blob` | blob delete |
| docker | `check_blob` | blob get (was returning 404 for all errors) |
| maven | `upload` | checksum, artifact, metadata, opaque put (4 places) |
| raw | `upload` / `do_overwrite` / `delete_file` / `download` | put, delete, get |

### Proxy errors (debug level) — 10 locations
| Registry | Handler |
|----------|---------|
| docker | `download_blob` (3 upstream loops), `get_manifest` (2 upstream loops) |
| maven | `download` proxy loop |
| npm | `handle_request` proxy fallback |
| pypi | `package_versions`, `download_file` (page + file fetch) |
| cargo | `get_metadata`, `download` |

## Test plan
- [x] Reproduced #280: Nora with read-only storage + htpasswd auth, `docker push` returns 500
- [x] Verified new logging: `ERROR Failed to store blob error="IO error: Permission denied (os error 13)"` appears in logs (was completely silent before)
- [x] `cargo build --release` passes
- [x] All unit tests pass (38/38)