### PR TITLE
fix(raw): configurable Cache-Control, default no-cache

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -317,6 +317,8 @@ pub struct RawConfig {
     pub enabled: bool,
     #[serde(default = "default_max_file_size")]
     pub max_file_size: u64, // in bytes
+    #[serde(default = "default_raw_cache_control")]
+    pub cache_control: String,
 }
 
 /// RubyGems proxy configuration
@@ -549,6 +551,10 @@ fn default_max_file_size() -> u64 {
     104_857_600 // 100MB
 }
 
+fn default_raw_cache_control() -> String {
+    "no-cache".to_string()
+}
+
 /// CIDR-aware trusted proxy list for X-Forwarded-For validation.
 ///
 /// Only connections from trusted proxies have their XFF/X-Real-IP headers
@@ -756,6 +762,7 @@ impl Default for RawConfig {
         Self {
             enabled: true,
             max_file_size: 104_857_600, // 100MB
+            cache_control: default_raw_cache_control(),
         }
     }
 }
@@ -1924,6 +1931,9 @@ impl Config {
                 self.raw.max_file_size = size;
             }
         }
+        if let Ok(val) = env::var("NORA_RAW_CACHE_CONTROL") {
+            self.raw.cache_control = val;
+        }
 
         // Gems config
         if let Ok(val) = env::var("NORA_GEMS_PROXY") {
@@ -2547,11 +2557,14 @@ mod tests {
         let mut config = Config::default();
         std::env::set_var("NORA_RAW_ENABLED", "false");
         std::env::set_var("NORA_RAW_MAX_FILE_SIZE", "524288000");
+        std::env::set_var("NORA_RAW_CACHE_CONTROL", "no-cache");
         config.apply_env_overrides();
         assert!(!config.raw.enabled);
         assert_eq!(config.raw.max_file_size, 524288000);
+        assert_eq!(config.raw.cache_control, "no-cache");
         std::env::remove_var("NORA_RAW_ENABLED");
         std::env::remove_var("NORA_RAW_MAX_FILE_SIZE");
+        std::env::remove_var("NORA_RAW_CACHE_CONTROL");
     }
 
     #[test]

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -92,7 +92,7 @@ async fn download(
             let mut builder = axum::http::Response::builder()
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, content_type)
-                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable");
+                .header(header::CACHE_CONTROL, &state.config.raw.cache_control);
             if let Some(hash) = state.storage.get_pin_hash(&key) {
                 builder = builder.header(header::ETAG, format!("\"{}\"", hash));
             }
@@ -305,7 +305,7 @@ async fn check_exists(State(state): State<Arc<AppState>>, Path(path): Path<Strin
                 .status(StatusCode::OK)
                 .header(header::CONTENT_LENGTH, meta.size.to_string())
                 .header(header::CONTENT_TYPE, guess_content_type(&key))
-                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable");
+                .header(header::CACHE_CONTROL, &state.config.raw.cache_control);
             if let Some(hash) = state.storage.get_pin_hash(&key) {
                 builder = builder.header(header::ETAG, format!("\"{}\"", hash));
             }
@@ -830,5 +830,21 @@ mod integration_tests {
         assert_eq!(get.status(), StatusCode::OK);
         let body = body_bytes(get).await;
         assert_eq!(&body[..], b"updated");
+    }
+
+    #[tokio::test]
+    async fn test_raw_cache_control_default() {
+        let ctx = create_test_context();
+        send(&ctx.app, Method::PUT, "/raw/cc.txt", b"data".to_vec()).await;
+
+        let get = send(&ctx.app, Method::GET, "/raw/cc.txt", "").await;
+        assert_eq!(get.status(), StatusCode::OK);
+        let cc = get
+            .headers()
+            .get("cache-control")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(cc, "no-cache");
     }
 }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -134,6 +134,7 @@ fn build_context(
         raw: RawConfig {
             enabled: true,
             max_file_size: 1_048_576, // 1 MB
+            cache_control: "no-cache".to_string(),
         },
         gems: GemsConfig::default(),
         terraform: TerraformConfig::default(),


### PR DESCRIPTION
## Summary

- Raw GET/HEAD had hardcoded `Cache-Control: public, max-age=31536000, immutable` which is incorrect since conditional PUT (#278) made files mutable
- Default changed to `no-cache` — clients revalidate via ETag/`If-None-Match`, get `304 Not Modified` for unchanged files (zero extra bytes)
- Configurable via `raw.cache_control` in TOML config or `NORA_RAW_CACHE_CONTROL` env var

## Test plan

- [x] `make check` passes
- [x] Binary built and smoke-tested: GET/HEAD return `cache-control: no-cache`
- [x] Env override verified: `NORA_RAW_CACHE_CONTROL="private, no-cache"` applied correctly
- [ ] Verify 304 revalidation flow with `If-None-Match` + ETag

Closes #300