### PR TITLE
fix: security hardening — HTML escape, brute-force, realm validation, health endpoint

### DIFF
--- a/nora-registry/src/auth.rs
+++ b/nora-registry/src/auth.rs
@@ -398,8 +398,22 @@ pub struct TokenListResponse {
 /// Create a new API token (requires Basic auth)
 async fn create_token(
     State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Json(req): Json<CreateTokenRequest>,
 ) -> Response {
+    let client_ip = addr.ip();
+    if let Some(retry_after) = state.auth_failures.check_blocked(&client_ip) {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(header::RETRY_AFTER, retry_after.to_string())],
+            format!(
+                r#"{{"error":"Too many failed attempts. Retry after {} seconds."}}"#,
+                retry_after
+            ),
+        )
+            .into_response();
+    }
+
     // Verify user credentials first
     let auth = match &state.auth {
         Some(auth) => auth,
@@ -407,8 +421,11 @@ async fn create_token(
     };
 
     if !auth.authenticate(&req.username, &req.password) {
+        state.auth_failures.record_failure(client_ip);
         return (StatusCode::UNAUTHORIZED, "Invalid credentials").into_response();
     }
+
+    state.auth_failures.record_success(&client_ip);
 
     let token_store = match &state.tokens {
         Some(ts) => ts,
@@ -446,16 +463,33 @@ async fn create_token(
 /// List tokens for authenticated user
 async fn list_tokens(
     State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Json(req): Json<CreateTokenRequest>,
 ) -> Response {
+    let client_ip = addr.ip();
+    if let Some(retry_after) = state.auth_failures.check_blocked(&client_ip) {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(header::RETRY_AFTER, retry_after.to_string())],
+            format!(
+                r#"{{"error":"Too many failed attempts. Retry after {} seconds."}}"#,
+                retry_after
+            ),
+        )
+            .into_response();
+    }
+
     let auth = match &state.auth {
         Some(auth) => auth,
         None => return (StatusCode::SERVICE_UNAVAILABLE, "Auth not configured").into_response(),
     };
 
     if !auth.authenticate(&req.username, &req.password) {
+        state.auth_failures.record_failure(client_ip);
         return (StatusCode::UNAUTHORIZED, "Invalid credentials").into_response();
     }
+
+    state.auth_failures.record_success(&client_ip);
 
     let token_store = match &state.tokens {
         Some(ts) => ts,
@@ -494,16 +528,33 @@ pub struct RevokeRequest {
 /// Revoke a token
 async fn revoke_token(
     State(state): State<Arc<AppState>>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
     Json(req): Json<RevokeRequest>,
 ) -> Response {
+    let client_ip = addr.ip();
+    if let Some(retry_after) = state.auth_failures.check_blocked(&client_ip) {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [(header::RETRY_AFTER, retry_after.to_string())],
+            format!(
+                r#"{{"error":"Too many failed attempts. Retry after {} seconds."}}"#,
+                retry_after
+            ),
+        )
+            .into_response();
+    }
+
     let auth = match &state.auth {
         Some(auth) => auth,
         None => return (StatusCode::SERVICE_UNAVAILABLE, "Auth not configured").into_response(),
     };
 
     if !auth.authenticate(&req.username, &req.password) {
+        state.auth_failures.record_failure(client_ip);
         return (StatusCode::UNAUTHORIZED, "Invalid credentials").into_response();
     }
+
+    state.auth_failures.record_success(&client_ip);
 
     let token_store = match &state.tokens {
         Some(ts) => ts,

--- a/nora-registry/src/health.rs
+++ b/nora-registry/src/health.rs
@@ -22,7 +22,6 @@ pub struct HealthStatus {
 pub struct StorageHealth {
     pub backend: String,
     pub reachable: bool,
-    pub endpoint: String,
     pub total_size_bytes: u64,
 }
 
@@ -57,10 +56,6 @@ async fn health_check(State(state): State<Arc<AppState>>) -> (StatusCode, Json<H
         storage: StorageHealth {
             backend: state.storage.backend_name().to_string(),
             reachable: storage_reachable,
-            endpoint: match state.storage.backend_name() {
-                "s3" => state.config.storage.s3_url.clone(),
-                _ => state.config.storage.path.clone(),
-            },
             total_size_bytes: total_size,
         },
         registries,

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -724,6 +724,7 @@ async fn run_server(config: Config, storage: Storage) {
             }
         }
     } else {
+        warn!("Authentication is DISABLED — all endpoints are publicly accessible. Set [auth] enabled=true for production.");
         None
     };
 

--- a/nora-registry/src/registry/docker_auth.rs
+++ b/nora-registry/src/registry/docker_auth.rs
@@ -81,6 +81,13 @@ impl DockerAuth {
         let params = parse_www_authenticate(www_authenticate)?;
 
         let realm = params.get("realm")?;
+
+        // Validate realm URL scheme — only HTTP(S) allowed
+        if !realm.starts_with("https://") && !realm.starts_with("http://") {
+            tracing::warn!(realm = %realm, "Rejecting auth realm with non-HTTP(S) scheme");
+            return None;
+        }
+
         let service = params.get("service").map(|s| s.as_str()).unwrap_or("");
 
         // Build token request URL

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -14,6 +14,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_text,
 };
+use crate::ui::components::html_escape;
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
@@ -90,7 +91,12 @@ async fn list_packages(
             "<!DOCTYPE html>\n<html><head><title>Simple Index</title></head><body><h1>Simple Index</h1>\n",
         );
         for pkg in pkg_list {
-            let _ = writeln!(html, "<a href=\"/simple/{}/\">{}</a><br>", pkg, pkg);
+            let _ = writeln!(
+                html,
+                "<a href=\"/simple/{}/\">{}</a><br>",
+                html_escape(&pkg),
+                html_escape(&pkg)
+            );
         }
         html.push_str("</body></html>");
         (
@@ -532,7 +538,11 @@ fn versions_html_response(normalized: &str, files: &[FileEntry], base_url: &str)
         let _ = writeln!(
             html,
             "<a href=\"{}/simple/{}/{}{}\">{}</a><br>",
-            base_url, normalized, f.filename, hash_fragment, f.filename
+            base_url,
+            normalized,
+            html_escape(&f.filename),
+            hash_fragment,
+            html_escape(&f.filename)
         );
     }
     html.push_str("</body></html>");

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -8,9 +8,15 @@
 
 #![allow(clippy::unwrap_used)] // tests may use .unwrap() freely
 
-use axum::{body::Body, extract::DefaultBodyLimit, http::Request, middleware, Router};
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, DefaultBodyLimit},
+    http::Request,
+    middleware, Router,
+};
 use http_body_util::BodyExt;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tempfile::TempDir;
@@ -316,11 +322,14 @@ pub async fn send(
 ) -> axum::http::Response<Body> {
     use tower::ServiceExt;
 
-    let request = Request::builder()
+    let mut request = Request::builder()
         .method(method)
         .uri(uri)
         .body(body.into())
         .unwrap();
+    request
+        .extensions_mut()
+        .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 0))));
 
     app.clone().oneshot(request).await.unwrap()
 }
@@ -339,7 +348,10 @@ pub async fn send_with_headers(
     for (k, v) in headers {
         builder = builder.header(k, v);
     }
-    let request = builder.body(body.into()).unwrap();
+    let mut request = builder.body(body.into()).unwrap();
+    request
+        .extensions_mut()
+        .insert(ConnectInfo(SocketAddr::from(([127, 0, 0, 1], 0))));
 
     app.clone().oneshot(request).await.unwrap()
 }


### PR DESCRIPTION
## Summary

- Escape HTML entities in PyPI Simple Index responses (package names, filenames)
- Add brute-force protection (AuthFailureTracker) to Token API endpoints
- Validate realm URL scheme in Docker auth token fetch (reject non-HTTP(S))
- Warn at startup when authentication is disabled
- Remove storage backend path/URL from public /health endpoint

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test` — 948 passed, 0 failed
- [x] `pre-commit-check.sh` — pass
- [x] `semgrep` — no new findings
- [x] `arch-predict` — no new violations

Closes #287, #288, #289, #290, #291