### PR TITLE
feat(ui): add hierarchical browsing for Go modules

### DIFF
--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -805,6 +805,67 @@ pub async fn get_pypi_detail(
     }
 }
 
+/// List immediate children of a Go namespace path for hierarchical browsing.
+/// Returns (entries, is_leaf_module). A leaf module has an `@v/` subdirectory.
+pub async fn get_go_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoInfo>, bool) {
+    let prefix = if path.is_empty() {
+        "go/".to_string()
+    } else {
+        format!("go/{}/", path)
+    };
+    let keys = storage.list(&prefix).await;
+
+    if keys.is_empty() {
+        return (vec![], false);
+    }
+
+    // Leaf detection: if any key under this prefix contains /@v/ → this is a module
+    let is_module = keys.iter().any(|k| {
+        k.strip_prefix(&prefix)
+            .is_some_and(|r| r.starts_with("@v/"))
+    });
+    if is_module {
+        return (vec![], true);
+    }
+
+    // Group by immediate child segment (skip @latest and other direct files)
+    let mut groups: HashMap<String, (usize, u64, u64)> = HashMap::new();
+    for key in &keys {
+        if let Some(rest) = key.strip_prefix(&prefix) {
+            if rest.is_empty() || !rest.contains('/') {
+                continue;
+            }
+            let child_name = rest.split('/').next().unwrap_or(rest).to_string();
+            // Skip @v and @latest markers — they are not namespace directories
+            if child_name.starts_with('@') {
+                continue;
+            }
+            let entry = groups.entry(child_name).or_insert((0, 0, 0));
+            entry.0 += 1;
+            if let Some(meta) = storage.stat(key).await {
+                entry.1 += meta.size;
+                if meta.modified > entry.2 {
+                    entry.2 = meta.modified;
+                }
+            }
+        }
+    }
+
+    let mut result: Vec<RepoInfo> = groups
+        .into_iter()
+        .map(|(name, (count, size, modified))| RepoInfo {
+            name,
+            versions: count,
+            size,
+            updated: format_timestamp(modified),
+            ..Default::default()
+        })
+        .collect();
+    result.sort_by(|a, b| a.name.cmp(&b.name));
+
+    (result, false)
+}
+
 pub async fn get_go_detail(
     storage: &Storage,
     module: &str,

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -466,19 +466,15 @@ async fn go_list(
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let lang = extract_lang_from_list(&query, headers.get("cookie").and_then(|v| v.to_str().ok()));
-    let page = query.page.unwrap_or(1).max(1);
-    let limit = query.limit.unwrap_or(DEFAULT_PAGE_SIZE).min(100);
     let auth_enabled = state.auth.is_some();
 
-    let all_modules = state.repo_index.get("go", &state.storage).await;
-    let (modules, total) = paginate(&all_modules, page, limit);
+    // Show top-level namespace directories (github.com, golang.org, etc.)
+    let (entries, _) = api::get_go_dir_listing(&state.storage, "").await;
+    let total = entries.len();
 
-    Html(render_registry_list_paginated(
-        "go",
-        "Go Modules",
-        &modules,
-        page,
-        limit,
+    Html(templates::render_go_dir(
+        "",
+        &entries,
         total,
         lang,
         auth_enabled,
@@ -500,19 +496,36 @@ async fn go_detail(
             headers.get("cookie").and_then(|v| v.to_str().ok()),
         )
     };
-    let base_url = resolve_base_url(&state);
     let auth_enabled = state.auth.is_some();
-    let show_prerelease = query.prerelease.unwrap_or(false);
-    let show_all = query.all.unwrap_or(false);
-    let detail = get_go_detail(&state.storage, &name, show_prerelease, show_all).await;
-    Html(render_package_detail(
-        "go",
-        &name,
-        &detail,
-        lang,
-        &base_url,
-        auth_enabled,
-    ))
+
+    // Try hierarchical browsing: check if this is a directory or leaf module
+    let (entries, is_leaf) = api::get_go_dir_listing(&state.storage, &name).await;
+
+    if is_leaf || entries.is_empty() {
+        // Leaf module — show version detail page
+        let base_url = resolve_base_url(&state);
+        let show_prerelease = query.prerelease.unwrap_or(false);
+        let show_all = query.all.unwrap_or(false);
+        let detail = get_go_detail(&state.storage, &name, show_prerelease, show_all).await;
+        Html(render_package_detail(
+            "go",
+            &name,
+            &detail,
+            lang,
+            &base_url,
+            auth_enabled,
+        ))
+    } else {
+        // Namespace directory — show children
+        let total = entries.len();
+        Html(templates::render_go_dir(
+            &name,
+            &entries,
+            total,
+            lang,
+            auth_enabled,
+        ))
+    }
 }
 
 // Raw pages

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -1037,11 +1037,13 @@ pub fn render_package_detail(
         _ => String::new(),
     };
 
-    // Build breadcrumbs — for raw, make each path segment clickable
-    let breadcrumb_html = if registry_type == "raw" && name.contains('/') {
+    // Build breadcrumbs — make each path segment clickable for hierarchical names
+    let breadcrumb_html = if name.contains('/') {
         let segments: Vec<&str> = name.split('/').collect();
-        let mut crumbs =
-            r#"<a href="/ui/raw" class="text-blue-400 hover:text-blue-300">Raw</a>"#.to_string();
+        let mut crumbs = format!(
+            r#"<a href="/ui/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+            registry_type, registry_title
+        );
         for (i, seg) in segments.iter().enumerate() {
             let crumb_path = segments[..=i]
                 .iter()
@@ -1058,7 +1060,8 @@ pub fn render_package_detail(
             } else {
                 let _ = write!(
                     crumbs,
-                    r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/raw/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+                    r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/{}/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+                    registry_type,
                     crumb_path,
                     html_escape(seg)
                 );

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -792,6 +792,134 @@ pub fn render_maven_dir(
     )
 }
 
+/// Renders a Go module namespace browser with breadcrumbs and folder listing
+pub fn render_go_dir(
+    path: &str,
+    entries: &[RepoInfo],
+    total: usize,
+    lang: Lang,
+    auth_enabled: bool,
+) -> String {
+    let t = get_translations(lang);
+
+    // Build breadcrumbs: Go Modules / github.com / gin-gonic
+    let mut breadcrumbs =
+        r#"<a href="/ui/go" class="text-blue-400 hover:text-blue-300">Go Modules</a>"#.to_string();
+    if !path.is_empty() {
+        let segments: Vec<&str> = path.split('/').collect();
+        for (i, seg) in segments.iter().enumerate() {
+            let crumb_path = segments[..=i].join("/");
+            if i == segments.len() - 1 {
+                let _ = write!(
+                    breadcrumbs,
+                    r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
+                    html_escape(seg)
+                );
+            } else {
+                let _ = write!(
+                    breadcrumbs,
+                    r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/go/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+                    crumb_path,
+                    html_escape(seg)
+                );
+            }
+        }
+    }
+
+    let folder_icon = r#"<svg class="w-4 h-4 flex-shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>"#;
+
+    let rows: String = entries
+        .iter()
+        .map(|entry| {
+            let href = if path.is_empty() {
+                format!("/ui/go/{}", encode_uri_component(&entry.name))
+            } else {
+                format!(
+                    "/ui/go/{}/{}",
+                    path,
+                    encode_uri_component(&entry.name)
+                )
+            };
+            format!(
+                r##"
+                <tr class="hover:bg-slate-700 cursor-pointer" onclick="window.location='{}'">
+                    <td class="px-3 md:px-6 py-3 md:py-4">
+                        <div class="flex items-center gap-3">{}<a href="{}" class="text-blue-400 hover:text-blue-300 font-medium">{}</a></div>
+                    </td>
+                    <td class="px-3 md:px-6 py-3 md:py-4 text-slate-400">{}</td>
+                    <td class="px-3 md:px-6 py-3 md:py-4 text-slate-400 hidden md:table-cell">{}</td>
+                    <td class="px-3 md:px-6 py-3 md:py-4 text-slate-500 text-sm hidden md:table-cell">{}</td>
+                </tr>
+            "##,
+                href,
+                folder_icon,
+                href,
+                html_escape(&entry.name),
+                entry.versions,
+                format_size(entry.size),
+                &entry.updated,
+            )
+        })
+        .collect();
+
+    let title_display = if path.is_empty() {
+        "Go Modules".to_string()
+    } else {
+        html_escape(path.rsplit('/').next().unwrap_or(path))
+    };
+    let showing = t.showing_all.replace("{count}", &total.to_string());
+
+    let content = format!(
+        r##"
+        <div class="mb-6">
+            <div class="flex items-center mb-4 text-sm">{breadcrumbs}</div>
+            <div class="flex items-center">
+                <svg class="w-6 h-6 md:w-8 md:h-8 mr-3 text-slate-400 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">{icon}</svg>
+                <h1 class="text-xl md:text-2xl font-bold text-slate-200">{title}</h1>
+            </div>
+        </div>
+
+        <div class="bg-[#1e293b] rounded-lg shadow-sm border border-slate-700 overflow-x-auto">
+            <table class="w-full">
+                <thead class="bg-slate-800 border-b border-slate-700">
+                    <tr>
+                        <th class="px-3 md:px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">{col_name}</th>
+                        <th class="px-3 md:px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">{col_items}</th>
+                        <th class="px-3 md:px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider hidden md:table-cell">{col_size}</th>
+                        <th class="px-3 md:px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider hidden md:table-cell">{col_updated}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-700">
+                    {rows}
+                </tbody>
+            </table>
+            <div class="mt-4 mb-4 ml-4 text-sm text-slate-500">{showing}</div>
+        </div>
+    "##,
+        breadcrumbs = breadcrumbs,
+        icon = icons::GO,
+        title = title_display,
+        col_name = t.name,
+        col_items = t.items,
+        col_size = t.size,
+        col_updated = t.updated,
+        rows = rows,
+        showing = showing,
+    );
+
+    layout_dark(
+        &format!(
+            "Go Modules — {}",
+            if path.is_empty() { "Browse" } else { path }
+        ),
+        &content,
+        Some("go"),
+        "",
+        lang,
+        auth_enabled,
+    )
+}
+
 /// Renders package detail page (npm, cargo, pypi)
 pub fn render_package_detail(
     registry_type: &str,


### PR DESCRIPTION
## Summary

- Go modules UI now shows hierarchical namespace browsing instead of a flat list of full module paths
- Top level shows domains (github.com, golang.org), clicking navigates deeper with breadcrumbs
- Follows the existing Maven directory browsing pattern (`get_maven_dir_listing` / `render_maven_dir`)
- Hierarchical breadcrumbs generalized for all registries with `/` in package names (Go, Maven, Terraform, Ansible, Docker, Raw)

## Changes

- `api.rs`: Added `get_go_dir_listing()` — groups Go storage keys by immediate child segment, uses `@v/` as leaf module detector
- `templates.rs`: Added `render_go_dir()` — breadcrumb navigation + folder listing for Go namespaces
- `templates.rs`: Generalized clickable breadcrumbs in `render_package_detail()` from raw-only to all registries
- `mod.rs`: Updated `go_list()` and `go_detail()` to use hierarchical browsing with leaf/directory dispatch

## Test plan

- `cargo fmt --check` — pass
- `cargo clippy -- -D warnings` — pass
- `cargo test --package nora-registry` — 975 tests pass
- Manual: Go modules UI shows domain-level grouping, breadcrumbs navigate back at every level