### PR TITLE
fix: add warn-level log when all proxy upstreams fail

### DIFF
--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -233,6 +233,7 @@ async fn get_metadata(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, crate_name = %crate_name, "Cargo metadata proxy fetch failed");
+            tracing::warn!(registry = "cargo", crate_name = %crate_name, "Proxy failed, returning 404");
             StatusCode::NOT_FOUND.into_response()
         }
     }
@@ -369,6 +370,7 @@ async fn download(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, crate_name = %crate_name, version = %version, "Cargo crate proxy fetch failed");
+            tracing::warn!(registry = "cargo", crate_name = %crate_name, version = %version, "Proxy failed, returning 404");
             StatusCode::NOT_FOUND.into_response()
         }
     }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -421,6 +421,9 @@ async fn download_blob(
         }
     }
 
+    if !state.config.docker.upstreams.is_empty() {
+        tracing::warn!(registry = "docker", name = %name, digest = %digest, "Proxy failed, returning 404");
+    }
     StatusCode::NOT_FOUND.into_response()
 }
 
@@ -936,6 +939,9 @@ async fn get_manifest(
         }
     }
 
+    if !state.config.docker.upstreams.is_empty() {
+        tracing::warn!(registry = "docker", name = %name, reference = %reference, "Proxy failed, returning 404");
+    }
     StatusCode::NOT_FOUND.into_response()
 }
 

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -219,6 +219,9 @@ async fn download(
         }
     }
 
+    if !state.config.maven.proxies.is_empty() {
+        tracing::warn!(registry = "maven", path = %path, "Proxy failed, returning 404");
+    }
     StatusCode::NOT_FOUND.into_response()
 }
 

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -243,6 +243,7 @@ async fn handle_request(
                 tracing::debug!(error = ?e, path = %path, "npm proxy fetch failed");
             }
         }
+        tracing::warn!(registry = "npm", path = %path, "Proxy failed, returning 404");
     }
 
     StatusCode::NOT_FOUND.into_response()

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -177,6 +177,7 @@ async fn package_versions(
                 tracing::debug!(error = ?e, package = %normalized, "PyPI versions proxy fetch failed, falling through to local-only");
             }
         }
+        tracing::warn!(registry = "pypi", package = %normalized, "Proxy failed, returning 404");
     }
 
     // No proxy configured, or proxy failed — return local files only
@@ -340,6 +341,7 @@ async fn download_file(
                 tracing::debug!(error = ?e, package = %normalized, "PyPI page proxy fetch failed");
             }
         }
+        tracing::warn!(registry = "pypi", package = %normalized, filename = %filename, "Proxy failed, returning 404");
     }
 
     StatusCode::NOT_FOUND.into_response()


### PR DESCRIPTION
## Summary

- Add `tracing::warn!` at every proxy fallthrough-to-404 path across all registries with proxy support
- With default `RUST_LOG=info`, proxy failures are now visible (previously only logged at debug level)
- Each warn includes `registry=` field for uniform log filtering / alerting
- Local-only mode (no proxy configured) does not trigger warns

Affected registries: Docker (`download_blob`, `get_manifest`), Maven (`download`), npm (`handle_request`), PyPI (`package_versions`, `download_file`), Cargo (`get_metadata`, `download`).

Depends on #282.

## Test plan

- [ ] Start Nora with proxy configured pointing to unreachable upstream
- [ ] Request a non-cached artifact — verify warn appears in logs at default log level
- [ ] Start Nora without proxy (local-only) — verify no spurious warns on 404
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

Closes #283