### PR TITLE
fix(pypi): merge upstream and local files in simple index

### DIFF
--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -592,58 +592,6 @@ fn is_valid_pypi_filename(name: &str) -> bool {
             || ends_with_ci(name, ".egg"))
 }
 
-/// Rewrite PyPI links to point to our registry.
-fn rewrite_pypi_links(html: &str, package_name: &str, base_url: &str) -> String {
-    let mut result = String::with_capacity(html.len());
-    let mut remaining = html;
-
-    while let Some(href_start) = remaining.find("href=\"") {
-        result.push_str(&remaining[..href_start + 6]);
-        remaining = &remaining[href_start + 6..];
-
-        if let Some(href_end) = remaining.find('"') {
-            let url = &remaining[..href_end];
-
-            if let Some(filename) = extract_filename(url) {
-                // Extract hash fragment from original URL
-                let hash_fragment = url.find('#').map(|pos| &url[pos..]).unwrap_or("");
-                let _ = write!(
-                    result,
-                    "{}/simple/{}/{}{}",
-                    base_url, package_name, filename, hash_fragment
-                );
-            } else {
-                result.push_str(url);
-            }
-
-            remaining = &remaining[href_end..];
-        }
-    }
-    result.push_str(remaining);
-
-    // Remove data-core-metadata and data-dist-info-metadata attributes
-    let result = remove_attribute(&result, "data-core-metadata");
-    remove_attribute(&result, "data-dist-info-metadata")
-}
-
-/// Remove an HTML attribute from all tags.
-fn remove_attribute(html: &str, attr_name: &str) -> String {
-    let mut result = String::with_capacity(html.len());
-    let mut remaining = html;
-    let pattern = format!(" {}=\"", attr_name);
-
-    while let Some(attr_start) = remaining.find(&pattern) {
-        result.push_str(&remaining[..attr_start]);
-        remaining = &remaining[attr_start + pattern.len()..];
-
-        if let Some(attr_end) = remaining.find('"') {
-            remaining = &remaining[attr_end + 1..];
-        }
-    }
-    result.push_str(remaining);
-    result
-}
-
 /// Extract filename from PyPI download URL.
 fn extract_filename(url: &str) -> Option<&str> {
     let url = url.split('#').next()?;
@@ -883,63 +831,6 @@ mod tests {
             extract_filename("package-1.0.tar.gz"),
             Some("package-1.0.tar.gz")
         );
-    }
-
-    #[test]
-    fn test_remove_attribute_present() {
-        let html = r#"<a href="url" data-core-metadata="true">link</a>"#;
-        let result = remove_attribute(html, "data-core-metadata");
-        assert_eq!(result, r#"<a href="url">link</a>"#);
-    }
-
-    #[test]
-    fn test_remove_attribute_absent() {
-        let html = r#"<a href="url">link</a>"#;
-        let result = remove_attribute(html, "data-core-metadata");
-        assert_eq!(result, html);
-    }
-
-    #[test]
-    fn test_remove_attribute_multiple() {
-        let html =
-            r#"<a data-core-metadata="true">one</a><a data-core-metadata="sha256=abc">two</a>"#;
-        let result = remove_attribute(html, "data-core-metadata");
-        assert_eq!(result, r#"<a>one</a><a>two</a>"#);
-    }
-
-    #[test]
-    fn test_rewrite_pypi_links_basic() {
-        let html = r#"<a href="https://files.pythonhosted.org/packages/aa/bb/flask-2.0.tar.gz#sha256=abc">flask-2.0.tar.gz</a>"#;
-        let result = rewrite_pypi_links(html, "flask", "https://registry.example.com");
-        assert!(result
-            .contains("https://registry.example.com/simple/flask/flask-2.0.tar.gz#sha256=abc"));
-    }
-
-    #[test]
-    fn test_rewrite_pypi_links_preserves_hash() {
-        let html = r#"<a href="https://example.com/pkg-1.0.whl#sha256=deadbeef">pkg</a>"#;
-        let result = rewrite_pypi_links(html, "pkg", "http://localhost:4000");
-        assert!(result.contains("#sha256=deadbeef"));
-    }
-
-    #[test]
-    fn test_rewrite_pypi_links_unknown_ext() {
-        let html = r#"<a href="https://example.com/readme.txt">readme</a>"#;
-        let result = rewrite_pypi_links(html, "test", "http://localhost:4000");
-        assert!(result.contains("https://example.com/readme.txt"));
-    }
-
-    #[test]
-    fn test_rewrite_pypi_links_removes_metadata_attrs() {
-        let html = r#"<a href="https://example.com/pkg-1.0.whl" data-core-metadata="sha256=abc" data-dist-info-metadata="sha256=def">pkg</a>"#;
-        let result = rewrite_pypi_links(html, "pkg", "http://localhost:4000");
-        assert!(!result.contains("data-core-metadata"));
-        assert!(!result.contains("data-dist-info-metadata"));
-    }
-
-    #[test]
-    fn test_rewrite_pypi_links_empty() {
-        assert_eq!(rewrite_pypi_links("", "pkg", "http://localhost:4000"), "");
     }
 
     #[test]

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -107,6 +107,11 @@ async fn list_packages(
 // ============================================================================
 
 /// GET /simple/{name}/ — list files for a package (PEP 503 HTML or PEP 691 JSON).
+///
+/// When proxy is configured, always fetches the upstream index and merges with
+/// locally cached/uploaded files. This ensures pip sees all available wheels
+/// (e.g. both cp310 and cp314) regardless of which were cached first.
+/// Falls back to local-only when upstream is unavailable.
 async fn package_versions(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -114,11 +119,11 @@ async fn package_versions(
 ) -> Response {
     let normalized = normalize_name(&name);
     let prefix = format!("pypi/{}/", normalized);
-    let keys = state.storage.list(&prefix).await;
     let base_url = nora_base_url(&state);
 
-    // Collect files with their hashes
-    let mut files: Vec<FileEntry> = Vec::new();
+    // Collect local files with their hashes
+    let keys = state.storage.list(&prefix).await;
+    let mut local_files: Vec<FileEntry> = Vec::new();
     for key in &keys {
         if let Some(filename) = key.strip_prefix(&prefix) {
             if !filename.is_empty() && !ends_with_ci(filename, ".sha256") {
@@ -128,7 +133,7 @@ async fn package_versions(
                     .await
                     .ok()
                     .and_then(|d| String::from_utf8(d.to_vec()).ok());
-                files.push(FileEntry {
+                local_files.push(FileEntry {
                     filename: filename.to_string(),
                     sha256,
                 });
@@ -136,15 +141,9 @@ async fn package_versions(
         }
     }
 
-    if !files.is_empty() {
-        return if wants_json(&headers) {
-            versions_json_response(&normalized, &files, &base_url)
-        } else {
-            versions_html_response(&normalized, &files, &base_url)
-        };
-    }
-
-    // Try proxy if configured
+    // When proxy is configured, fetch upstream index and merge with local files.
+    // This fixes the case where a cp314 wheel is cached but pip 3.10 needs to
+    // see the full upstream file list to find a compatible cp310 wheel.
     if let Some(proxy_url) = &state.config.pypi.proxy {
         let url = format!("{}/{}/", proxy_url.trim_end_matches('/'), normalized);
 
@@ -160,14 +159,31 @@ async fn package_versions(
         .await
         {
             Ok(html) => {
-                let rewritten = rewrite_pypi_links(&html, &normalized, &base_url);
-                return (StatusCode::OK, Html(rewritten)).into_response();
+                let upstream_files = parse_upstream_files(&html);
+                let merged = merge_file_lists(upstream_files, &local_files);
+
+                if !merged.is_empty() {
+                    return if wants_json(&headers) {
+                        versions_json_response(&normalized, &merged, &base_url)
+                    } else {
+                        versions_html_response(&normalized, &merged, &base_url)
+                    };
+                }
             }
             Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
                 return circuit_open_response(&reg)
             }
-            Err(_) => {}
+            Err(_) => {} // Upstream unavailable — fall through to local-only
         }
+    }
+
+    // No proxy configured, or proxy failed — return local files only
+    if !local_files.is_empty() {
+        return if wants_json(&headers) {
+            versions_json_response(&normalized, &local_files, &base_url)
+        } else {
+            versions_html_response(&normalized, &local_files, &base_url)
+        };
     }
 
     StatusCode::NOT_FOUND.into_response()
@@ -645,6 +661,56 @@ fn extract_filename(url: &str) -> Option<&str> {
     }
 }
 
+/// Parse upstream PyPI simple index HTML into file entries.
+///
+/// Extracts filenames and optional `#sha256=` fragments from `<a href="...">` links.
+fn parse_upstream_files(html: &str) -> Vec<FileEntry> {
+    let mut files = Vec::new();
+    let mut remaining = html;
+
+    while let Some(href_start) = remaining.find("href=\"") {
+        remaining = &remaining[href_start + 6..];
+        if let Some(href_end) = remaining.find('"') {
+            let url = &remaining[..href_end];
+            if let Some(filename) = extract_filename(url) {
+                let sha256 = url
+                    .find("#sha256=")
+                    .map(|pos| url[pos + 8..].to_string());
+                files.push(FileEntry {
+                    filename: filename.to_string(),
+                    sha256,
+                });
+            }
+            remaining = &remaining[href_end..];
+        }
+    }
+    files
+}
+
+/// Merge upstream and local file lists.
+///
+/// Local entries take precedence (they have verified hashes from storage).
+/// Upstream entries are added only if no local file with the same name exists.
+fn merge_file_lists(upstream: Vec<FileEntry>, local: &[FileEntry]) -> Vec<FileEntry> {
+    let seen: std::collections::HashSet<&str> = local.iter().map(|f| f.filename.as_str()).collect();
+    let mut result = Vec::with_capacity(upstream.len() + local.len());
+
+    for f in local {
+        result.push(FileEntry {
+            filename: f.filename.clone(),
+            sha256: f.sha256.clone(),
+        });
+    }
+
+    for f in upstream {
+        if !seen.contains(f.filename.as_str()) {
+            result.push(f);
+        }
+    }
+
+    result
+}
+
 /// Find the download URL for a specific file in the HTML.
 fn find_file_url(html: &str, target_filename: &str) -> Option<String> {
     let mut remaining = html;
@@ -934,6 +1000,104 @@ mod tests {
     fn test_wants_json_no_header() {
         let headers = HeaderMap::new();
         assert!(!wants_json(&headers));
+    }
+
+    // --- parse_upstream_files ---
+
+    #[test]
+    fn test_parse_upstream_files_basic() {
+        let html = r#"<a href="https://files.example.com/pkg-1.0-cp310-cp310-linux_x86_64.whl#sha256=aaa">pkg</a>
+<a href="https://files.example.com/pkg-1.0-cp314-cp314-linux_x86_64.whl#sha256=bbb">pkg</a>"#;
+        let files = parse_upstream_files(html);
+        assert_eq!(files.len(), 2);
+        assert_eq!(files[0].filename, "pkg-1.0-cp310-cp310-linux_x86_64.whl");
+        assert_eq!(files[0].sha256.as_deref(), Some("aaa"));
+        assert_eq!(files[1].filename, "pkg-1.0-cp314-cp314-linux_x86_64.whl");
+        assert_eq!(files[1].sha256.as_deref(), Some("bbb"));
+    }
+
+    #[test]
+    fn test_parse_upstream_files_no_hash() {
+        let html = r#"<a href="https://example.com/pkg-1.0.tar.gz">pkg</a>"#;
+        let files = parse_upstream_files(html);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].filename, "pkg-1.0.tar.gz");
+        assert!(files[0].sha256.is_none());
+    }
+
+    #[test]
+    fn test_parse_upstream_files_empty() {
+        assert!(parse_upstream_files("").is_empty());
+        assert!(parse_upstream_files("<html><body></body></html>").is_empty());
+    }
+
+    #[test]
+    fn test_parse_upstream_files_skips_non_package_links() {
+        let html = r#"<a href="https://example.com/readme.txt">readme</a>
+<a href="https://example.com/pkg-1.0.whl#sha256=abc">pkg</a>"#;
+        let files = parse_upstream_files(html);
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].filename, "pkg-1.0.whl");
+    }
+
+    // --- merge_file_lists ---
+
+    #[test]
+    fn test_merge_disjoint() {
+        let upstream = vec![FileEntry {
+            filename: "pkg-1.0-cp314-cp314-linux_x86_64.whl".to_string(),
+            sha256: Some("uuu".to_string()),
+        }];
+        let local = vec![FileEntry {
+            filename: "pkg-1.0-cp310-cp310-linux_x86_64.whl".to_string(),
+            sha256: Some("lll".to_string()),
+        }];
+        let merged = merge_file_lists(upstream, &local);
+        assert_eq!(merged.len(), 2);
+        // Local first
+        assert_eq!(merged[0].filename, "pkg-1.0-cp310-cp310-linux_x86_64.whl");
+        assert_eq!(merged[1].filename, "pkg-1.0-cp314-cp314-linux_x86_64.whl");
+    }
+
+    #[test]
+    fn test_merge_local_wins_on_duplicate() {
+        let upstream = vec![FileEntry {
+            filename: "pkg-1.0.tar.gz".to_string(),
+            sha256: Some("upstream-hash".to_string()),
+        }];
+        let local = vec![FileEntry {
+            filename: "pkg-1.0.tar.gz".to_string(),
+            sha256: Some("local-verified-hash".to_string()),
+        }];
+        let merged = merge_file_lists(upstream, &local);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].sha256.as_deref(), Some("local-verified-hash"));
+    }
+
+    #[test]
+    fn test_merge_empty_upstream() {
+        let local = vec![FileEntry {
+            filename: "pkg-1.0.tar.gz".to_string(),
+            sha256: None,
+        }];
+        let merged = merge_file_lists(vec![], &local);
+        assert_eq!(merged.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_empty_local() {
+        let upstream = vec![FileEntry {
+            filename: "pkg-1.0.tar.gz".to_string(),
+            sha256: Some("hash".to_string()),
+        }];
+        let merged = merge_file_lists(upstream, &[]);
+        assert_eq!(merged.len(), 1);
+    }
+
+    #[test]
+    fn test_merge_both_empty() {
+        let merged = merge_file_lists(vec![], &[]);
+        assert!(merged.is_empty());
     }
 }
 

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -673,9 +673,7 @@ fn parse_upstream_files(html: &str) -> Vec<FileEntry> {
         if let Some(href_end) = remaining.find('"') {
             let url = &remaining[..href_end];
             if let Some(filename) = extract_filename(url) {
-                let sha256 = url
-                    .find("#sha256=")
-                    .map(|pos| url[pos + 8..].to_string());
+                let sha256 = url.find("#sha256=").map(|pos| url[pos + 8..].to_string());
                 files.push(FileEntry {
                     filename: filename.to_string(),
                     sha256,


### PR DESCRIPTION
## Summary
- Fix bug where cached wheel for one Python version (e.g. cp314) prevented pip on another version (e.g. 3.10) from finding compatible wheels
- `package_versions()` now fetches upstream index when proxy is configured and merges with local files, instead of returning local-only on first cache hit
- Falls back to local-only when upstream is unavailable (circuit breaker, timeout, etc.)

## Test plan
- [ ] `cargo test -p nora-registry` — 926 tests pass (9 new unit tests for parse/merge)
- [ ] On test cluster: `pip install websockets` via NORA with Python 3.14, then repeat with Python 3.10 — both should succeed
- [ ] Verify twine-uploaded packages still appear in index when proxy is configured
- [ ] Verify PEP 691 JSON response includes upstream files
- [ ] Verify fallback to local-only when upstream proxy is down