### PR TITLE
docs: sync README and ROADMAP with v0.8.3 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NORA
 
-**The artifact registry that grows with you.** Starts with `docker run`, scales to enterprise.
+**The artifact registry that grows with you.** Starts with `docker run`, scales with your needs.
 
 ```bash
 docker run -d -p 4000:4000 -v nora-data:/data getnora/nora:latest
@@ -16,7 +16,7 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 
 - **Zero-config** — single binary, no database, no dependencies. `docker run` and it works.
 - **13 registries** — Docker, Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++).
-- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 900+ tests.
+- **Secure by default** — [OpenSSF Scorecard](https://scorecard.dev/viewer/?uri=github.com/getnora-io/nora), signed releases, SBOM, fuzz testing, 990+ tests.
 
 [![Release](https://img.shields.io/github/v/release/getnora-io/nora)](https://github.com/getnora-io/nora/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
@@ -140,13 +140,16 @@ docker run -d -p 4000:4000 \
 - ~~Garbage Collection & Retention~~ ✅ v0.6.0
 - ~~Helm Chart~~ ✅ v0.6.1
 - ~~Signed releases & SBOM~~ ✅ v0.6.4
-- ~~Curation layer~~ ✅ v0.7.0
-- ~~13 registry formats~~ ✅ v0.7.0
+- ~~Curation layer & 13 registry formats~~ ✅ v0.7.0
 - ~~Min Release Age~~ ✅ v0.7.1
-- **OIDC / Workload Identity** — zero-secret auth for GitHub Actions, GitLab CI
+- ~~Hash Pin Store, auth rate limiting, Cache-Control~~ ✅ v0.8.0
+- ~~Outbound proxy, structured audit log, 994 tests~~ ✅ v0.8.3
+- **Circuit breaker** — per-registry upstream resilience ([#339](https://github.com/getnora-io/nora/issues/339))
+- **OIDC / Workload Identity** — zero-secret auth for CI systems ([#342](https://github.com/getnora-io/nora/issues/342))
+- **Hot reload** — config and curation policy changes without restart ([#343](https://github.com/getnora-io/nora/issues/343))
 - **Image Signing Policy** — cosign verification on upstream pulls
 
-See [CHANGELOG.md](CHANGELOG.md) for release history.
+See [ROADMAP.md](ROADMAP.md) for the full roadmap and [CHANGELOG.md](CHANGELOG.md) for release history.
 
 ## Security & Trust
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,18 +14,23 @@ For completed milestones, see [CHANGELOG.md](CHANGELOG.md).
 - **v0.7.1** — Min-release-age filter for supply chain protection
 - **v0.7.3** — Docker auth fix, raw directory browser, version consistency gate
 - **v0.8.0** — Hash Pin Store, auth rate limiting, trusted proxies, Cache-Control
+- **v0.8.3** — Outbound HTTP/SOCKS5 proxy, structured audit log, 994 tests
 
-## v0.9 — Resilience & Enterprise Auth
+## v0.9 — Resilience & Auth
 
 Focus: upstream resilience, production-grade authentication, operational maturity.
 
-- **Circuit breaker** — per-registry circuit breaker for upstream proxy connections (503+Retry-After on failures, half-open recovery)
-- **Cache-Control completeness** — extend caching headers to remaining registries (Ansible, Conan, Gems, NuGet, Terraform)
-- **Streaming read_timeout** — per-chunk timeout for large blob downloads instead of total request timeout
-- **OIDC / Workload Identity** — zero-secret auth for GitHub Actions and GitLab CI JWT
-- **Hot reload** — apply curation policy and configuration changes without restart
-- **Audit log to stdout** — structured JSON logs for multi-replica deployments and SIEM integration ([#175](https://github.com/getnora-io/nora/issues/175))
+- **Circuit breaker** — per-registry circuit breaker for upstream proxy connections ([#339](https://github.com/getnora-io/nora/issues/339))
+- **Cache-Control completeness** — extend caching headers to remaining registries ([#340](https://github.com/getnora-io/nora/issues/340))
+- **Streaming read_timeout** — per-chunk timeout for large blob downloads ([#341](https://github.com/getnora-io/nora/issues/341))
+- **OIDC / Workload Identity** — zero-secret auth for GitHub Actions and GitLab CI JWT ([#342](https://github.com/getnora-io/nora/issues/342))
+- **Hot reload** — apply curation policy and configuration changes without restart ([#343](https://github.com/getnora-io/nora/issues/343))
+- **Audit log to stdout** — structured JSON logs for multi-replica deployments ([#175](https://github.com/getnora-io/nora/issues/175))
 - **arm64 support** — Linux arm64 binary and multi-arch Docker image ([#193](https://github.com/getnora-io/nora/issues/193))
+- **Docker namespacing** — configurable namespace mapping for mirror mode ([#323](https://github.com/getnora-io/nora/issues/323))
+- **Docker metadata TTL** — stale-while-error for proxy cache ([#311](https://github.com/getnora-io/nora/issues/311))
+- **docker-compose + systemd** — production deployment templates ([#307](https://github.com/getnora-io/nora/issues/307))
+- **thiserror v2** — dependency migration ([#226](https://github.com/getnora-io/nora/issues/226))
 
 ## v1.0 — Stability
 


### PR DESCRIPTION
## Summary
- README roadmap was stuck at v0.7.1 — added v0.8.0 and v0.8.3 as completed
- Updated test count from 900+ to 990+ (currently 994)
- Added issue links to all v0.9 roadmap items (#339-#343, #175, #193, #323, #311, #307, #226)
- Removed stale "enterprise" wording from tagline

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify all issue links in ROADMAP.md resolve