### PR TITLE
fix(ui): show package names instead of filenames in gems index

### DIFF
--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -30,9 +30,6 @@ use std::sync::Arc;
 
 const UPSTREAM_DEFAULT: &str = "https://rubygems.org";
 
-/// Storage prefix and file suffix for repo index scanning.
-pub const INDEX_PATTERN: (&str, &str) = ("gems/gems/", ".gem");
-
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         // Index files (mutable)
@@ -439,7 +436,7 @@ fn with_text(data: Vec<u8>) -> Response {
 ///   "rails-7.0.0"      → ("rails", "7.0.0")
 ///   "rack-test-1.0.0"  → ("rack-test", "1.0.0")
 ///   "rspec-core-3.12"  → ("rspec-core", "3.12")
-fn split_gem_filename(stem: &str) -> Option<(String, String)> {
+pub fn split_gem_filename(stem: &str) -> Option<(String, String)> {
     // Find the last '-' that is followed by a digit (start of version)
     let mut split_pos = None;
     for (i, c) in stem.char_indices() {

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -134,10 +134,7 @@ impl RepoIndex {
                     let (p, s) = crate::registry::nuget::INDEX_PATTERN;
                     build_generic_index(storage, p, s).await
                 }
-                RegistryType::Gems => {
-                    let (p, s) = crate::registry::gems::INDEX_PATTERN;
-                    build_generic_index(storage, p, s).await
-                }
+                RegistryType::Gems => build_gems_index(storage).await,
                 RegistryType::Terraform => {
                     let (p, s) = crate::registry::terraform::INDEX_PATTERN;
                     build_generic_index(storage, p, s).await
@@ -425,6 +422,39 @@ async fn build_generic_index(storage: &Storage, prefix: &str, suffix: &str) -> V
         }
         if let Some(rest) = key.strip_prefix(prefix) {
             let name = rest.split('/').next().unwrap_or(rest).to_string();
+            if name.is_empty() {
+                continue;
+            }
+            let entry = packages.entry(name).or_insert((0, 0, 0));
+            entry.0 += 1;
+            if let Some(meta) = storage.stat(key).await {
+                entry.1 += meta.size;
+                if meta.modified > entry.2 {
+                    entry.2 = meta.modified;
+                }
+            }
+        }
+    }
+
+    to_sorted_vec(packages)
+}
+
+/// Gems index: keys like gems/gems/{name}-{version}.gem
+/// Uses split_gem_filename to extract package name from flat file layout.
+async fn build_gems_index(storage: &Storage) -> Vec<RepoInfo> {
+    let keys = storage.list("gems/gems/").await;
+    let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
+
+    for key in &keys {
+        if !key.ends_with(".gem") {
+            continue;
+        }
+        if let Some(rest) = key.strip_prefix("gems/gems/") {
+            let stem = rest.strip_suffix(".gem").unwrap_or(rest);
+            let name = match crate::registry::gems::split_gem_filename(stem) {
+                Some((n, _)) => n,
+                None => stem.to_string(),
+            };
             if name.is_empty() {
                 continue;
             }


### PR DESCRIPTION
## Summary

- RubyGems UI listing showed each `.gem` file as a separate entry (e.g., `bundler-2.6.7.gem`) instead of grouping by package name
- Root cause: `build_generic_index()` groups by first path segment after prefix, but gems are stored flat (`gems/gems/{name}-{version}.gem`) — no subdirectory to split on
- Added dedicated `build_gems_index()` that uses `split_gem_filename()` to correctly extract package names and group versions

## Changes

- `repo_index.rs`: Added `build_gems_index()` function, replaced `build_generic_index()` call for Gems registry type
- `gems.rs`: Made `split_gem_filename()` public, removed unused `INDEX_PATTERN` constant

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test --package nora-registry` — 975 passed, 0 failed
- [x] Manual: verify gems UI shows package names (e.g., `bundler`) instead of filenames (`bundler-2.6.7.gem`)