### PR TITLE
fix: add Content-Length to library/ fallback manifest response

### DIFF
--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1150,11 +1150,13 @@ async fn get_manifest(
 
                     state.repo_index.invalidate("docker");
 
+                    let content_length = data.len().to_string();
                     return (
                         StatusCode::OK,
                         [
                             (header::CONTENT_TYPE, content_type),
                             (HeaderName::from_static("docker-content-digest"), digest),
+                            (header::CONTENT_LENGTH, content_length),
                         ],
                         Bytes::from(data),
                     )


### PR DESCRIPTION
## Summary
- The `library/` auto-prepend path for Docker Hub official images (e.g. `nginx` → `library/nginx`) was missing the `Content-Length` header in manifest responses
- The other two manifest return paths already had it — this was an oversight during the wildcard dispatch refactor in #336
- HEAD requests on single-segment official images returned `Content-Length: 0`, breaking Docker clients that validate `Target.Size > 0`

## Test plan
- [ ] `docker pull nginx` through NORA proxy — verify manifest HEAD returns correct Content-Length
- [ ] `docker pull alpine` — same check for another single-segment official image
- [ ] CI Integration tests pass