### PR TITLE
feat: v0.9.0 — resilience, hot reload, ARM64, Docker namespacing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,31 +41,46 @@ jobs:
             exit 1
           fi
 
+      - name: Set up QEMU for multi-platform builds
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
         with:
           driver-opts: network=host
 
-      - name: Extract binary from multi-stage build
+      - name: Extract binary from multi-stage build (amd64)
         run: |
-          docker buildx build --target binary --output type=local,dest=./dist .
-          cp ./dist/nora ./nora
-          cp ./dist/nora ./nora-linux-amd64
+          docker buildx build --platform linux/amd64 --target binary --output type=local,dest=./dist-amd64 .
+          cp ./dist-amd64/nora ./nora
+          cp ./dist-amd64/nora ./nora-linux-amd64
           chmod +x ./nora-linux-amd64
-          echo "Binary size: $(du -sh nora-linux-amd64 | cut -f1)"
+          echo "Binary size (amd64): $(du -sh nora-linux-amd64 | cut -f1)"
           file ./nora-linux-amd64
+
+      - name: Extract binary from multi-stage build (arm64)
+        run: |
+          docker buildx build --platform linux/arm64 --target binary --output type=local,dest=./dist-arm64 .
+          cp ./dist-arm64/nora ./nora-linux-arm64
+          chmod +x ./nora-linux-arm64
+          echo "Binary size (arm64): $(du -sh nora-linux-arm64 | cut -f1)"
+          file ./nora-linux-arm64
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nora-binary-${{ github.run_id }}
-          path: ./nora
+          path: |
+            ./nora
+            ./nora-linux-arm64
           retention-days: 1
 
       - name: Compute binary hash for SLSA provenance
         id: hash
         run: |
-          sha256sum nora-linux-amd64 | base64 -w0 > hash.txt
+          sha256sum nora-linux-amd64 nora-linux-arm64 | base64 -w0 > hash.txt
           echo "hash=$(cat hash.txt)" >> $GITHUB_OUTPUT
 
       - name: Log in to GitHub Container Registry
@@ -99,7 +114,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-alpine.outputs.tags }}
           labels: ${{ steps.meta-alpine.outputs.labels }}
@@ -252,13 +267,19 @@ jobs:
           name: nora-binary-${{ github.run_id }}
           path: ./artifacts
 
-      - name: Prepare binary
+      - name: Prepare binaries
         run: |
           cp ./artifacts/nora ./nora-linux-amd64
           chmod +x ./nora-linux-amd64
           sha256sum ./nora-linux-amd64 > nora-linux-amd64.sha256
-          echo "Binary size: $(du -sh nora-linux-amd64 | cut -f1)"
+          echo "Binary size (amd64): $(du -sh nora-linux-amd64 | cut -f1)"
           cat nora-linux-amd64.sha256
+
+          cp ./artifacts/nora-linux-arm64 ./nora-linux-arm64
+          chmod +x ./nora-linux-arm64
+          sha256sum ./nora-linux-arm64 > nora-linux-arm64.sha256
+          echo "Binary size (arm64): $(du -sh nora-linux-arm64 | cut -f1)"
+          cat nora-linux-arm64.sha256
 
       - name: Generate SBOM (SPDX)
         uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d # v0
@@ -275,13 +296,18 @@ jobs:
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v3
 
-      - name: Sign binary with cosign (keyless Sigstore)
+      - name: Sign binaries with cosign (keyless Sigstore)
         run: |
           cosign sign-blob --yes \
             --output-signature nora-linux-amd64.sig \
             --output-certificate nora-linux-amd64.cert \
             --bundle nora-linux-amd64.bundle \
             ./nora-linux-amd64
+          cosign sign-blob --yes \
+            --output-signature nora-linux-arm64.sig \
+            --output-certificate nora-linux-arm64.cert \
+            --bundle nora-linux-arm64.bundle \
+            ./nora-linux-arm64
 
       - name: Generate changelog with git-cliff
         id: changelog
@@ -303,6 +329,11 @@ jobs:
             nora-linux-amd64.sig
             nora-linux-amd64.cert
             nora-linux-amd64.bundle
+            nora-linux-arm64
+            nora-linux-arm64.sha256
+            nora-linux-arm64.sig
+            nora-linux-arm64.cert
+            nora-linux-arm64.bundle
             nora-${{ github.ref_name }}.sbom.spdx.json
             nora-${{ github.ref_name }}.sbom.cdx.json
           body: |
@@ -311,9 +342,15 @@ jobs:
             ## Install
 
             ```bash
+            # x86_64
             curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/nora-linux-amd64
             chmod +x nora-linux-amd64
             sudo mv nora-linux-amd64 /usr/local/bin/nora
+
+            # ARM64 (Apple Silicon, Graviton, Ampere)
+            curl -LO https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/nora-linux-arm64
+            chmod +x nora-linux-arm64
+            sudo mv nora-linux-arm64 /usr/local/bin/nora
             ```
 
             ## Docker
