### PR TITLE
feat(audit): structured audit log with configurable output

### DIFF
--- a/nora-registry/src/audit.rs
+++ b/nora-registry/src/audit.rs
@@ -1,19 +1,45 @@
 // Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
-//! Persistent audit log — append-only JSONL file
+//! Structured audit log — append-only JSONL output.
 //!
-//! Records who/when/what for every registry operation.
-//! File: {storage_path}/audit.jsonl
+//! Records who/when/what for every registry write operation.
+//! Output modes (NORA_AUDIT_LOG):
+//!   - `file`   — write to {storage_path}/audit.jsonl (default)
+//!   - `stdout`  — write JSONL to stderr (12-factor compatible)
+//!   - `both`   — write to file AND stderr
+//!   - `off`    — disable audit logging
 
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::{info, warn};
+
+/// Audit output mode.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AuditMode {
+    #[default]
+    File,
+    Stdout,
+    Both,
+    Off,
+}
+
+impl AuditMode {
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "stdout" | "stderr" => Self::Stdout,
+            "both" => Self::Both,
+            "off" | "none" | "false" | "0" => Self::Off,
+            _ => Self::File,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AuditEntry {
@@ -41,41 +67,77 @@ impl AuditEntry {
 pub struct AuditLog {
     path: PathBuf,
     writer: Arc<Mutex<Option<fs::File>>>,
+    mode: AuditMode,
 }
 
 impl AuditLog {
-    pub fn new(storage_path: &str) -> Self {
-        let path = PathBuf::from(storage_path).join("audit.jsonl");
-        if let Some(parent) = path.parent() {
-            let _ = fs::create_dir_all(parent);
+    pub fn new(storage_path: &str, mode: AuditMode) -> Self {
+        if mode == AuditMode::Off {
+            info!("Audit log disabled (mode=off)");
+            return Self {
+                path: PathBuf::from(storage_path).join("audit.jsonl"),
+                writer: Arc::new(Mutex::new(None)),
+                mode,
+            };
         }
-        let writer = match OpenOptions::new().create(true).append(true).open(&path) {
-            Ok(f) => {
-                info!(path = %path.display(), "Audit log initialized");
-                Arc::new(Mutex::new(Some(f)))
+
+        let path = PathBuf::from(storage_path).join("audit.jsonl");
+        let writer = if mode == AuditMode::File || mode == AuditMode::Both {
+            if let Some(parent) = path.parent() {
+                let _ = fs::create_dir_all(parent);
             }
-            Err(e) => {
-                warn!(path = %path.display(), error = %e, "Failed to open audit log, auditing disabled");
-                Arc::new(Mutex::new(None))
+            match OpenOptions::new().create(true).append(true).open(&path) {
+                Ok(f) => {
+                    info!(path = %path.display(), mode = ?mode, "Audit log initialized");
+                    Arc::new(Mutex::new(Some(f)))
+                }
+                Err(e) => {
+                    warn!(path = %path.display(), error = %e, "Failed to open audit log file");
+                    Arc::new(Mutex::new(None))
+                }
             }
+        } else {
+            info!(mode = ?mode, "Audit log initialized (stderr only)");
+            Arc::new(Mutex::new(None))
         };
-        Self { path, writer }
+
+        Self { path, writer, mode }
     }
 
     pub fn log(&self, entry: AuditEntry) {
+        if self.mode == AuditMode::Off {
+            return;
+        }
+
         let writer = Arc::clone(&self.writer);
+        let mode = self.mode.clone();
         tokio::task::spawn_blocking(move || {
-            if let Some(ref mut file) = *writer.lock() {
-                if let Ok(json) = serde_json::to_string(&entry) {
+            let json = match serde_json::to_string(&entry) {
+                Ok(j) => j,
+                Err(_) => return,
+            };
+
+            // Write to file if mode is file or both
+            if mode == AuditMode::File || mode == AuditMode::Both {
+                if let Some(ref mut file) = *writer.lock() {
                     let _ = writeln!(file, "{}", json);
                     let _ = file.flush();
                 }
+            }
+
+            // Write to stderr if mode is stdout or both
+            if mode == AuditMode::Stdout || mode == AuditMode::Both {
+                eprintln!("{}", json);
             }
         });
     }
 
     pub fn path(&self) -> &PathBuf {
         &self.path
+    }
+
+    pub fn mode(&self) -> &AuditMode {
+        &self.mode
     }
 }
 
@@ -104,14 +166,14 @@ mod tests {
     #[test]
     fn test_audit_log_new_and_path() {
         let tmp = TempDir::new().unwrap();
-        let log = AuditLog::new(tmp.path().to_str().unwrap());
+        let log = AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::File);
         assert!(log.path().ends_with("audit.jsonl"));
     }
 
     #[tokio::test]
     async fn test_audit_log_write_entry() {
         let tmp = TempDir::new().unwrap();
-        let log = AuditLog::new(tmp.path().to_str().unwrap());
+        let log = AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::File);
 
         let entry = AuditEntry::new("pull", "user1", "lodash", "npm", "downloaded");
         log.log(entry);
@@ -135,7 +197,7 @@ mod tests {
     #[tokio::test]
     async fn test_audit_log_multiple_entries() {
         let tmp = TempDir::new().unwrap();
-        let log = AuditLog::new(tmp.path().to_str().unwrap());
+        let log = AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::File);
 
         log.log(AuditEntry::new("push", "admin", "a", "docker", ""));
         log.log(AuditEntry::new("pull", "user", "b", "npm", ""));
@@ -163,5 +225,24 @@ mod tests {
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains(r#""action":"push""#));
         assert!(json.contains(r#""ts":""#));
+    }
+
+    #[test]
+    fn test_audit_mode_from_str_lossy() {
+        assert_eq!(AuditMode::from_str_lossy("stdout"), AuditMode::Stdout);
+        assert_eq!(AuditMode::from_str_lossy("stderr"), AuditMode::Stdout);
+        assert_eq!(AuditMode::from_str_lossy("both"), AuditMode::Both);
+        assert_eq!(AuditMode::from_str_lossy("off"), AuditMode::Off);
+        assert_eq!(AuditMode::from_str_lossy("none"), AuditMode::Off);
+        assert_eq!(AuditMode::from_str_lossy("false"), AuditMode::Off);
+        assert_eq!(AuditMode::from_str_lossy("file"), AuditMode::File);
+        assert_eq!(AuditMode::from_str_lossy("anything"), AuditMode::File);
+    }
+
+    #[test]
+    fn test_audit_log_off_mode() {
+        let tmp = TempDir::new().unwrap();
+        let log = AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::Off);
+        assert_eq!(log.mode(), &AuditMode::Off);
     }
 }

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -62,6 +62,8 @@ pub struct Config {
     pub circuit_breaker: CircuitBreakerConfig,
     #[serde(default)]
     pub tls: TlsConfig,
+    #[serde(default)]
+    pub audit: AuditConfig,
     /// Declarative registry selection: `[registries] enable = ["docker", "npm"]`
     #[serde(default)]
     pub registries: Option<RegistriesSection>,
@@ -1257,6 +1259,29 @@ impl EnableSpec {
     }
 }
 
+/// Audit log configuration.
+///
+/// Controls where audit events are written:
+/// - `file`   — write to {storage_path}/audit.jsonl (default)
+/// - `stdout` — write JSONL to stderr (12-factor compatible)
+/// - `both`   — write to file AND stderr
+/// - `off`    — disable audit logging
+///
+/// ENV: `NORA_AUDIT_LOG=file|stdout|both|off`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditConfig {
+    #[serde(default)]
+    pub mode: crate::audit::AuditMode,
+}
+
+impl Default for AuditConfig {
+    fn default() -> Self {
+        Self {
+            mode: crate::audit::AuditMode::File,
+        }
+    }
+}
+
 impl Config {
     /// Returns the set of enabled registry types.
     ///
@@ -2146,6 +2171,11 @@ impl Config {
                 field.min_release_age = if val.is_empty() { None } else { Some(val) };
             }
         }
+
+        // Audit config
+        if let Ok(val) = env::var("NORA_AUDIT_LOG") {
+            self.audit.mode = crate::audit::AuditMode::from_str_lossy(&val);
+        }
     }
 }
 
@@ -2188,6 +2218,7 @@ impl Default for Config {
             curation: CurationConfig::default(),
             circuit_breaker: CircuitBreakerConfig::default(),
             tls: TlsConfig::default(),
+            audit: AuditConfig::default(),
             registries: None,
         }
     }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -367,7 +367,7 @@ async fn main() {
                 println!("  Keys deleted:       {}", result.deleted_keys);
                 println!("  Bytes freed:        {}", result.bytes_freed);
                 if result.planned > 0 {
-                    let audit = AuditLog::new(&config.storage.path);
+                    let audit = AuditLog::new(&config.storage.path, config.audit.mode.clone());
                     audit.log(audit::AuditEntry::new(
                         "retention-apply",
                         "cli",
@@ -891,6 +891,7 @@ async fn run_server(config: Config, storage: Storage) {
     let startup_duration_ms = start_time.elapsed().as_millis() as u64;
 
     let cb_config = config.circuit_breaker.clone();
+    let audit_mode = config.audit.mode.clone();
 
     let state = Arc::new(AppState {
         storage,
@@ -902,7 +903,7 @@ async fn run_server(config: Config, storage: Storage) {
         tokens,
         metrics: DashboardMetrics::with_persistence(&storage_path),
         activity: ActivityLog::new(50),
-        audit: AuditLog::new(&storage_path),
+        audit: AuditLog::new(&storage_path, audit_mode.clone()),
         docker_auth,
         repo_index: RepoIndex::new(),
         http_client,
@@ -938,7 +939,10 @@ async fn run_server(config: Config, storage: Storage) {
             state.config.retention.rules.clone(),
             state.config.retention.interval,
             state.config.retention.dry_run,
-            Some(std::sync::Arc::new(audit::AuditLog::new(&storage_path))),
+            Some(std::sync::Arc::new(audit::AuditLog::new(
+                &storage_path,
+                audit_mode,
+            ))),
             cleanup_lock.clone(),
         );
         info!(

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -558,15 +558,16 @@ async fn publish(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
     }
 
     state.metrics.record_upload("cargo");
+    let artifact = format!("{}@{}", name, vers);
+    state
+        .audit
+        .log(AuditEntry::new("push", "api", &artifact, "cargo", ""));
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
-        format!("{}@{}", name, vers),
+        artifact,
         "cargo",
         "LOCAL",
     ));
-    state
-        .audit
-        .log(AuditEntry::new("push", "api", "", "cargo", ""));
     state.repo_index.invalidate("cargo");
 
     // Cargo expects a JSON response with warnings array

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -683,6 +683,13 @@ async fn upload_blob(
     match state.storage.put(&key, &data).await {
         Ok(()) => {
             state.metrics.record_upload("docker");
+            state.audit.log(AuditEntry::new(
+                "push",
+                "api",
+                &format!("{}@{}", name, digest),
+                "docker",
+                "blob",
+            ));
             state.activity.push(ActivityEntry::new(
                 ActionType::Push,
                 format!("{}@{}", name, &digest[..19.min(digest.len())]),

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -319,15 +319,15 @@ async fn upload(
             update_artifact_metadata(&state, &coords.group_path, &coords.artifact_id).await;
 
             state.metrics.record_upload("maven");
+            state
+                .audit
+                .log(AuditEntry::new("push", "api", &artifact_name, "maven", ""));
             state.activity.push(ActivityEntry::new(
                 ActionType::Push,
                 artifact_name,
                 "maven",
                 "LOCAL",
             ));
-            state
-                .audit
-                .log(AuditEntry::new("push", "api", "", "maven", ""));
             state.repo_index.invalidate("maven");
 
             StatusCode::CREATED.into_response()
@@ -351,15 +351,15 @@ async fn upload(
         MavenPathKind::Opaque => match state.storage.put(&key, &body).await {
             Ok(()) => {
                 state.metrics.record_upload("maven");
+                state
+                    .audit
+                    .log(AuditEntry::new("push", "api", &artifact_name, "maven", ""));
                 state.activity.push(ActivityEntry::new(
                     ActionType::Push,
                     artifact_name,
                     "maven",
                     "LOCAL",
                 ));
-                state
-                    .audit
-                    .log(AuditEntry::new("push", "api", "", "maven", ""));
                 state.repo_index.invalidate("maven");
                 StatusCode::CREATED.into_response()
             }

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -459,15 +459,15 @@ async fn handle_publish(
     }
 
     state.metrics.record_upload("npm");
+    state
+        .audit
+        .log(AuditEntry::new("push", "api", &package_name, "npm", ""));
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
         package_name,
         "npm",
         "LOCAL",
     ));
-    state
-        .audit
-        .log(AuditEntry::new("push", "api", "", "npm", ""));
     state.repo_index.invalidate("npm");
 
     StatusCode::CREATED.into_response()

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -464,15 +464,16 @@ async fn upload(State(state): State<Arc<AppState>>, mut multipart: Multipart) ->
     let _ = state.storage.put(&hash_key, computed_hash.as_bytes()).await;
 
     state.metrics.record_upload("pypi");
+    let artifact = format!("{}-{}", name, version);
+    state
+        .audit
+        .log(AuditEntry::new("push", "api", &artifact, "pypi", ""));
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
-        format!("{}-{}", name, version),
+        artifact,
         "pypi",
         "LOCAL",
     ));
-    state
-        .audit
-        .log(AuditEntry::new("push", "api", "", "pypi", ""));
     state.repo_index.invalidate("pypi");
 
     StatusCode::OK.into_response()

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -227,11 +227,11 @@ async fn upload(
         Ok(()) => {
             state.metrics.record_upload("raw");
             state
+                .audit
+                .log(AuditEntry::new("push", "api", &path, "raw", ""));
+            state
                 .activity
                 .push(ActivityEntry::new(ActionType::Push, path, "raw", "LOCAL"));
-            state
-                .audit
-                .log(AuditEntry::new("push", "api", "", "raw", ""));
             state.repo_index.invalidate("raw");
             StatusCode::CREATED.into_response()
         }
@@ -260,7 +260,7 @@ async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8])
             ));
             state
                 .audit
-                .log(AuditEntry::new("overwrite", "api", "", "raw", ""));
+                .log(AuditEntry::new("overwrite", "api", path, "raw", ""));
             state.repo_index.invalidate("raw");
             StatusCode::OK.into_response()
         }
@@ -279,6 +279,9 @@ async fn delete_file(State(state): State<Arc<AppState>>, Path(path): Path<String
     let key = format!("raw/{}", path);
     match state.storage.delete(&key).await {
         Ok(()) => {
+            state
+                .audit
+                .log(AuditEntry::new("delete", "api", &path, "raw", ""));
             state.repo_index.invalidate("raw");
             StatusCode::NO_CONTENT.into_response()
         }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -152,6 +152,7 @@ fn build_context(
         curation: CurationConfig::default(),
         circuit_breaker: crate::config::CircuitBreakerConfig::default(),
         tls: crate::config::TlsConfig::default(),
+        audit: crate::config::AuditConfig::default(),
         registries: None,
     };
 
@@ -215,7 +216,7 @@ fn build_context(
         tokens,
         metrics: DashboardMetrics::new(),
         activity: ActivityLog::new(50),
-        audit: AuditLog::new(&storage_path),
+        audit: AuditLog::new(&storage_path, crate::audit::AuditMode::Off),
         docker_auth,
         repo_index: RepoIndex::new(),
         http_client: reqwest::Client::new(),


### PR DESCRIPTION
## Summary

- Add configurable audit output mode via `NORA_AUDIT_LOG` env var: `file` (default), `stdout`, `both`, or `off`
- Populate artifact names in all audit entries (previously empty strings)
- Add missing audit entries for raw file delete and docker blob upload

Closes #248

## Changes

**Commit 1: configurable output mode**
- New `AuditMode` enum (File/Stdout/Both/Off) with env var override
- `AuditConfig` section in config with `NORA_AUDIT_LOG` support
- Stdout mode writes JSONL to stderr (12-factor compatible, won't interfere with health checks)
- Tests default to `Off` mode

**Commit 2: audit coverage and artifact names**
- Fill in artifact names across all 7 existing audit.log() call sites (maven, npm, pypi, cargo, raw push, raw overwrite)
- Add audit entry for `raw delete` operation (was completely untracked)
- Add audit entry for `docker blob upload` (only manifest upload was tracked)

## Test plan

- [x] 930 tests pass
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean (no new warnings)
- [ ] Manual: `NORA_AUDIT_LOG=stdout` → verify JSONL on stderr
- [ ] Manual: `NORA_AUDIT_LOG=both` → verify file + stderr
- [ ] Manual: push artifact → verify artifact name appears in audit JSONL