### PR TITLE
fix: race conditions, non-atomic writes, and version sorting (#318)

### DIFF
--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -469,9 +469,15 @@ async fn start_upload(State(state): State<Arc<AppState>>, Path(name): Path<Strin
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    // Enforce max concurrent sessions
+    let uuid = uuid::Uuid::new_v4().to_string();
+
+    // Create temp file for blob data
+    let temp_dir = upload_temp_dir(&state.config.storage.path);
+    let temp_path = temp_dir.join(&uuid);
+
+    // Single write lock: check limit + insert atomically (no TOCTOU)
     {
-        let sessions = state.upload_sessions.read();
+        let mut sessions = state.upload_sessions.write();
         let max_sessions = max_upload_sessions();
         if sessions.len() >= max_sessions {
             tracing::warn!(
@@ -481,17 +487,6 @@ async fn start_upload(State(state): State<Arc<AppState>>, Path(name): Path<Strin
             );
             return (StatusCode::TOO_MANY_REQUESTS, "Too many concurrent uploads").into_response();
         }
-    }
-
-    let uuid = uuid::Uuid::new_v4().to_string();
-
-    // Create temp file for blob data
-    let temp_dir = upload_temp_dir(&state.config.storage.path);
-    let temp_path = temp_dir.join(&uuid);
-
-    // Create session with metadata
-    {
-        let mut sessions = state.upload_sessions.write();
         sessions.insert(
             uuid.clone(),
             UploadSession {
@@ -591,6 +586,7 @@ async fn patch_blob(
             }
             Err(e) => {
                 tracing::error!(error = %e, "Failed to open upload temp file");
+                let _ = tokio::fs::remove_file(&temp_path).await;
                 state.upload_sessions.write().remove(&uuid);
                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
             }
@@ -1192,6 +1188,11 @@ async fn delete_manifest(
     }
 
     let key = format!("docker/{}/manifests/{}.json", name, reference);
+
+    // Serialize tag delete with put_manifest via publish_lock to prevent
+    // concurrent put from updating the tag between our read and delete
+    let lock = state.publish_lock(&key);
+    let _guard = lock.lock().await;
 
     // If reference is a tag, also delete digest-keyed copy
     let is_tag = !reference.starts_with("sha256:");

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -437,18 +437,38 @@ async fn update_artifact_metadata(state: &AppState, group_path: &str, artifact_i
 }
 
 fn sort_maven_versions(versions: &mut [String]) {
-    versions.sort_by(|a, b| {
-        let a_base = a.strip_suffix("-SNAPSHOT").unwrap_or(a);
-        let b_base = b.strip_suffix("-SNAPSHOT").unwrap_or(b);
-        match a_base.cmp(b_base) {
-            std::cmp::Ordering::Equal => {
-                let a_snap = a.ends_with("-SNAPSHOT");
-                let b_snap = b.ends_with("-SNAPSHOT");
-                a_snap.cmp(&b_snap)
-            }
-            other => other,
+    versions.sort_by(|a, b| compare_maven_versions(a, b));
+}
+
+/// Compare Maven versions: split on `.`/`-`, compare numeric segments numerically.
+/// SNAPSHOT sorts before release for the same base version.
+fn compare_maven_versions(a: &str, b: &str) -> std::cmp::Ordering {
+    let a_base = a.strip_suffix("-SNAPSHOT").unwrap_or(a);
+    let b_base = b.strip_suffix("-SNAPSHOT").unwrap_or(b);
+
+    let a_parts: Vec<&str> = a_base.split(['.', '-']).collect();
+    let b_parts: Vec<&str> = b_base.split(['.', '-']).collect();
+
+    for (ap, bp) in a_parts.iter().zip(b_parts.iter()) {
+        let ord = match (ap.parse::<u64>(), bp.parse::<u64>()) {
+            (Ok(an), Ok(bn)) => an.cmp(&bn),
+            _ => ap.cmp(bp),
+        };
+        if ord != std::cmp::Ordering::Equal {
+            return ord;
         }
-    });
+    }
+
+    // If all compared parts equal, shorter version is less (1.0 < 1.0.1)
+    let base_ord = a_parts.len().cmp(&b_parts.len());
+    if base_ord != std::cmp::Ordering::Equal {
+        return base_ord;
+    }
+
+    // Same base: SNAPSHOT before release (1.0-SNAPSHOT < 1.0)
+    let a_snap = a.ends_with("-SNAPSHOT");
+    let b_snap = b.ends_with("-SNAPSHOT");
+    b_snap.cmp(&a_snap)
 }
 
 /// Escape XML special characters in interpolated values.
@@ -716,10 +736,17 @@ mod tests {
     }
 
     #[test]
-    fn test_sort_snapshot_after_release() {
+    fn test_sort_snapshot_before_release() {
         let mut v = vec!["1.0.0-SNAPSHOT".into(), "1.0.0".into(), "0.9.0".into()];
         sort_maven_versions(&mut v);
-        assert_eq!(v, vec!["0.9.0", "1.0.0", "1.0.0-SNAPSHOT"]);
+        assert_eq!(v, vec!["0.9.0", "1.0.0-SNAPSHOT", "1.0.0"]);
+    }
+
+    #[test]
+    fn test_sort_numeric_segments() {
+        let mut v = vec!["10.0.0".into(), "9.0.0".into(), "2.1.0".into()];
+        sort_maven_versions(&mut v);
+        assert_eq!(v, vec!["2.1.0", "9.0.0", "10.0.0"]);
     }
 
     // ── Metadata XML generation ─────────────────────────────────────────

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -244,11 +244,8 @@ async fn upload(
 
 /// Overwrite an existing file (conditional PUT with `If-Match`).
 async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8]) -> Response {
-    // Delete old, write new (within publish_lock — atomic from NORA's perspective)
-    if let Err(e) = state.storage.delete(key).await {
-        tracing::error!(error = %e, key = %key, "Failed to delete raw artifact before overwrite");
-        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
+    // Direct put() — both filesystem and S3 backends overwrite in-place,
+    // avoiding the 404 window that delete-then-put created for concurrent readers.
     match state.storage.put(key, body).await {
         Ok(()) => {
             state.metrics.record_upload("raw");


### PR DESCRIPTION
## Summary
- Docker: single write lock for session check+insert (TOCTOU fix)
- Docker: publish_lock on tag-to-digest delete to prevent race with put_manifest
- Docker: clean up temp file when open() fails (orphan prevention)
- Raw: direct put() in overwrite — eliminates 404 window from delete-then-put
- Maven: numeric version segment comparison (10.0.0 > 9.0.0 instead of lexicographic)
- Maven: SNAPSHOT sorts before release for same base version

## Test plan
- [x] 957 tests pass (including updated `test_sort_snapshot_before_release` and new `test_sort_numeric_segments`)