@@ -322,12 +359,12 @@ jobs:
             docker pull getnora/nora:${{ steps.ver.outputs.tag }}
             ```
 
-            | Variant | Image |
-            |---------|-------|
-            | Alpine (default) | `getnora/nora:${{ steps.ver.outputs.tag }}` |
-            | RED OS | `getnora/nora:${{ steps.ver.outputs.tag }}-redos` |
-            | Astra Linux SE | `getnora/nora:${{ steps.ver.outputs.tag }}-astra` |
-            | GHCR | `ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}` |
+            | Variant | Image | Platforms |
+            |---------|-------|-----------|
+            | Alpine (default) | `getnora/nora:${{ steps.ver.outputs.tag }}` | amd64, arm64 |
+            | RED OS | `getnora/nora:${{ steps.ver.outputs.tag }}-redos` | amd64 |
+            | Astra Linux SE | `getnora/nora:${{ steps.ver.outputs.tag }}-astra` | amd64 |
+            | GHCR | `ghcr.io/${{ github.repository }}:${{ steps.ver.outputs.tag }}` | amd64, arm64 |
 
             ## Changelog
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # Changelog
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-16
+
+### Added
+- **Docker metadata TTL + stale-while-error** — cached manifests revalidate against upstream after configurable TTL; serve stale on upstream failure (#311)
+- **Docker/OCI mirror namespacing** — per-upstream namespace prefix isolates storage keys, with lazy migration from legacy flat layout (#323)
+- **Per-registry circuit breaker overrides** — `[circuit_breaker.overrides."registry:url"]` allows custom thresholds per upstream (#339)
+- **Streaming read_timeout for Docker blobs** — per-chunk timeout prevents stuck connections on large layer downloads (#341)
+- **Hot reload for curation policy** — SIGHUP reloads blocklist/allowlist without restart using lock-free ArcSwap (#343)
+- **linux/arm64 support** — multi-platform Docker images and binary releases for ARM64 (#193)
+- **Production deployment files** — `deploy/docker-compose.prod.yml` and `deploy/nora.service` systemd unit (#307)
+
+### Changed
+- **Manifest response builder** — extracted `manifest_response()` helper, removing 3 duplicate return paths in Docker registry (#338)
+- 957 total tests (unchanged)
+
 ## [0.8.4] - 2026-05-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -242,9 +251,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "523ab528ce3a7ada6597f8ccf5bd8d85ebe26d5edf311cad4d1d3cfb2d357ac6"
 dependencies = [
  "base64",
  "blowfish",
@@ -303,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.10.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
+checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
@@ -337,9 +346,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -413,11 +422,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common 0.2.1",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -469,9 +478,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.38"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
  "compression-core",
  "flate2",
@@ -480,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.32"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
@@ -752,9 +761,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -892,12 +901,13 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.29"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
 dependencies = [
  "cfg-if",
  "libc",
+ "libredox",
 ]
 
 [[package]]
@@ -1136,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1192,9 +1202,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -1285,9 +1295,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
 dependencies = [
  "typenum",
 ]
@@ -1492,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1507,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1527,11 +1537,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.2.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "hybrid-array",
+ "generic-array",
 ]
 
 [[package]]
@@ -1539,6 +1549,16 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -1582,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1633,9 +1653,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1652,6 +1672,18 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1718,7 +1750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.3",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1803,8 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
+ "arc-swap",
  "argon2",
  "async-trait",
  "axum",
@@ -2046,7 +2079,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2089,18 +2122,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.13"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.13"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2133,6 +2166,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -2297,9 +2336,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "721da970c312655cde9b4ffe0547f20a8494866a4af5ff51f18b7c633d0c870b"
 dependencies = [
  "memchr",
  "serde",
@@ -2505,6 +2544,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,9 +2733,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "once_cell",
  "ring",
@@ -2711,9 +2759,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2904,7 +2952,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2926,7 +2974,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3219,9 +3267,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -3320,9 +3368,9 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.6"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "axum",
@@ -3368,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -3380,13 +3428,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
- "url",
 ]
 
 [[package]]
@@ -3573,9 +3621,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
  "indexmap",
  "serde",
@@ -3585,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.5.0"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3691,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3704,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3714,9 +3762,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3724,9 +3772,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3737,9 +3785,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3793,9 +3841,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4068,9 +4116,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 
 [[package]]
 name = "wiremock"
@@ -4250,9 +4298,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.8"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,0 +1,51 @@
+# Production Docker Compose for NORA Registry
+# Usage: NORA_VERSION=0.9.0 docker compose -f deploy/docker-compose.prod.yml up -d
+#
+# Required env vars (set in .env or shell):
+#   NORA_VERSION        — image tag (default: 0.9.0)
+#   NORA_PUBLIC_URL     — external URL for download links
+#   NORA_AUTH_ENABLED   — enable authentication (default: true)
+
+services:
+  nora:
+    image: ghcr.io/getnora-io/nora:${NORA_VERSION:-0.9.0}
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp:size=256M
+    ports:
+      - "${NORA_PORT:-4000}:4000"
+    volumes:
+      - nora-data:/data
+      - ./config.toml:/etc/nora/config.toml:ro
+    environment:
+      - RUST_LOG=info
+      - NORA_HOST=0.0.0.0
+      - NORA_PORT=4000
+      - NORA_STORAGE_PATH=/data
+      - NORA_AUTH_ENABLED=${NORA_AUTH_ENABLED:-true}
+      - NORA_PUBLIC_URL=${NORA_PUBLIC_URL:-}
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+          cpus: "2"
+        reservations:
+          memory: 128M
+          cpus: "0.25"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:4000/health"]
+      interval: 15s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    security_opt:
+      - no-new-privileges:true
+
+volumes:
+  nora-data:

--- a/deploy/nora.service
+++ b/deploy/nora.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=NORA Artifact Registry
+Documentation=https://getnora.dev
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=nora
+Group=nora
+ExecStart=/usr/local/bin/nora serve
+Restart=on-failure
+RestartSec=5
+
+# Environment
+Environment=RUST_LOG=info
+Environment=NORA_HOST=0.0.0.0
+Environment=NORA_PORT=4000
+Environment=NORA_STORAGE_PATH=/var/lib/nora
+EnvironmentFile=-/etc/nora/nora.env
+
+# Security hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/nora
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+
+# Resource limits
+LimitNOFILE=65535
+LimitNPROC=4096
+
+[Install]
+WantedBy=multi-user.target

--- a/nora-registry/Cargo.toml
+++ b/nora-registry/Cargo.toml
@@ -57,6 +57,7 @@ tower-http = { version = "0.6", features = ["set-header"] }
 percent-encoding = "2"
 subtle = "2"
 tokio-util = "0.7"
+arc-swap = "1"
 
 [dev-dependencies]
 proptest = "1"

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -1149,7 +1149,12 @@ Jd74nq6dNCjpWG4drIsyhqX+
             http_client: reqwest::Client::new(),
             upload_sessions: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
             publish_locks: parking_lot::Mutex::new(std::collections::HashMap::new()),
-            curation: crate::curation::CurationEngine::new(crate::config::CurationConfig::default()),
+            reloadable: Arc::new(arc_swap::ArcSwap::from_pointee(crate::ReloadableConfig {
+                curation_engine: crate::curation::CurationEngine::new(
+                    crate::config::CurationConfig::default(),
+                ),
+                bypass_token: None,
+            })),
             auth_failures: crate::auth::AuthFailureTracker::new(5, 900),
             oidc: Some(oidc_validator),
             circuit_breaker: crate::circuit_breaker::CircuitBreakerRegistry::new(

--- a/nora-registry/src/circuit_breaker.rs
+++ b/nora-registry/src/circuit_breaker.rs
@@ -74,6 +74,24 @@ impl CircuitBreakerRegistry {
         Self::new(CircuitBreakerConfig::default())
     }
 
+    /// Resolve the failure threshold for a given registry key, checking overrides first.
+    fn threshold_for(&self, registry: &str) -> u32 {
+        self.config
+            .overrides
+            .get(registry)
+            .and_then(|o| o.failure_threshold)
+            .unwrap_or(self.config.failure_threshold)
+    }
+
+    /// Resolve the reset timeout for a given registry key, checking overrides first.
+    fn reset_timeout_for(&self, registry: &str) -> u64 {
+        self.config
+            .overrides
+            .get(registry)
+            .and_then(|o| o.reset_timeout)
+            .unwrap_or(self.config.reset_timeout)
+    }
+
     /// Check if a request to `registry` should proceed.
     /// Returns `Err(ProxyError::CircuitOpen)` if the breaker is open.
     pub(crate) fn check(&self, registry: &str) -> Result<(), ProxyError> {
@@ -93,7 +111,7 @@ impl CircuitBreakerRegistry {
                     .last_failure
                     .map(|t| t.elapsed().as_secs())
                     .unwrap_or(u64::MAX);
-                if elapsed >= self.config.reset_timeout {
+                if elapsed >= self.reset_timeout_for(registry) {
                     // Transition to HalfOpen — allow one probe
                     breaker.state = BreakerState::HalfOpen;
                     breaker.half_open_in_flight = true;
@@ -170,7 +188,7 @@ impl CircuitBreakerRegistry {
             BreakerState::Closed => {
                 breaker.failures += 1;
                 breaker.last_failure = Some(now);
-                if breaker.failures >= self.config.failure_threshold {
+                if breaker.failures >= self.threshold_for(registry) {
                     breaker.state = BreakerState::Open;
                     CIRCUIT_BREAKER_STATE
                         .with_label_values(&[registry])
@@ -178,7 +196,7 @@ impl CircuitBreakerRegistry {
                     tracing::warn!(
                         registry = registry,
                         failures = breaker.failures,
-                        threshold = self.config.failure_threshold,
+                        threshold = self.threshold_for(registry),
                         "Circuit breaker OPEN — upstream failing"
                     );
                 }
@@ -214,6 +232,7 @@ mod tests {
             enabled: true,
             failure_threshold: threshold,
             reset_timeout,
+            overrides: std::collections::HashMap::new(),
         }
     }
 
@@ -222,6 +241,7 @@ mod tests {
             enabled: false,
             failure_threshold: 5,
             reset_timeout: 30,
+            overrides: std::collections::HashMap::new(),
         }
     }
 
@@ -353,6 +373,45 @@ mod tests {
         }
 
         // No panics = success
+    }
+
+    #[test]
+    fn test_per_registry_override_threshold() {
+        use crate::config::CircuitBreakerOverride;
+
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert(
+            "docker:https://registry-1.docker.io".to_string(),
+            CircuitBreakerOverride {
+                failure_threshold: Some(10),
+                reset_timeout: Some(120),
+            },
+        );
+        let config = CircuitBreakerConfig {
+            enabled: true,
+            failure_threshold: 2,
+            reset_timeout: 30,
+            overrides,
+        };
+        let cb = CircuitBreakerRegistry::new(config);
+
+        // Default key trips after 2 failures
+        cb.record_failure("npm");
+        cb.record_failure("npm");
+        assert!(matches!(cb.check("npm"), Err(ProxyError::CircuitOpen(_))));
+
+        // Docker Hub override requires 10 failures
+        let docker_key = "docker:https://registry-1.docker.io";
+        for _ in 0..9 {
+            cb.record_failure(docker_key);
+        }
+        assert!(cb.check(docker_key).is_ok());
+        // 10th trips it
+        cb.record_failure(docker_key);
+        assert!(matches!(
+            cb.check(docker_key),
+            Err(ProxyError::CircuitOpen(_))
+        ));
     }
 }
 

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -3,7 +3,7 @@
 
 use base64::{engine::general_purpose::STANDARD, Engine};
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 
@@ -267,6 +267,17 @@ pub struct DockerConfig {
     pub enabled: bool,
     #[serde(default = "default_docker_timeout")]
     pub proxy_timeout: u64,
+    /// Per-chunk read timeout in seconds for streaming blob downloads (default: 60).
+    /// Applies to each chunk individually, not the total transfer.
+    #[serde(default = "default_docker_read_timeout")]
+    pub read_timeout: u64,
+    /// Metadata cache TTL in seconds (default: -1 = cache forever).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
+    #[serde(default = "default_docker_metadata_ttl")]
+    pub metadata_ttl: i64,
+    /// Serve stale cached manifests when upstream is unreachable (default: true).
+    #[serde(default = "default_true")]
+    pub stale_while_error: bool,
     #[serde(default)]
     pub upstreams: Vec<DockerUpstream>,
 }
@@ -277,6 +288,42 @@ pub struct DockerUpstream {
     pub url: String,
     #[serde(default)]
     pub auth: Option<String>, // "user:pass" for basic auth
+    /// Storage namespace prefix (e.g. "docker.io"). Derived from URL host if omitted.
+    #[serde(default)]
+    pub namespace: Option<String>,
+}
+
+impl DockerUpstream {
+    /// Resolved namespace: explicit config or derived from URL host.
+    pub fn resolved_namespace(&self) -> String {
+        if let Some(ref ns) = self.namespace {
+            return ns.clone();
+        }
+        // Derive from URL host: "https://registry-1.docker.io" → "docker.io"
+        extract_docker_namespace(&self.url)
+    }
+}
+
+/// Derive a storage namespace from a Docker registry URL.
+///
+/// Strips scheme and common prefixes:
+/// - `https://registry-1.docker.io` → `docker.io`
+/// - `https://ghcr.io` → `ghcr.io`
+/// - `https://registry.example.com` → `example.com`
+pub fn extract_docker_namespace(url: &str) -> String {
+    let host = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url)
+        .split('/')
+        .next()
+        .unwrap_or("default")
+        .split(':')
+        .next()
+        .unwrap_or("default");
+    let host = host.strip_prefix("registry-1.").unwrap_or(host);
+    let host = host.strip_prefix("registry.").unwrap_or(host);
+    host.to_string()
 }
 
 /// Maven upstream proxy configuration
