### PR TITLE
fix(docker): flush temp file in chunked upload PATCH handler

### DIFF
--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -748,6 +748,17 @@ async fn patch_blob(
                     state.upload_sessions.write().remove(&uuid);
                     return StatusCode::INTERNAL_SERVER_ERROR.into_response();
                 }
+                // Flush to ensure data is visible to subsequent reads (e.g.
+                // the PUT handler that finalizes this upload). Without an
+                // explicit flush, data may remain in OS page cache only and
+                // can be invisible on overlay-fs / CI runners under I/O
+                // pressure.
+                if let Err(e) = f.flush().await {
+                    tracing::error!(error = %e, "Failed to flush upload temp file");
+                    let _ = tokio::fs::remove_file(&temp_path).await;
+                    state.upload_sessions.write().remove(&uuid);
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
             }
             Err(e) => {
                 tracing::error!(error = %e, "Failed to open upload temp file");


### PR DESCRIPTION
## Summary
- Add explicit `flush()` after `write_all()` in the Docker chunked upload PATCH handler
- Ensures chunk data is committed to the filesystem before the response is returned
- Fixes a rare CI flake where the subsequent PUT handler reads stale data on overlay-fs or under I/O pressure, causing spurious `DIGEST_INVALID` 400 errors

## Test plan
- [x] `test_docker_chunked_upload` passes locally (20/20 runs)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean