### PR TITLE
chore: release v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,26 @@
 # Changelog
 ## [Unreleased]
 
+## [0.8.3] - 2026-05-13
+
+### Added
+- Outbound HTTP/SOCKS5 proxy support (#296)
+- Structured audit log with configurable output (#286)
+- Raw registry RFC 9110 conditional PUT (#278)
+- Raw registry POST /raw/-/reindex endpoint (#276)
+- Reverse proxy setup guide (#275)
+
 ### Fixed
-- **OpenAPI 429 documentation** — all rate-limited endpoints (44 total) now document `429` response with `Retry-After` header in OpenAPI spec. Eliminates false positives from API fuzz tools like Schemathesis (#267)
-- **405 Method Not Allowed with Allow header** — unsupported HTTP methods on multi-method routes now return `405` with RFC 9110 `Allow` header instead of axum's default headerless 405. Affected registries: Docker, Raw, Maven, npm, PyPI, Cargo (#268)
+- Duplicate library/ prefix block in Docker download_blob (#297, #285)
+- Security hardening: HTML escape, brute-force, realm validation (#292)
+- Warn-level log when all proxy upstreams fail (#284)
+- Log all silent storage and proxy errors (#282)
+- PyPI: merge upstream and local files in simple index (#295)
+- Flaky quarantine persistence test under tarpaulin (#299)
+- OpenAPI 429 docs, 405 with Allow header (#279)
 
 ### Changed
-- Docker and Maven/npm route definitions merged from separate `.route()` calls into explicit method chains for correctness and clarity
-- Raw registry docs corrected: files are immutable by default (409 on re-upload), not overwrite-only. Conditional overwrite via `If-Match`/`If-None-Match` documented
-- Raw `PUT` OpenAPI spec updated with `200` (conditional overwrite) and `412` (precondition failed) responses
+- 994 total tests (up from 910)
 
 ## [0.8.2] - 2026-05-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.8.2",
+        version = "0.8.3",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
## Summary
- Bump version to 0.8.3 in Cargo.toml, openapi.rs, Cargo.lock
- Update CHANGELOG.md with 0.8.3 release notes

### Highlights
- Outbound HTTP/SOCKS5 proxy support (#296)
- Structured audit log with configurable output (#286)
- Security hardening: HTML escape, brute-force, realm validation (#292)
- Duplicate library/ prefix fix in Docker download_blob (#297)
- 994 total tests (up from 910)

## Test plan
- [x] `make check` passed (fmt, clippy, 956 unit tests, coherence, lock-audit, changelog verification)
- [x] Tag `v0.8.3` pushed, release workflow triggered