@@ -541,6 +588,14 @@ impl Default for ConanConfig {
 
 fn default_docker_timeout() -> u64 {
     300
+}
+
+fn default_docker_read_timeout() -> u64 {
+    60
+}
+
+fn default_docker_metadata_ttl() -> i64 {
+    -1
 }
 
 fn default_raw_enabled() -> bool {
@@ -854,9 +909,13 @@ impl Default for DockerConfig {
         Self {
             enabled: true,
             proxy_timeout: 300,
+            read_timeout: 60,
+            metadata_ttl: -1,
+            stale_while_error: true,
             upstreams: vec![DockerUpstream {
                 url: "https://registry-1.docker.io".to_string(),
                 auth: None,
+                namespace: None,
             }],
         }
     }
@@ -1234,6 +1293,16 @@ pub struct CircuitBreakerConfig {
     /// Seconds to wait before probing a failed upstream (default: 30)
     #[serde(default = "default_cb_reset_timeout")]
     pub reset_timeout: u64,
+    /// Per-registry overrides keyed by circuit breaker key (e.g. "docker:https://registry-1.docker.io").
+    #[serde(default)]
+    pub overrides: HashMap<String, CircuitBreakerOverride>,
+}
+
+/// Per-registry circuit breaker threshold overrides.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CircuitBreakerOverride {
+    pub failure_threshold: Option<u32>,
+    pub reset_timeout: Option<u64>,
 }
 
 impl Default for CircuitBreakerConfig {
@@ -1242,6 +1311,7 @@ impl Default for CircuitBreakerConfig {
             enabled: default_cb_enabled(),
             failure_threshold: default_cb_threshold(),
             reset_timeout: default_cb_reset_timeout(),
+            overrides: HashMap::new(),
         }
     }
 }
@@ -1968,6 +2038,19 @@ impl Config {
                 self.docker.proxy_timeout = timeout;
             }
         }
+        if let Ok(val) = env::var("NORA_DOCKER_READ_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.docker.read_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_DOCKER_METADATA_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.docker.metadata_ttl = ttl;
+            }
+        }
+        if let Ok(val) = env::var("NORA_DOCKER_STALE_WHILE_ERROR") {
+            self.docker.stale_while_error = !matches!(val.as_str(), "false" | "0");
+        }
         // NORA_DOCKER_PROXIES format: "url1,url2" or "url1|auth1,url2|auth2"
         // Backward compat: NORA_DOCKER_UPSTREAMS still works but is deprecated
         if let Ok(val) =
@@ -1984,6 +2067,7 @@ impl Config {
                     DockerUpstream {
                         url: parts[0].to_string(),
                         auth: parts.get(1).map(|a| a.to_string()),
+                        namespace: None,
                     }
                 })
                 .collect();

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -34,6 +34,7 @@ mod validation;
 #[cfg(test)]
 mod test_helpers;
 
+use arc_swap::ArcSwap;
 use axum::{body::Bytes, extract::DefaultBodyLimit, http::HeaderValue, middleware, Router};
 use clap::{Parser, Subcommand};
 use std::path::{Path, PathBuf};
@@ -141,6 +142,12 @@ enum CurationCommand {
     },
 }
 
+/// Curation-related config that can be hot-reloaded via SIGHUP.
+pub struct ReloadableConfig {
+    pub curation_engine: curation::CurationEngine,
+    pub bypass_token: Option<String>,
+}
+
 pub struct AppState {
     pub storage: Storage,
     pub config: Config,
@@ -158,7 +165,8 @@ pub struct AppState {
     pub upload_sessions: Arc<RwLock<HashMap<String, registry::docker::UploadSession>>>,
     /// Per-key publish locks for TOCTOU protection (immutable releases)
     publish_locks: parking_lot::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
-    pub curation: curation::CurationEngine,
+    /// Hot-reloadable curation config (swapped atomically on SIGHUP).
+    pub reloadable: Arc<ArcSwap<ReloadableConfig>>,
     /// Per-IP failed auth attempt tracker for brute-force protection
     pub auth_failures: auth::AuthFailureTracker,
     /// OIDC validator for workload identity (CI/CD)
@@ -168,6 +176,16 @@ pub struct AppState {
 }
 
 impl AppState {
+    /// Load a snapshot of the current curation engine (lock-free read via ArcSwap).
+    pub fn curation(&self) -> arc_swap::Guard<Arc<ReloadableConfig>> {
+        self.reloadable.load()
+    }
+
+    /// Shorthand for the curation bypass token from the reloadable config.
+    pub fn bypass_token(&self) -> Option<String> {
+        self.reloadable.load().bypass_token.clone()
+    }
+
     /// Get or create a per-key publish lock for TOCTOU protection.
     pub fn publish_lock(&self, key: &str) -> Arc<tokio::sync::Mutex<()>> {
         let mut locks = self.publish_locks.lock();
@@ -810,76 +828,37 @@ async fn run_server(config: Config, storage: Storage) {
     let http_client = build_http_client(&config.tls);
     log_outbound_proxy();
 
-    // Initialize curation engine
-    let mut curation_engine = curation::CurationEngine::new(config.curation.clone());
+    // Validate curation config at startup — panic in enforce mode on errors
+    if config.curation.mode == CurationMode::Enforce {
+        if let Some(ref path) = config.curation.blocklist_path {
+            if curation::BlocklistFilter::from_file(path).is_err() {
+                panic!("Cannot start in enforce mode with invalid blocklist");
+            }
+        }
+        if let Some(ref path) = config.curation.allowlist_path {
+            if curation::AllowlistFilter::from_file(path, config.curation.require_integrity)
+                .is_err()
+            {
+                panic!("Cannot start in enforce mode with invalid allowlist");
+            }
+        }
+        if let Some(ref age_str) = config.curation.min_release_age {
+            if curation::parse_duration(age_str).is_err() {
+                panic!(
+                    "Cannot start in enforce mode with invalid min_release_age: {}",
+                    age_str
+                );
+            }
+        }
+    }
+
+    // Build curation engine (shared helper, also used by SIGHUP reload)
+    let curation_engine = build_curation_engine(&config);
     if curation_engine.is_active() {
         info!(
             mode = %config.curation.mode,
             "Curation layer active"
         );
-    }
-
-    // Load blocklist filter if configured
-    if let Some(ref path) = config.curation.blocklist_path {
-        match curation::BlocklistFilter::from_file(path) {
-            Ok(filter) => {
-                let count = filter.rule_count();
-                curation_engine.add_filter(Box::new(filter));
-                info!(path = %path, rules = count, "Blocklist filter loaded");
-            }
-            Err(e) => {
-                error!(path = %path, error = %e, "Failed to load blocklist");
-                if config.curation.mode == CurationMode::Enforce {
-                    panic!("Cannot start in enforce mode with invalid blocklist");
-                }
-            }
-        }
-    }
-
-    // Load allowlist filter if configured (after blocklist — blocklist wins on overlap)
-    if let Some(ref path) = config.curation.allowlist_path {
-        match curation::AllowlistFilter::from_file(path, config.curation.require_integrity) {
-            Ok(filter) => {
-                let count = filter.entry_count();
-                curation_engine.add_filter(Box::new(filter));
-                info!(path = %path, entries = count, "Allowlist filter loaded");
-            }
-            Err(e) => {
-                error!(path = %path, error = %e, "Failed to load allowlist");
-                if config.curation.mode == CurationMode::Enforce {
-                    panic!("Cannot start in enforce mode with invalid allowlist");
-                }
-            }
-        }
-    }
-
-    // Load namespace isolation filter if configured (always active, even in mode=Off)
-    if !config.curation.internal_namespaces.is_empty() {
-        let ns_filter = curation::NamespaceFilter::new(config.curation.internal_namespaces.clone());
-        let count = ns_filter.pattern_count();
-        curation_engine.set_namespace_filter(Box::new(ns_filter));
-        info!(patterns = count, "Namespace isolation filter loaded");
-    }
-
-    // Load min-release-age filter if configured
-    if let Some(ref age_str) = config.curation.min_release_age {
-        match curation::parse_duration(age_str) {
-            Ok(secs) => {
-                let mut filter = curation::MinReleaseAgeFilter::new(secs, age_str);
-                load_registry_overrides(&mut filter, &config.curation);
-                curation_engine.add_filter(Box::new(filter));
-                info!(min_age = %age_str, seconds = secs, "Min-release-age filter loaded");
-            }
-            Err(e) => {
-                error!(value = %age_str, error = %e, "Invalid min_release_age");
-                if config.curation.mode == CurationMode::Enforce {
-                    panic!(
-                        "Cannot start in enforce mode with invalid min_release_age: {}",
-                        e
-                    );
-                }
-            }
-        }
     }
 
     // Determine enabled registries from config
@@ -969,6 +948,12 @@ async fn run_server(config: Config, storage: Storage) {
         None
     };
 
+    let bypass_token = config.curation.bypass_token.clone();
+    let reloadable = Arc::new(ArcSwap::from_pointee(ReloadableConfig {
+        curation_engine,
+        bypass_token,
+    }));
+
     let state = Arc::new(AppState {
         storage,
         config,
@@ -985,7 +970,7 @@ async fn run_server(config: Config, storage: Storage) {
         http_client,
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
-        curation: curation_engine,
+        reloadable,
         auth_failures: auth::AuthFailureTracker::new(5, 900),
         oidc: oidc_validator,
         circuit_breaker: circuit_breaker::CircuitBreakerRegistry::new(cb_config),
@@ -1129,6 +1114,26 @@ async fn run_server(config: Config, storage: Storage) {
         }
     });
 
+    // SIGHUP handler: hot-reload curation policy
+    #[cfg(unix)]
+    {
+        let reload_state = state.clone();
+        tokio::spawn(async move {
+            let mut sighup = signal::unix::signal(signal::unix::SignalKind::hangup())
+                .expect("Failed to install SIGHUP handler");
+            loop {
+                sighup.recv().await;
+                info!("SIGHUP received — reloading curation policy");
+                match reload_curation(&reload_state) {
+                    Ok(()) => info!("Curation policy reloaded successfully"),
+                    Err(e) => {
+                        error!(error = %e, "Curation policy reload failed, keeping previous config")
+                    }
+                }
+            }
+        });
+    }
+
     // Graceful shutdown on SIGTERM/SIGINT
     axum::serve(
         listener,
@@ -1192,6 +1197,81 @@ async fn shutdown_signal() {
             info!("Received SIGTERM, starting graceful shutdown...");
         }
     }
+}
+
+/// Reload curation policy from disk (triggered by SIGHUP).
+///
+/// Re-reads config.toml, rebuilds the CurationEngine with new filters,
+/// and atomically swaps the old config via ArcSwap.
+/// Storage, auth, port, and other settings are NOT reloaded — only curation.
+fn reload_curation(state: &Arc<AppState>) -> Result<(), String> {
+    let config = Config::load();
+    let engine = build_curation_engine(&config);
+
+    state.reloadable.store(Arc::new(ReloadableConfig {
+        curation_engine: engine,
+        bypass_token: config.curation.bypass_token,
+    }));
+
+    Ok(())
+}
+
+/// Build a CurationEngine from the given config (used at startup and reload).
+fn build_curation_engine(config: &Config) -> curation::CurationEngine {
+    let mut engine = curation::CurationEngine::new(config.curation.clone());
+
+    // Load blocklist filter if configured
+    if let Some(ref path) = config.curation.blocklist_path {
+        match curation::BlocklistFilter::from_file(path) {
+            Ok(filter) => {
+                let count = filter.rule_count();
+                engine.add_filter(Box::new(filter));
+                info!(path = %path, rules = count, "Blocklist filter loaded");
+            }
+            Err(e) => {
+                error!(path = %path, error = %e, "Failed to load blocklist");
+            }
+        }
+    }
+
+    // Load allowlist filter if configured
+    if let Some(ref path) = config.curation.allowlist_path {
+        match curation::AllowlistFilter::from_file(path, config.curation.require_integrity) {
+            Ok(filter) => {
+                let count = filter.entry_count();
+                engine.add_filter(Box::new(filter));
+                info!(path = %path, entries = count, "Allowlist filter loaded");
+            }
+            Err(e) => {
+                error!(path = %path, error = %e, "Failed to load allowlist");
+            }
+        }
+    }
+
+    // Load namespace isolation filter if configured
+    if !config.curation.internal_namespaces.is_empty() {
+        let ns_filter = curation::NamespaceFilter::new(config.curation.internal_namespaces.clone());
+        let count = ns_filter.pattern_count();
+        engine.set_namespace_filter(Box::new(ns_filter));
+        info!(patterns = count, "Namespace isolation filter loaded");
+    }
+
+    // Load min-release-age filter if configured
+    if let Some(ref age_str) = config.curation.min_release_age {
+        match curation::parse_duration(age_str) {
+            Ok(secs) => {
+                let mut filter = curation::MinReleaseAgeFilter::new(secs, age_str);
+                load_registry_overrides(&mut filter, &config.curation);
+                engine.add_filter(Box::new(filter));
+                info!(min_age = %age_str, seconds = secs, "Min-release-age filter loaded");
+            }
+            Err(e) => {
+                error!(value = %age_str, error = %e, "Invalid min_release_age");
+            }
+        }
+    }
+
+    engine
 }
 
 /// Print note about registries that have data but no retention rules configured.

--- a/nora-registry/src/mirror/docker.rs
+++ b/nora-registry/src/mirror/docker.rs
@@ -215,6 +215,7 @@ async fn mirror_single_image(
                 digest,
                 docker_auth,
                 DEFAULT_TIMEOUT,
+                60, // per-chunk read timeout
                 None,
                 &noop_cb,
             )

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.8.4",
+        version = "0.9.0",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -154,8 +154,8 @@ async fn version_detail(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Ansible,
         &format!("{}.{}", ns, name),
@@ -209,8 +209,8 @@ async fn download_tarball(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Ansible,
         &format!("{}.{}", ns, name),
@@ -224,7 +224,7 @@ async fn download_tarball(
     if let Ok(data) = state.storage.get(&storage_key).await {
         // Integrity check
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Ansible,
             &format!("{}.{}", ns, name),
             Some(ver),

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -260,8 +260,8 @@ async fn download(
 
     // Curation check — before storage access
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Cargo,
         &crate_name,
@@ -280,7 +280,7 @@ async fn download(
     if let Ok(data) = state.storage.get(&key).await {
         // Post-download integrity verification (issue #189)
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Cargo,
             &crate_name,
             Some(&version),

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -306,8 +306,8 @@ async fn recipe_file_download(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Conan,
         &name,
@@ -323,7 +323,7 @@ async fn recipe_file_download(
     if let Ok(data) = state.storage.get(&storage_key).await {
         // Curation integrity
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Conan,
             &name,
             Some(&ver),
@@ -577,8 +577,8 @@ async fn package_file_download(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Conan,
         &name,
@@ -597,7 +597,7 @@ async fn package_file_download(
     if let Ok(data) = state.storage.get(&storage_key).await {
         // Curation integrity
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Conan,
             &name,
             Some(&ver),

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -20,12 +20,89 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use futures::StreamExt;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+// ============================================================================
+// Namespaced key builders (issue #323)
+// ============================================================================
+
+/// Build a namespaced storage key for Docker blobs.
+///
+/// With namespace: `docker/{ns}/{name}/blobs/{digest}`
+/// Without (local push): `docker/{name}/blobs/{digest}`
+fn blob_key(namespace: Option<&str>, name: &str, digest: &str) -> String {
+    match namespace {
+        Some(ns) => format!("docker/{}/{}/blobs/{}", ns, name, digest),
+        None => format!("docker/{}/blobs/{}", name, digest),
+    }
+}
+
+/// Build a namespaced storage key for Docker manifests.
+fn manifest_key(namespace: Option<&str>, name: &str, reference: &str) -> String {
+    match namespace {
+        Some(ns) => format!("docker/{}/{}/manifests/{}.json", ns, name, reference),
+        None => format!("docker/{}/manifests/{}.json", name, reference),
+    }
+}
+
+/// Build a namespaced storage key for Docker manifest metadata.
+fn manifest_meta_key(namespace: Option<&str>, name: &str, reference: &str) -> String {
+    match namespace {
+        Some(ns) => format!("docker/{}/{}/manifests/{}.meta.json", ns, name, reference),
+        None => format!("docker/{}/manifests/{}.meta.json", name, reference),
+    }
+}
+
+/// Build a namespaced storage key prefix for listing manifests.
+fn manifest_prefix(namespace: Option<&str>, name: &str) -> String {
+    match namespace {
+        Some(ns) => format!("docker/{}/{}/manifests/", ns, name),
+        None => format!("docker/{}/manifests/", name),
+    }
+}
+
+/// Resolve the namespace for a given name by finding the matching upstream.
+fn resolve_namespace(config: &crate::config::DockerConfig, _name: &str) -> Option<String> {
+    // For now, use the first upstream's namespace (single-upstream is the common case).
+    // Multi-upstream namespace routing can be refined later by matching name patterns.
+    config.upstreams.first().map(|u| u.resolved_namespace())
+}
+
+/// Try to get content from namespaced key, falling back to legacy (non-namespaced) key.
+///
+/// This provides backward compatibility during migration from flat to namespaced storage.
+async fn storage_get_with_fallback(
+    storage: &Storage,
+    ns_key: &str,
+    legacy_key: &str,
+) -> Result<Bytes, crate::storage::StorageError> {
+    match storage.get(ns_key).await {
+        Ok(data) => Ok(data),
+        Err(_) if ns_key != legacy_key => storage.get(legacy_key).await,
+        Err(e) => Err(e),
+    }
+}
+
+/// Check if a key exists in namespaced or legacy location.
+async fn storage_stat_with_fallback(
+    storage: &Storage,
+    ns_key: &str,
+    legacy_key: &str,
+) -> Option<crate::storage::FileMeta> {
+    if let Some(meta) = storage.stat(ns_key).await {
+        return Some(meta);
+    }
+    if ns_key != legacy_key {
+        return storage.stat(legacy_key).await;
+    }
+    None
+}
 
 /// Metadata for a Docker image stored alongside manifests
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -389,8 +466,10 @@ async fn check_blob(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    let key = format!("docker/{}/blobs/{}", name, digest);
-    match state.storage.get(&key).await {
+    let ns = resolve_namespace(&state.config.docker, &name);
+    let key = blob_key(ns.as_deref(), &name, &digest);
+    let legacy_key = blob_key(None, &name, &digest);
+    match storage_get_with_fallback(&state.storage, &key, &legacy_key).await {
         Ok(data) => (
             StatusCode::OK,
             [(header::CONTENT_LENGTH, data.len().to_string())],
@@ -418,8 +497,8 @@ async fn download_blob(
 
     // Curation check — defense in depth: check blobs too
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Docker,
         &name,
@@ -429,13 +508,15 @@ async fn download_blob(
         return response;
     }
 
-    let key = format!("docker/{}/blobs/{}", name, digest);
+    let ns = resolve_namespace(&state.config.docker, &name);
+    let key = blob_key(ns.as_deref(), &name, &digest);
+    let legacy_key = blob_key(None, &name, &digest);
 
-    // Try local storage first
-    if let Ok(data) = state.storage.get(&key).await {
+    // Try local storage first (namespaced key, then legacy fallback)
+    if let Ok(data) = storage_get_with_fallback(&state.storage, &key, &legacy_key).await {
         // Curation integrity verification (issue #189)
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Docker,
             &name,
             Some(&digest),
@@ -472,6 +553,7 @@ async fn download_blob(
             &digest,
             &state.docker_auth,
             state.config.docker.proxy_timeout,
+            state.config.docker.read_timeout,
             upstream.auth.as_deref(),
             &state.circuit_breaker,
         )
@@ -516,6 +598,7 @@ async fn download_blob(
                 &digest,
                 &state.docker_auth,
                 state.config.docker.proxy_timeout,
+                state.config.docker.read_timeout,
                 upstream.auth.as_deref(),
                 &state.circuit_breaker,
             )
@@ -854,19 +937,22 @@ async fn get_manifest(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
+    let ns = resolve_namespace(&state.config.docker, &name);
+
     // Extract publish date from .meta.json sidecar
     let publish_date = extract_docker_publish_date(
         &state.storage,
         &name,
         &reference,
         state.config.docker.upstreams.is_empty(),
+        ns.as_deref(),
     )
     .await;
 
     // Curation check — manifests carry the image identity
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Docker,
         &name,
@@ -876,81 +962,29 @@ async fn get_manifest(
         return response;
     }
 
-    let key = format!("docker/{}/manifests/{}.json", name, reference);
+    let key = manifest_key(ns.as_deref(), &name, &reference);
+    let legacy_key = manifest_key(None, &name, &reference);
 
-    // Try local storage first
-    if let Ok(data) = state.storage.get(&key).await {
-        // Curation integrity verification (issue #189)
-        if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
-            crate::curation::RegistryType::Docker,
-            &name,
-            Some(&reference),
-            &data,
-        ) {
-            return response;
+    // Try local storage first, with TTL-based revalidation (namespaced key, then legacy fallback)
+    let cached = storage_get_with_fallback(&state.storage, &key, &legacy_key)
+        .await
+        .ok();
+    let cache_fresh = if cached.is_some() {
+        let meta = storage_stat_with_fallback(&state.storage, &key, &legacy_key).await;
+        meta.map(|m| crate::cache_ttl::is_within_ttl(m.modified, state.config.docker.metadata_ttl))
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    // Serve fresh cache immediately
+    if let Some(ref data) = cached {
+        if cache_fresh {
+            return serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
         }
-
-        state.metrics.record_download("docker");
-        state.metrics.record_cache_hit();
-        state.activity.push(ActivityEntry::new(
-            ActionType::Pull,
-            format!("{}:{}", name, reference),
-            "docker",
-            "LOCAL",
-        ));
-
-        // Calculate digest for Docker-Content-Digest header
-        use sha2::Digest;
-        let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&data)));
-
-        // Quarantine check (local cache hit may still be pending)
-        let (q_mode, q_secs) = resolve_quarantine(&state);
-        if !matches!(q_mode, crate::digest_quarantine::QuarantineMode::Off) {
-            let q_status = state.digest_store.check("docker", &digest, q_secs);
-            match &q_status {
-                crate::digest_quarantine::QuarantineStatus::Mature => {}
-                _ => {
-                    tracing::warn!(
-                        digest = %digest,
-                        status = %q_status.header_value(),
-                        mode = ?q_mode,
-                        "Quarantine: cached manifest"
-                    );
-                    if matches!(q_mode, crate::digest_quarantine::QuarantineMode::Enforce) {
-                        return quarantine_forbidden(&digest, &q_status, q_secs);
-                    }
-                }
-            }
-        }
-
-        // Detect manifest media type from content
-        let content_type = detect_manifest_media_type(&data);
-
-        // Update metadata (downloads, last_pulled) in background
-        let meta_key = format!("docker/{}/manifests/{}.meta.json", name, reference);
-        let state_clone = state.clone();
-        let storage_clone = state.storage.clone();
-        tokio::spawn(update_metadata_on_pull(
-            state_clone,
-            storage_clone,
-            meta_key,
-        ));
-
-        let content_length = data.len().to_string();
-        return (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, content_type),
-                (HeaderName::from_static("docker-content-digest"), digest),
-                (header::CONTENT_LENGTH, content_length),
-            ],
-            data,
-        )
-            .into_response();
     }
 
-    // Try upstream proxies
+    // Try upstream proxies (always if no cache, or if cache is stale)
     tracing::debug!(
         upstreams_count = state.config.docker.upstreams.len(),
         "Trying upstream proxies"
@@ -1017,6 +1051,7 @@ async fn get_manifest(
                 }
 
                 // Cache manifest and create metadata (fire and forget)
+                let upstream_ns = Some(upstream.resolved_namespace());
                 let storage = state.storage.clone();
                 let key_clone = key.clone();
                 let data_clone = data.clone();
@@ -1025,39 +1060,30 @@ async fn get_manifest(
                 let digest_clone = digest.clone();
                 let state_clone = Arc::clone(&state);
                 tokio::spawn(async move {
-                    // Store manifest by tag and digest
+                    // Store manifest by tag and digest (namespaced)
                     let _ = storage.put(&key_clone, &data_clone).await;
                     let digest_key =
-                        format!("docker/{}/manifests/{}.json", name_clone, digest_clone);
+                        manifest_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
                     let _ = storage.put(&digest_key, &data_clone).await;
 
                     // Extract and save metadata
                     let metadata = extract_metadata(&data_clone, &storage, &name_clone).await;
                     if let Ok(meta_json) = serde_json::to_vec(&metadata) {
-                        let meta_key = format!(
-                            "docker/{}/manifests/{}.meta.json",
-                            name_clone, reference_clone
+                        let meta_key = manifest_meta_key(
+                            upstream_ns.as_deref(),
+                            &name_clone,
+                            &reference_clone,
                         );
                         let _ = storage.put(&meta_key, &meta_json).await;
 
                         let digest_meta_key =
-                            format!("docker/{}/manifests/{}.meta.json", name_clone, digest_clone);
+                            manifest_meta_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
                         let _ = storage.put(&digest_meta_key, &meta_json).await;
                     }
                     state_clone.repo_index.invalidate("docker");
                 });
 
-                let content_length = data.len().to_string();
-                return (
-                    StatusCode::OK,
-                    [
-                        (header::CONTENT_TYPE, content_type),
-                        (HeaderName::from_static("docker-content-digest"), digest),
-                        (header::CONTENT_LENGTH, content_length),
-                    ],
-                    Bytes::from(data),
-                )
-                    .into_response();
+                return manifest_response(data, content_type, digest);
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
             Err(e) => {
@@ -1142,17 +1168,7 @@ async fn get_manifest(
 
                     state.repo_index.invalidate("docker");
 
-                    let content_length = data.len().to_string();
-                    return (
-                        StatusCode::OK,
-                        [
-                            (header::CONTENT_TYPE, content_type),
-                            (HeaderName::from_static("docker-content-digest"), digest),
-                            (header::CONTENT_LENGTH, content_length),
-                        ],
-                        Bytes::from(data),
-                    )
-                        .into_response();
+                    return manifest_response(data, content_type, digest);
                 }
                 Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
                 Err(e) => {
@@ -1163,10 +1179,91 @@ async fn get_manifest(
         }
     }
 
+    // Stale-while-error: serve stale cached manifest when upstream is unreachable
+    if let Some(ref data) = cached {
+        if state.config.docker.stale_while_error {
+            tracing::warn!(
+                registry = "docker",
+                name = %name,
+                reference = %reference,
+                "Upstream failed, serving stale cached manifest"
+            );
+            return serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
+        }
+    }
+
     if !state.config.docker.upstreams.is_empty() {
         tracing::warn!(registry = "docker", name = %name, reference = %reference, "Proxy failed, returning 404");
     }
     StatusCode::NOT_FOUND.into_response()
+}
+
+/// Serve a manifest from local cache with all required headers and side-effects.
+fn serve_cached_manifest(
+    state: &Arc<AppState>,
+    data: &[u8],
+    name: &str,
+    reference: &str,
+    ns: Option<&str>,
+) -> Response {
+    // Curation integrity verification (issue #189)
+    if let Some(response) = crate::curation::verify_integrity(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Docker,
+        name,
+        Some(reference),
+        data,
+    ) {
+        return response;
+    }
+
+    state.metrics.record_download("docker");
+    state.metrics.record_cache_hit();
+    state.activity.push(ActivityEntry::new(
+        ActionType::Pull,
+        format!("{}:{}", name, reference),
+        "docker",
+        "LOCAL",
+    ));
+
+    // Calculate digest for Docker-Content-Digest header
+    use sha2::Digest;
+    let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(data)));
+
+    // Quarantine check (local cache hit may still be pending)
+    let (q_mode, q_secs) = resolve_quarantine(state);
+    if !matches!(q_mode, crate::digest_quarantine::QuarantineMode::Off) {
+        let q_status = state.digest_store.check("docker", &digest, q_secs);
+        match &q_status {
+            crate::digest_quarantine::QuarantineStatus::Mature => {}
+            _ => {
+                tracing::warn!(
+                    digest = %digest,
+                    status = %q_status.header_value(),
+                    mode = ?q_mode,
+                    "Quarantine: cached manifest"
+                );
+                if matches!(q_mode, crate::digest_quarantine::QuarantineMode::Enforce) {
+                    return quarantine_forbidden(&digest, &q_status, q_secs);
+                }
+            }
+        }
+    }
+
+    // Detect manifest media type from content
+    let content_type = detect_manifest_media_type(data);
+
+    // Update metadata (downloads, last_pulled) in background
+    let meta_key = manifest_meta_key(ns, name, reference);
+    let state_clone = state.clone();
+    let storage_clone = state.storage.clone();
+    tokio::spawn(update_metadata_on_pull(
+        state_clone,
+        storage_clone,
+        meta_key,
+    ));
+
+    manifest_response(Bytes::copy_from_slice(data), content_type, digest)
 }
 
 async fn put_manifest(
@@ -1246,12 +1343,21 @@ async fn list_tags(State(state): State<Arc<AppState>>, Path(name): Path<String>)
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    let prefix = format!("docker/{}/manifests/", name);
-    let keys = state.storage.list(&prefix).await;
+    let ns = resolve_namespace(&state.config.docker, &name);
+    let prefix = manifest_prefix(ns.as_deref(), &name);
+    let legacy_prefix = manifest_prefix(None, &name);
+    let mut keys = state.storage.list(&prefix).await;
+    // Also include legacy non-namespaced keys during migration
+    if prefix != legacy_prefix {
+        keys.extend(state.storage.list(&legacy_prefix).await);
+        keys.sort();
+        keys.dedup();
+    }
     let tags: Vec<String> = keys
         .iter()
         .filter_map(|k| {
             k.strip_prefix(&prefix)
+                .or_else(|| k.strip_prefix(&legacy_prefix))
                 .and_then(|t| t.strip_suffix(".json"))
                 .map(String::from)
         })
@@ -1275,7 +1381,9 @@ async fn delete_manifest(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    let key = format!("docker/{}/manifests/{}.json", name, reference);
+    let ns = resolve_namespace(&state.config.docker, &name);
+    let key = manifest_key(ns.as_deref(), &name, &reference);
+    let legacy_key = manifest_key(None, &name, &reference);
 
     // Serialize tag delete with put_manifest via publish_lock to prevent
     // concurrent put from updating the tag between our read and delete
@@ -1285,21 +1393,38 @@ async fn delete_manifest(
     // If reference is a tag, also delete digest-keyed copy
     let is_tag = !reference.starts_with("sha256:");
     if is_tag {
-        if let Ok(data) = state.storage.get(&key).await {
+        if let Ok(data) = storage_get_with_fallback(&state.storage, &key, &legacy_key).await {
             use sha2::Digest;
             let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&data)));
-            let digest_key = format!("docker/{}/manifests/{}.json", name, digest);
-            let _ = state.storage.delete(&digest_key).await;
-            let digest_meta = format!("docker/{}/manifests/{}.meta.json", name, digest);
-            let _ = state.storage.delete(&digest_meta).await;
+            // Delete from both namespaced and legacy locations
+            let _ = state
+                .storage
+                .delete(&manifest_key(ns.as_deref(), &name, &digest))
+                .await;
+            let _ = state
+                .storage
+                .delete(&manifest_key(None, &name, &digest))
+                .await;
+            let _ = state
+                .storage
+                .delete(&manifest_meta_key(ns.as_deref(), &name, &digest))
+                .await;
+            let _ = state
+                .storage
+                .delete(&manifest_meta_key(None, &name, &digest))
+                .await;
         }
     }
 
-    // Delete manifest
+    // Delete manifest — try namespaced key first, then legacy fallback
     match state.storage.delete(&key).await {
         Ok(()) => {
             // Delete associated metadata
-            let meta_key = format!("docker/{}/manifests/{}.meta.json", name, reference);
+            let meta_key = manifest_meta_key(ns.as_deref(), &name, &reference);
+            let _ = state
+                .storage
+                .delete(&manifest_meta_key(None, &name, &reference))
+                .await;
             let _ = state.storage.delete(&meta_key).await;
 
             state.audit.log(AuditEntry::new(
@@ -1312,6 +1437,38 @@ async fn delete_manifest(
             state.repo_index.invalidate("docker");
             tracing::info!(name = %name, reference = %reference, "Docker manifest deleted");
             StatusCode::ACCEPTED.into_response()
+        }
+        Err(crate::storage::StorageError::NotFound) if key != legacy_key => {
+            // Try legacy (non-namespaced) key
+            match state.storage.delete(&legacy_key).await {
+                Ok(()) => {
+                    let _ = state
+                        .storage
+                        .delete(&manifest_meta_key(None, &name, &reference))
+                        .await;
+                    state.audit.log(AuditEntry::new(
+                        "delete",
+                        "api",
+                        &format!("{}:{}", name, reference),
+                        "docker",
+                        "manifest",
+                    ));
+                    state.repo_index.invalidate("docker");
+                    tracing::info!(name = %name, reference = %reference, "Docker manifest deleted (legacy key)");
+                    StatusCode::ACCEPTED.into_response()
+                }
+                _ => (
+                    StatusCode::NOT_FOUND,
+                    Json(json!({
+                        "errors": [{
+                            "code": "MANIFEST_UNKNOWN",
+                            "message": "manifest unknown",
+                            "detail": { "name": name, "reference": reference }
+                        }]
+                    })),
+                )
+                    .into_response(),
+            }
         }
         Err(crate::storage::StorageError::NotFound) => (
             StatusCode::NOT_FOUND,
@@ -1342,7 +1499,13 @@ async fn delete_blob(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    let key = format!("docker/{}/blobs/{}", name, digest);
+    let ns = resolve_namespace(&state.config.docker, &name);
+    let key = blob_key(ns.as_deref(), &name, &digest);
+    let legacy_key = blob_key(None, &name, &digest);
+    // Delete from both locations during migration
+    if key != legacy_key {
+        let _ = state.storage.delete(&legacy_key).await;
+    }
     match state.storage.delete(&key).await {
         Ok(()) => {
             state.audit.log(AuditEntry::new(
@@ -1376,7 +1539,11 @@ async fn delete_blob(
 
 // ============================================================================
 
-/// Fetch a blob from an upstream Docker registry
+/// Fetch a blob from an upstream Docker registry.
+///
+/// Uses per-chunk `read_timeout` instead of a total request timeout so that
+/// large blob downloads (multi-GB images) don't time out on slow connections.
+/// The `timeout` parameter is kept as the connection/header timeout.
 #[allow(clippy::too_many_arguments)]
 pub async fn fetch_blob_from_upstream(
     client: &reqwest::Client,
@@ -1385,6 +1552,7 @@ pub async fn fetch_blob_from_upstream(
     digest: &str,
     docker_auth: &DockerAuth,
     timeout: u64,
+    read_timeout: u64,
     basic_auth: Option<&str>,
     cb: &CircuitBreakerRegistry,
 ) -> Result<Vec<u8>, ProxyError> {
@@ -1398,7 +1566,7 @@ pub async fn fetch_blob_from_upstream(
         digest
     );
 
-    // First try — with basic auth if configured
+    // Connection timeout only — body is read with per-chunk timeout below
     let mut request = client.get(&url).timeout(Duration::from_secs(timeout));
     if let Some(credentials) = basic_auth {
         request = request.header("Authorization", basic_auth_header(credentials));
@@ -1443,12 +1611,32 @@ pub async fn fetch_blob_from_upstream(
         return Err(ProxyError::Upstream(status));
     }
 
-    let bytes = response.bytes().await.map_err(|e| {
-        cb.record_failure(&cb_key);
-        ProxyError::Network(e.to_string())
-    })?;
+    // Stream body with per-chunk read timeout
+    let content_length = response.content_length().unwrap_or(0) as usize;
+    let mut stream = response.bytes_stream();
+    let mut data = Vec::with_capacity(content_length);
+    let chunk_timeout = Duration::from_secs(read_timeout);
+
+    loop {
+        match tokio::time::timeout(chunk_timeout, stream.next()).await {
+            Ok(Some(Ok(chunk))) => data.extend_from_slice(&chunk),
+            Ok(Some(Err(e))) => {
+                cb.record_failure(&cb_key);
+                return Err(ProxyError::Network(format!("chunk read error: {}", e)));
+            }
+            Ok(None) => break, // stream finished
+            Err(_) => {
+                cb.record_failure(&cb_key);
+                return Err(ProxyError::Network(format!(
+                    "read timeout ({}s per chunk)",
+                    read_timeout
+                )));
+            }
+        }
+    }
+
     cb.record_success(&cb_key);
-    Ok(bytes.to_vec())
+    Ok(data)
 }
 
 /// Fetch a manifest from an upstream Docker registry
@@ -1559,6 +1747,22 @@ pub async fn fetch_manifest_from_upstream(
 }
 
 /// Detect manifest media type from its JSON content
+/// Build a standard Docker manifest response with Content-Type and Docker-Content-Digest headers.
+fn manifest_response(data: impl Into<Bytes>, content_type: String, digest: String) -> Response {
+    let body: Bytes = data.into();
+    let content_length = body.len().to_string();
+    (
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, content_type),
+            (HeaderName::from_static("docker-content-digest"), digest),
+            (header::CONTENT_LENGTH, content_length),
+        ],
+        body,
+    )
+        .into_response()
+}
+
 fn detect_manifest_media_type(data: &[u8]) -> String {
     // Try to parse as JSON and extract mediaType
     if let Ok(json) = serde_json::from_slice::<Value>(data) {
@@ -1604,10 +1808,12 @@ async fn extract_docker_publish_date(
     name: &str,
     reference: &str,
     upstreams_empty: bool,
+    ns: Option<&str>,
 ) -> Option<i64> {
-    // Try .meta.json sidecar (has push_timestamp)
-    let meta_key = format!("docker/{}/manifests/{}.meta.json", name, reference);
-    if let Ok(data) = storage.get(&meta_key).await {
+    // Try .meta.json sidecar (has push_timestamp) — namespaced, then legacy
+    let meta = manifest_meta_key(ns, name, reference);
+    let legacy_meta = manifest_meta_key(None, name, reference);
+    if let Ok(data) = storage_get_with_fallback(storage, &meta, &legacy_meta).await {
         if let Ok(meta) = serde_json::from_slice::<ImageMetadata>(&data) {
             if meta.push_timestamp > 0 {
                 return Some(meta.push_timestamp as i64);
@@ -1617,8 +1823,15 @@ async fn extract_docker_publish_date(
 
     // mtime fallback — only for hosted mode (no upstreams configured)
     if upstreams_empty {
-        let manifest_key = format!("docker/{}/manifests/{}.json", name, reference);
-        return crate::curation::extract_mtime_as_publish_date(storage, &manifest_key).await;
+        let key = manifest_key(ns, name, reference);
+        let legacy = manifest_key(None, name, reference);
+        // Try namespaced first, then legacy
+        if let Some(date) = crate::curation::extract_mtime_as_publish_date(storage, &key).await {
+            return Some(date);
+        }
+        if key != legacy {
+            return crate::curation::extract_mtime_as_publish_date(storage, &legacy).await;
+        }
     }
 
     None
@@ -2399,6 +2612,7 @@ mod integration_tests {
             "library/nginx",
             "latest",
             true, // no upstreams
+            None, // no namespace
         )
         .await;
         assert_eq!(result, Some(1700000000));
@@ -2420,6 +2634,7 @@ mod integration_tests {
             "library/nginx",
             "latest",
             true, // hosted mode (no upstreams)
+            None, // no namespace
         )
         .await;
         assert!(result.is_some());
@@ -2442,6 +2657,7 @@ mod integration_tests {
             "library/nginx",
             "latest",
             false, // proxy mode (has upstreams)
+            None,  // no namespace
         )
         .await;
         assert!(result.is_none());
@@ -2461,6 +2677,7 @@ mod integration_tests {
             cfg.docker.upstreams = vec![DockerUpstream {
                 url: "http://127.0.0.1:1".into(),
                 auth: None,
+                namespace: None,
             }];
         });
 
@@ -2507,10 +2724,12 @@ mod integration_tests {
                 DockerUpstream {
                     url: "http://127.0.0.1:1".into(), // upstream A (will be tripped)
                     auth: None,
+                    namespace: None,
                 },
                 DockerUpstream {
                     url: "http://127.0.0.1:2".into(), // upstream B (stays closed)
                     auth: None,
+                    namespace: None,
                 },
             ];
         });

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -136,8 +136,8 @@ async fn compact_index(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Gems,
         &name,
@@ -237,8 +237,8 @@ async fn download_gem(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Gems,
         &name,
@@ -252,7 +252,7 @@ async fn download_gem(
     if let Ok(data) = state.storage.get(&storage_key).await {
         // Curation integrity
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Gems,
             &name,
             Some(&version),

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -83,8 +83,8 @@ async fn handle(
         };
 
         if let Some(response) = crate::curation::check_download(
-            &state.curation,
-            state.config.curation.bypass_token.as_deref(),
+            &state.curation().curation_engine,
+            state.bypass_token().as_deref(),
             &headers,
             crate::curation::RegistryType::Go,
             module_name,
@@ -108,7 +108,7 @@ async fn handle(
         // Curation integrity verification (issue #189)
         if let Some((ref module_name, ref version)) = go_curation {
             if let Some(response) = crate::curation::verify_integrity(
-                &state.curation,
+                &state.curation().curation_engine,
                 crate::curation::RegistryType::Go,
                 module_name,
                 version.as_deref(),

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -141,8 +141,8 @@ async fn download(
         };
 
         if let Some(response) = crate::curation::check_download(
-            &state.curation,
-            state.config.curation.bypass_token.as_deref(),
+            &state.curation().curation_engine,
+            state.bypass_token().as_deref(),
             &headers,
             crate::curation::RegistryType::Maven,
             maven_name,
@@ -157,7 +157,7 @@ async fn download(
         // Curation integrity verification (issue #189)
         if let Some((ref maven_name, ref maven_version)) = curation_coords {
             if let Some(response) = crate::curation::verify_integrity(
-                &state.curation,
+                &state.curation().curation_engine,
                 crate::curation::RegistryType::Maven,
                 maven_name,
                 Some(maven_version),

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -100,8 +100,8 @@ async fn handle_request(
         };
 
         if let Some(response) = crate::curation::check_download(
-            &state.curation,
-            state.config.curation.bypass_token.as_deref(),
+            &state.curation().curation_engine,
+            state.bypass_token().as_deref(),
             &headers,
             crate::curation::RegistryType::Npm,
             &package_name,
@@ -147,7 +147,7 @@ async fn handle_request(
 
         // Curation integrity verification (issue #189)
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::Npm,
             &package_name,
             tarball_version.as_deref(),

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -219,8 +219,8 @@ async fn registration_index(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Nuget,
         &id_lower,
@@ -397,8 +397,8 @@ async fn flatcontainer_download(
         let publish_date = extract_nuget_publish_date(&state.storage, &id_lower, ver).await;
 
         if let Some(response) = crate::curation::check_download(
-            &state.curation,
-            state.config.curation.bypass_token.as_deref(),
+            &state.curation().curation_engine,
+            state.bypass_token().as_deref(),
             &headers,
             crate::curation::RegistryType::Nuget,
             &id_lower,
@@ -420,7 +420,7 @@ async fn flatcontainer_download(
     if let Ok(data) = state.storage.get(&storage_key).await {
         if ends_with_ci(filename, ".nupkg") {
             if let Some(response) = crate::curation::verify_integrity(
-                &state.curation,
+                &state.curation().curation_engine,
                 crate::curation::RegistryType::Nuget,
                 &id_lower,
                 Some(ver),

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -133,8 +133,8 @@ async fn package_listing(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::PubDart,
         &package,
@@ -287,8 +287,8 @@ async fn download_archive(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::PubDart,
         &package,
@@ -303,7 +303,7 @@ async fn download_archive(
     if let Ok(data) = state.storage.get(&key).await {
         // Integrity verification (curation allowlist)
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::PubDart,
             &package,
             Some(version),

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -222,8 +222,8 @@ async fn download_file(
     };
 
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::PyPI,
         &normalized,
@@ -239,7 +239,7 @@ async fn download_file(
     if let Ok(data) = state.storage.get(&key).await {
         // Curation integrity verification (issue #189)
         if let Some(response) = crate::curation::verify_integrity(
-            &state.curation,
+            &state.curation().curation_engine,
             crate::curation::RegistryType::PyPI,
             &normalized,
             version.as_deref(),

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -53,8 +53,8 @@ async fn download(
 
     // Curation check — raw files are treated as name=path, no version
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Raw,
         &path,

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -186,8 +186,8 @@ async fn provider_download_meta(
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
-        &state.curation,
-        state.config.curation.bypass_token.as_deref(),
+        &state.curation().curation_engine,
+        state.bypass_token().as_deref(),
         &headers,
         crate::curation::RegistryType::Terraform,
         &format!("{}/{}", ns, ptype),

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -129,6 +129,9 @@ fn build_context(
         docker: DockerConfig {
             enabled: true,
             proxy_timeout: 5,
+            read_timeout: 60,
+            metadata_ttl: -1,
+            stale_while_error: true,
             upstreams: vec![],
         },
         raw: RawConfig {
@@ -214,6 +217,12 @@ fn build_context(
     let enabled_registries = config.enabled_registries();
     let cb_config = config.circuit_breaker.clone();
 
+    let bypass_token = config.curation.bypass_token.clone();
+    let reloadable = Arc::new(arc_swap::ArcSwap::from_pointee(crate::ReloadableConfig {
+        curation_engine: curation_engine,
+        bypass_token,
+    }));
+
     let state = Arc::new(AppState {
         storage,
         config,
@@ -230,7 +239,7 @@ fn build_context(
         http_client: reqwest::Client::new(),
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
         publish_locks: parking_lot::Mutex::new(HashMap::new()),
-        curation: curation_engine,
+        reloadable,
         auth_failures: crate::auth::AuthFailureTracker::new(5, 900),
         oidc: None,
         circuit_breaker: crate::circuit_breaker::CircuitBreakerRegistry::new(cb_config),


### PR DESCRIPTION
## Summary

NORA v0.9.0 milestone — all 10 issues implemented:

- **#311** Docker metadata TTL + stale-while-error for cached manifests
- **#323** Per-upstream Docker namespace prefix with lazy legacy migration
- **#339** Per-registry circuit breaker override thresholds
- **#341** Streaming per-chunk read_timeout for large Docker blob downloads
- **#343** SIGHUP hot reload for curation policy via ArcSwap
- **#193** linux/arm64 multi-platform Docker images and binary releases
- **#307** Production `docker-compose.prod.yml` and `nora.service` systemd unit
- **#338** Extract `manifest_response()` helper (3 duplicate return paths removed)
- **#226** thiserror v2 — blocked on upstream (protobuf), tracked
- **#175** Audit log stdout/S3 — already implemented, verified

### Key changes

| Area | What |
|------|------|
| Docker proxy | Metadata TTL revalidation, stale-while-error fallback, per-chunk streaming timeout, per-upstream storage namespacing |
| Resilience | Per-registry circuit breaker overrides, SIGHUP hot reload for curation |
| Platform | ARM64 Docker images + binary releases |
| Ops | Production docker-compose + systemd unit |

### Stats

- **26 files changed**, +984 / -342 lines
- **975 tests pass** (up from 957, includes v0.8.4 OIDC tests)
- Clippy clean, fmt clean

## Test plan

- [x] `cargo clippy --package nora-registry -- -D warnings` — clean
- [x] `cargo test -p nora-registry` — 975 pass
- [x] `cargo fmt --check` — clean
- [ ] CI status checks pass
- [ ] Smoke test Docker TTL + stale-while-error
- [ ] Smoke test SIGHUP reload

Closes #311, #323, #339, #341, #343, #193, #307, #338