### PR TITLE
docs: v0.9 documentation and env var renames

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,12 @@ docker run -d -p 4000:4000 -v nora-data:/data getnora/nora:latest
 ### Binary
 
 ```bash
+# x86_64
 curl -fsSL https://github.com/getnora-io/nora/releases/latest/download/nora-linux-amd64 -o nora
+
+# ARM64 (Raspberry Pi, Graviton, Apple Silicon VMs)
+curl -fsSL https://github.com/getnora-io/nora/releases/latest/download/nora-linux-arm64 -o nora
+
 chmod +x nora && ./nora
 ```
 

--- a/deploy/traefik.yml
+++ b/deploy/traefik.yml
@@ -1,0 +1,87 @@
+# =============================================================================
+# Traefik reverse proxy configuration for NORA
+# =============================================================================
+#
+# Two files are needed:
+#   1. traefik.yml    -- static configuration (entry points, providers)
+#   2. dynamic.yml    -- dynamic configuration (routers, services)
+#
+# Usage with Docker Compose:
+#
+#   services:
+#     traefik:
+#       image: traefik:v3
+#       ports:
+#         - "80:80"
+#         - "443:443"
+#       volumes:
+#         - ./traefik.yml:/etc/traefik/traefik.yml:ro
+#         - ./dynamic.yml:/etc/traefik/dynamic.yml:ro
+#         - /var/run/docker.sock:/var/run/docker.sock:ro
+#         - certs:/etc/traefik/certs
+#
+#     nora:
+#       image: getnora/nora:latest
+#       environment:
+#         NORA_HOST: "0.0.0.0"
+#         NORA_PUBLIC_URL: "https://registry.example.com"
+#         NORA_AUTH_TRUSTED_PROXIES: "172.16.0.0/12"
+#       expose:
+#         - "4000"
+#
+# =============================================================================
+
+# --- traefik.yml (static configuration) ---
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+  websecure:
+    address: ":443"
+
+providers:
+  file:
+    filename: /etc/traefik/dynamic.yml
+
+api:
+  dashboard: false
+
+log:
+  level: WARN
+
+# --- dynamic.yml (dynamic configuration) ---
+# Save this section as a separate file: /etc/traefik/dynamic.yml
+#
+# http:
+#   routers:
+#     nora:
+#       rule: "Host(`registry.example.com`)"
+#       service: nora
+#       entryPoints:
+#         - websecure
+#       tls:
+#         certResolver: letsencrypt
+#
+#   services:
+#     nora:
+#       loadBalancer:
+#         servers:
+#           - url: "http://nora:4000"
+#         healthCheck:
+#           path: /health
+#           interval: 10s
+#           timeout: 3s
+#
+# tls:
+#   certResolver:
+#     letsencrypt:
+#       acme:
+#         email: admin@example.com
+#         storage: /etc/traefik/certs/acme.json
+#         httpChallenge:
+#           entryPoint: web

--- a/dist/nora.env.example
+++ b/dist/nora.env.example
@@ -51,8 +51,8 @@ NORA_STORAGE_PATH=/var/lib/nora
 # NORA_GEMS_METADATA_TTL=300
 
 # Terraform proxy
-# NORA_TERRAFORM_PROXY=https://registry.terraform.io
-# NORA_TERRAFORM_METADATA_TTL=300
+# NORA_TF_PROXY=https://registry.terraform.io
+# NORA_TF_METADATA_TTL=300
 
 # Ansible Galaxy proxy
 # NORA_ANSIBLE_PROXY=https://galaxy.ansible.com

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -72,6 +72,7 @@ export default defineConfig({
 						{ label: 'TLS / HTTPS', slug: 'configuration/tls' },
 						{ label: 'Outbound Proxy', translations: { ru: 'Исходящий прокси' }, slug: 'configuration/http-proxy' },
 						{ label: 'Curation', translations: { ru: 'Курирование' }, slug: 'configuration/curation' },
+						{ label: 'Circuit Breaker', translations: { ru: 'Автоматический выключатель' }, slug: 'configuration/circuit-breaker' },
 						{ label: 'Rate Limits', translations: { ru: 'Ограничение запросов' }, slug: 'configuration/rate-limits' },
 					],
 				},

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -82,6 +82,15 @@ export default defineConfig({
 					items: [
 						{ label: 'Production Guide', translations: { ru: 'Руководство по продакшену' }, slug: 'deployment/production' },
 						{ label: 'Helm Chart', slug: 'deployment/helm' },
+						{ label: 'Upgrade Guide', translations: { ru: 'Руководство по обновлению' }, slug: 'deployment/upgrade-guide' },
+					],
+				},
+				{
+					label: 'Observability',
+					translations: { ru: 'Наблюдаемость' },
+					items: [
+						{ label: 'Prometheus Metrics', translations: { ru: 'Метрики Prometheus' }, slug: 'observability/prometheus-metrics' },
+						{ label: 'Audit Log', translations: { ru: 'Журнал аудита' }, slug: 'observability/audit-log' },
 					],
 				},
 				{

--- a/docs-site/src/content/docs/configuration/circuit-breaker.md
+++ b/docs-site/src/content/docs/configuration/circuit-breaker.md
@@ -1,0 +1,127 @@
+---
+title: Circuit Breaker
+description: Configure the upstream circuit breaker to fail fast when registries are unreachable
+---
+
+
+NORA includes a per-registry circuit breaker that tracks upstream failures and short-circuits requests when a registry is known to be down. This avoids slow timeouts cascading into your build pipelines.
+
+The circuit breaker is **disabled by default** and must be explicitly enabled.
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_CB_ENABLED` | `false` | Enable upstream circuit breaker |
+| `NORA_CB_THRESHOLD` | `5` | Consecutive failures before opening the circuit |
+| `NORA_CB_RESET_TIMEOUT` | `30` | Seconds to wait before probing a failed upstream |
+
+---
+
+## How It Works
+
+The circuit breaker operates as a state machine with three states per upstream registry:
+
+```
+          success
+  ┌─────────────────────┐
+  │                     │
+  ▼     N failures      │
+Closed ──────────► Open ──(reset_timeout)──► HalfOpen
+  ▲                  │                          │
+  │                  │  reject (503 +           │ probe
+  │                  │  Retry-After)            │ succeeds
+  │                  ▼                          │
+  │              caller gets 503               │
+  └────────────────────────────────────────────┘
+           probe fails → back to Open
+```
+
+**Closed** -- Normal operation. All requests pass through to the upstream. Each failure increments a counter.
+
+**Open** -- The upstream has failed `failure_threshold` consecutive times. All proxy requests immediately receive `503 Service Unavailable` with a `Retry-After` header. No upstream connections are attempted.
+
+**HalfOpen** -- After `reset_timeout` seconds, a single probe request is allowed through. If it succeeds, the breaker closes. If it fails, the breaker re-opens.
+
+:::note
+Local reads are never affected by an open circuit breaker. Only upstream proxy requests are short-circuited -- packages already in local storage continue to serve normally.
+:::
+
+---
+
+## config.toml
+
+```toml
+[circuit_breaker]
+enabled = true
+failure_threshold = 5
+reset_timeout = 30
+```
+
+### Per-Registry Overrides
+
+Override the threshold or timeout for specific registries. The key format is `"registry:url"`:
+
+```toml
+[circuit_breaker]
+enabled = true
+failure_threshold = 5
+reset_timeout = 30
+
+[circuit_breaker.overrides."docker:https://registry-1.docker.io"]
+failure_threshold = 10
+reset_timeout = 120
+
+[circuit_breaker.overrides."npm:https://registry.npmjs.org"]
+failure_threshold = 3
+reset_timeout = 60
+```
+
+This lets you be more tolerant of occasional Docker Hub failures while cutting off flaky npm upstreams faster.
+
+---
+
+## Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_circuit_breaker_state` | Gauge | `registry` | Current state: 0 = Closed, 1 = Open, 2 = HalfOpen |
+| `nora_circuit_breaker_rejections_total` | Counter | `registry` | Total requests rejected by an open breaker |
+
+Example alert (Prometheus):
+
+```yaml
+- alert: NoraCircuitBreakerOpen
+  expr: nora_circuit_breaker_state == 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "NORA circuit breaker open for {{ $labels.registry }}"
+```
+
+---
+
+## Example: Docker Compose
+
+```yaml
+services:
+  nora:
+    image: getnora/nora:latest
+    environment:
+      NORA_CB_ENABLED: "true"
+      NORA_CB_THRESHOLD: "5"
+      NORA_CB_RESET_TIMEOUT: "30"
+    ports:
+      - "4000:4000"
+```
+
+---
+
+## See Also
+
+- [Settings](/configuration/settings/) -- complete environment variable reference
+- [Docker Proxy](/configuration/docker-proxy/) -- upstream proxy configuration
+- [Production Deployment](/deployment/production/) -- production deployment guide

--- a/docs-site/src/content/docs/configuration/curation.md
+++ b/docs-site/src/content/docs/configuration/curation.md
@@ -1,0 +1,241 @@
+---
+title: Curation
+description: Configure package access control with blocklists, allowlists, release age quarantine, and hot reload
+---
+
+
+Curation lets you control which packages can be installed through NORA. Use it to block known-malicious packages, enforce an allowlist of approved dependencies, quarantine new releases, or isolate internal namespaces.
+
+---
+
+## Modes
+
+Curation has three modes:
+
+| Mode | Behavior |
+|------|----------|
+| `off` | No curation checks (default) |
+| `audit` | Check all packages, log violations, but allow all requests |
+| `enforce` | Check all packages, block violations with 403 |
+
+```bash
+export NORA_CURATION_MODE="enforce"
+```
+
+```toml
+[curation]
+mode = "enforce"
+```
+
+:::tip
+Start with `audit` mode to observe what would be blocked before switching to `enforce`. Check your logs for `curation_violation` events.
+:::
+
+---
+
+## Blocklist
+
+A blocklist blocks specific packages by name, version, or pattern. Create a JSON file:
+
+```json
+[
+  {
+    "registry": "npm",
+    "name": "event-stream",
+    "reason": "Known supply-chain attack (CVE-2018-16492)"
+  },
+  {
+    "registry": "npm",
+    "name": "colors",
+    "versions": [">=1.4.1"],
+    "reason": "Intentional sabotage in 1.4.1+"
+  },
+  {
+    "registry": "pypi",
+    "name": "jeIlyfish",
+    "reason": "Typosquat of jellyfish"
+  }
+]
+```
+
+Configure the path:
+
+```bash
+export NORA_CURATION_BLOCKLIST_PATH="/etc/nora/blocklist.json"
+```
+
+```toml
+[curation]
+blocklist_path = "/etc/nora/blocklist.json"
+```
+
+---
+
+## Allowlist
+
+An allowlist restricts installations to only approved packages. When an allowlist is active, any package not on the list is blocked.
+
+```json
+[
+  {
+    "registry": "npm",
+    "name": "express"
+  },
+  {
+    "registry": "npm",
+    "name": "lodash",
+    "versions": ["4.17.21"]
+  },
+  {
+    "registry": "pypi",
+    "name": "requests",
+    "integrity": "sha256:abcdef1234567890..."
+  }
+]
+```
+
+```bash
+export NORA_CURATION_ALLOWLIST_PATH="/etc/nora/allowlist.json"
+```
+
+When `require_integrity` is enabled, allowlist entries must include an `integrity` field that matches the package checksum:
+
+```toml
+[curation]
+allowlist_path = "/etc/nora/allowlist.json"
+require_integrity = true
+```
+
+---
+
+## On-Failure Behavior
+
+When a curation filter encounters an error (e.g., corrupted blocklist, I/O failure), the `on_failure` setting determines what happens:
+
+| Value | Behavior |
+|-------|----------|
+| `closed` | Block the request (fail-safe, default) |
+| `open` | Allow the request (fail-open) |
+
+```toml
+[curation]
+on_failure = "closed"
+```
+
+:::caution
+`open` mode means a broken filter silently allows all packages. Use `closed` in production unless you have a specific reason to prefer availability over security.
+:::
+
+---
+
+## Hot Reload with SIGHUP
+
+NORA supports reloading curation policy without restarting:
+
+```bash
+kill -HUP $(pgrep nora)
+```
+
+SIGHUP reloads:
+- Curation mode, blocklist, and allowlist files
+- Bypass token
+
+SIGHUP does **not** reload:
+- Server settings (host, port, public_url)
+- Authentication configuration
+- Storage configuration
+- Registry enable/disable flags
+
+On reload failure, the previous configuration is preserved and an error is logged.
+
+---
+
+## Bypass Token
+
+For emergency access when curation is blocking a critical package, set a bypass token:
+
+```bash
+export NORA_CURATION_BYPASS_TOKEN="emergency-token-keep-secret"
+```
+
+Clients pass the token in the `X-Nora-Bypass` header:
+
+```bash
+# npm
+npm install express --registry http://nora:4000/npm/ \
+  --header "X-Nora-Bypass: emergency-token-keep-secret"
+```
+
+:::danger[Security]
+The bypass token skips all curation checks. Treat it like a root password -- store it in a secrets manager and rotate it after use. Never put it in `config.toml`.
+:::
+
+---
+
+## Internal Namespaces
+
+Packages matching internal namespace patterns skip curation checks entirely. This is a security boundary -- internal packages are never proxied upstream regardless of curation mode.
+
+```toml
+[curation]
+internal_namespaces = ["@mycompany/**", "com.mycompany.**"]
+```
+
+```bash
+export NORA_CURATION_INTERNAL_NS="@mycompany/**,com.mycompany.**"
+```
+
+---
+
+## Minimum Release Age Quarantine
+
+Block packages that were published less than a configurable duration ago. This gives the community time to detect supply-chain attacks before your builds pull new releases.
+
+```toml
+[curation]
+min_release_age = "7d"    # global default
+
+# Per-registry overrides
+[curation.npm]
+min_release_age = "3d"
+
+[curation.pypi]
+min_release_age = "14d"
+```
+
+Supported duration formats: `12h`, `3d`, `1w`, `2w`.
+
+```bash
+export NORA_CURATION_MIN_RELEASE_AGE="7d"
+export NORA_CURATION_NPM_MIN_RELEASE_AGE="3d"
+```
+
+---
+
+## Full config.toml Example
+
+```toml
+[curation]
+mode = "enforce"
+on_failure = "closed"
+blocklist_path = "/etc/nora/blocklist.json"
+allowlist_path = "/etc/nora/allowlist.json"
+# bypass_token = ""  # prefer NORA_CURATION_BYPASS_TOKEN env var
+require_integrity = false
+internal_namespaces = ["@mycompany/**", "com.mycompany.**"]
+min_release_age = "7d"
+
+[curation.npm]
+min_release_age = "3d"
+
+[curation.pypi]
+min_release_age = "14d"
+```
+
+---
+
+## See Also
+
+- [Settings](/configuration/settings/) -- complete environment variable reference
+- [Authentication](/configuration/authentication/) -- user management and access control
+- [Production Deployment](/deployment/production/) -- production deployment guide

--- a/docs-site/src/content/docs/configuration/curation.md
+++ b/docs-site/src/content/docs/configuration/curation.md
@@ -38,24 +38,29 @@ Start with `audit` mode to observe what would be blocked before switching to `en
 A blocklist blocks specific packages by name, version, or pattern. Create a JSON file:
 
 ```json
-[
-  {
-    "registry": "npm",
-    "name": "event-stream",
-    "reason": "Known supply-chain attack (CVE-2018-16492)"
-  },
-  {
-    "registry": "npm",
-    "name": "colors",
-    "versions": [">=1.4.1"],
-    "reason": "Intentional sabotage in 1.4.1+"
-  },
-  {
-    "registry": "pypi",
-    "name": "jeIlyfish",
-    "reason": "Typosquat of jellyfish"
-  }
-]
+{
+  "version": 1,
+  "rules": [
+    {
+      "registry": "npm",
+      "name": "event-stream",
+      "version": "*",
+      "reason": "Known supply-chain attack (CVE-2018-16492)"
+    },
+    {
+      "registry": "npm",
+      "name": "colors",
+      "version": ">=1.4.1",
+      "reason": "Intentional sabotage in 1.4.1+"
+    },
+    {
+      "registry": "pypi",
+      "name": "jeIlyfish",
+      "version": "*",
+      "reason": "Typosquat of jellyfish"
+    }
+  ]
+}
 ```
 
 Configure the path:
@@ -76,22 +81,27 @@ blocklist_path = "/etc/nora/blocklist.json"
 An allowlist restricts installations to only approved packages. When an allowlist is active, any package not on the list is blocked.
 
 ```json
-[
-  {
-    "registry": "npm",
-    "name": "express"
-  },
-  {
-    "registry": "npm",
-    "name": "lodash",
-    "versions": ["4.17.21"]
-  },
-  {
-    "registry": "pypi",
-    "name": "requests",
-    "integrity": "sha256:abcdef1234567890..."
-  }
-]
+{
+  "version": 1,
+  "entries": [
+    {
+      "registry": "npm",
+      "name": "express",
+      "version": "*"
+    },
+    {
+      "registry": "npm",
+      "name": "lodash",
+      "version": "4.17.21"
+    },
+    {
+      "registry": "pypi",
+      "name": "requests",
+      "version": "*",
+      "integrity": "sha256:abcdef1234567890..."
+    }
+  ]
+}
 ```
 
 ```bash
@@ -158,12 +168,12 @@ For emergency access when curation is blocking a critical package, set a bypass 
 export NORA_CURATION_BYPASS_TOKEN="emergency-token-keep-secret"
 ```
 
-Clients pass the token in the `X-Nora-Bypass` header:
+Clients pass the token in the `X-Nora-Bypass-Token` header:
 
 ```bash
 # npm
 npm install express --registry http://nora:4000/npm/ \
-  --header "X-Nora-Bypass: emergency-token-keep-secret"
+  --header "X-Nora-Bypass-Token: emergency-token-keep-secret"
 ```
 
 :::danger[Security]

--- a/docs-site/src/content/docs/configuration/docker-proxy.md
+++ b/docs-site/src/content/docs/configuration/docker-proxy.md
@@ -13,7 +13,7 @@ NORA can proxy Docker (OCI) images from multiple upstream registries simultaneou
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `NORA_DOCKER_PROXIES` | `https://registry-1.docker.io` | Upstream registries. Format: `url1,url2` or `url1\|auth1,url2\|auth2` |
-| `NORA_DOCKER_PROXY_TIMEOUT` | `60` | Connection timeout in seconds |
+| `NORA_DOCKER_PROXY_TIMEOUT` | `300` | Connection timeout in seconds |
 | `NORA_DOCKER_READ_TIMEOUT` | `60` | Per-chunk read timeout for streaming blob downloads |
 | `NORA_DOCKER_METADATA_TTL` | `-1` | Metadata cache TTL in seconds (-1 = forever, 0 = always refetch) |
 | `NORA_DOCKER_SERVE_STALE` | `true` | Serve stale cached manifests when upstream is unreachable |
@@ -27,7 +27,7 @@ Configure multiple upstream registries using `[[docker.upstreams]]` in config.to
 ```toml
 [docker]
 enabled = true
-proxy_timeout = 60
+proxy_timeout = 300
 read_timeout = 60
 metadata_ttl = -1
 serve_stale = true

--- a/docs-site/src/content/docs/configuration/docker-proxy.md
+++ b/docs-site/src/content/docs/configuration/docker-proxy.md
@@ -1,0 +1,139 @@
+---
+title: Docker Proxy
+description: Configure upstream Docker/OCI registry proxying with namespace isolation, metadata caching, and stale-while-error
+---
+
+
+NORA can proxy Docker (OCI) images from multiple upstream registries simultaneously. Each upstream is isolated by namespace and supports independent authentication, timeouts, and path-based routing.
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_DOCKER_PROXIES` | `https://registry-1.docker.io` | Upstream registries. Format: `url1,url2` or `url1\|auth1,url2\|auth2` |
+| `NORA_DOCKER_PROXY_TIMEOUT` | `60` | Connection timeout in seconds |
+| `NORA_DOCKER_READ_TIMEOUT` | `60` | Per-chunk read timeout for streaming blob downloads |
+| `NORA_DOCKER_METADATA_TTL` | `-1` | Metadata cache TTL in seconds (-1 = forever, 0 = always refetch) |
+| `NORA_DOCKER_SERVE_STALE` | `true` | Serve stale cached manifests when upstream is unreachable |
+
+---
+
+## Multiple Upstreams
+
+Configure multiple upstream registries using `[[docker.upstreams]]` in config.toml. Each upstream gets its own URL, auth, and namespace:
+
+```toml
+[docker]
+enabled = true
+proxy_timeout = 60
+read_timeout = 60
+metadata_ttl = -1
+serve_stale = true
+
+# Docker Hub
+[[docker.upstreams]]
+url = "https://registry-1.docker.io"
+# auth = "user:pass"
+
+# GitHub Container Registry
+[[docker.upstreams]]
+url = "https://ghcr.io"
+# auth = "user:ghp_token"
+
+# Private registry
+[[docker.upstreams]]
+url = "https://registry.internal.example.com"
+namespace = "internal"
+```
+
+With environment variables, separate multiple upstreams with commas:
+
+```bash
+export NORA_DOCKER_PROXIES="https://registry-1.docker.io,https://ghcr.io|user:ghp_token"
+```
+
+---
+
+## Namespace Isolation
+
+Each upstream is assigned a **namespace** that isolates its cached images from other upstreams. This prevents name collisions (e.g., `library/nginx` on Docker Hub vs `library/nginx` on a private registry).
+
+The namespace is resolved in this order:
+
+1. Explicit `namespace` field in the upstream config
+2. Derived from the upstream URL host (e.g., `https://registry-1.docker.io` becomes `docker.io`)
+
+```toml
+[[docker.upstreams]]
+url = "https://registry-1.docker.io"
+# namespace = "docker.io"  (derived automatically)
+
+[[docker.upstreams]]
+url = "https://registry.internal.example.com"
+namespace = "internal"  # explicit override
+```
+
+### Path-Based Routing
+
+Upstreams can be exposed at a URL prefix. Requests to `/v2/<prefix>/...` route to the upstream with the prefix stripped:
+
+```toml
+[[docker.upstreams]]
+url = "https://registry-1.docker.io"
+prefix = "docker-hub"
+
+[[docker.upstreams]]
+url = "https://ghcr.io"
+prefix = "ghcr"
+```
+
+With this config:
+- `docker pull nora:4000/docker-hub/library/nginx:latest` pulls from Docker Hub
+- `docker pull nora:4000/ghcr/owner/image:tag` pulls from GHCR
+
+---
+
+## Metadata TTL
+
+The `metadata_ttl` setting controls how long cached manifests and tag lists are considered fresh:
+
+| Value | Behavior |
+|-------|----------|
+| `-1` | Cache forever (default) -- manifests never expire, best for airgapped or bandwidth-constrained environments |
+| `0` | Always refetch -- every request checks upstream, highest consistency but most bandwidth |
+| `> 0` | Cache for N seconds -- balance between freshness and performance |
+
+```toml
+[docker]
+metadata_ttl = 300  # 5 minutes
+```
+
+:::tip
+For mutable tags like `latest`, consider a shorter TTL (e.g., 60-300 seconds). For immutable tags like `v1.2.3`, the default of `-1` (forever) is optimal.
+:::
+
+---
+
+## Stale-While-Error
+
+When `serve_stale` is enabled (the default), NORA serves cached manifests from local storage when the upstream registry is unreachable. This prevents upstream outages from breaking builds that use already-pulled images.
+
+```toml
+[docker]
+serve_stale = true   # default
+```
+
+:::caution
+Stale-while-error only works for images that have been previously pulled and cached. It does not help with images that have never been fetched.
+:::
+
+---
+
+## See Also
+
+- [Settings](/configuration/settings/) -- complete environment variable reference
+- [Circuit Breaker](/configuration/circuit-breaker/) -- automatic upstream failure detection
+- [TLS / HTTPS](/configuration/tls/) -- custom CA certificates for private registries
+- [Outbound Proxy](/configuration/http-proxy/) -- HTTP/SOCKS5 proxy for upstream connections

--- a/docs-site/src/content/docs/configuration/settings.md
+++ b/docs-site/src/content/docs/configuration/settings.md
@@ -267,6 +267,12 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 | `NORA_CB_THRESHOLD` | `5` | Consecutive failures before opening the circuit |
 | `NORA_CB_RESET_TIMEOUT` | `30` | Seconds before probing a failed upstream |
 
+### Audit
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_AUDIT_LOG` | `file` | Audit log output: `file`, `stdout`, `both`, or `off` |
+
 ---
 
 ## config.toml Reference
@@ -518,6 +524,12 @@ on_failure = "closed"       # "closed" (fail-safe) or "open" (fail-open)
 # bypass_token = ""         # prefer NORA_CURATION_BYPASS_TOKEN env var
 require_integrity = false
 internal_namespaces = []    # e.g., ["@mycompany/**", "com.mycompany.**"]
+
+# =============================================================================
+# Audit
+# =============================================================================
+[audit]
+mode = "file"               # "file", "stdout", "both", "off"
 ```
 
 ---
@@ -557,3 +569,6 @@ In Kubernetes, mount credentials from a Secret into the container environment in
 - [Docker Proxy](/configuration/docker-proxy/) -- upstream Docker registry configuration
 - [TLS / HTTPS](/configuration/tls/) -- custom CA certificates
 - [Production Deployment](/deployment/production/) -- production deployment guide
+- [Prometheus Metrics](/observability/prometheus-metrics/) -- complete metrics reference
+- [Audit Log](/observability/audit-log/) -- structured audit logging
+- [Upgrade Guide](/deployment/upgrade-guide/) -- v0.8 to v0.9 migration

--- a/docs-site/src/content/docs/configuration/settings.md
+++ b/docs-site/src/content/docs/configuration/settings.md
@@ -60,6 +60,13 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 | `NORA_AUTH_ANONYMOUS_READ` | `false` | Allow unauthenticated read (pull) access |
 | `NORA_AUTH_HTPASSWD_FILE` | `users.htpasswd` | Path to htpasswd file |
 | `NORA_AUTH_TOKEN_STORAGE` | `data/tokens` | Directory for API token storage |
+| `NORA_AUTH_TRUSTED_PROXIES` | `127.0.0.1,::1` | Comma-separated IPs/CIDRs whose `X-Forwarded-For` is trusted |
+
+### Registry Selection
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_REGISTRIES_ENABLE` | *(none)* | Comma-separated list of registries to enable (e.g., `docker,npm,pypi`) or `all`. Overrides per-registry `NORA_*_ENABLED` flags when set. |
 
 ### Registry Enable/Disable
 
@@ -73,7 +80,7 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 | `NORA_GO_ENABLED` | `true` | Enable Go module proxy |
 | `NORA_RAW_ENABLED` | `true` | Enable raw file storage |
 | `NORA_GEMS_ENABLED` | `false` | Enable RubyGems registry |
-| `NORA_TERRAFORM_ENABLED` | `false` | Enable Terraform provider registry |
+| `NORA_TF_ENABLED` | `false` | Enable Terraform provider registry |
 | `NORA_ANSIBLE_ENABLED` | `false` | Enable Ansible Galaxy registry |
 | `NORA_NUGET_ENABLED` | `false` | Enable NuGet registry |
 | `NORA_PUB_ENABLED` | `false` | Enable Dart/Flutter pub registry |
@@ -111,6 +118,9 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 |----------|---------|-------------|
 | `NORA_DOCKER_PROXIES` | `https://registry-1.docker.io` | Upstream registries. Format: `url1,url2` or `url1\|auth1,url2\|auth2` |
 | `NORA_DOCKER_PROXY_TIMEOUT` | `60` | Proxy timeout in seconds |
+| `NORA_DOCKER_READ_TIMEOUT` | `60` | Per-chunk read timeout for streaming blob downloads |
+| `NORA_DOCKER_METADATA_TTL` | `-1` | Metadata cache TTL in seconds (-1 = forever, 0 = always refetch) |
+| `NORA_DOCKER_SERVE_STALE` | `true` | Serve stale cached manifests when upstream is unreachable |
 
 ### Go
 
@@ -150,10 +160,10 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `NORA_TERRAFORM_PROXY` | `https://registry.terraform.io` | Upstream Terraform registry |
-| `NORA_TERRAFORM_PROXY_AUTH` | *(none)* | Upstream auth (`user:pass`) |
-| `NORA_TERRAFORM_PROXY_TIMEOUT` | `30` | Proxy timeout in seconds |
-| `NORA_TERRAFORM_PROXY_TIMEOUT_DOWNLOAD` | `120` | Timeout for binary downloads in seconds |
+| `NORA_TF_PROXY` | `https://registry.terraform.io` | Upstream Terraform registry |
+| `NORA_TF_PROXY_AUTH` | *(none)* | Upstream auth (`user:pass`) |
+| `NORA_TF_PROXY_TIMEOUT` | `30` | Proxy timeout in seconds |
+| `NORA_TF_PROXY_TIMEOUT_DL` | `120` | Timeout for binary downloads in seconds |
 
 ### Ansible Galaxy
 
@@ -187,7 +197,7 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 | `NORA_CONAN_PROXY` | `https://center2.conan.io` | Upstream Conan registry |
 | `NORA_CONAN_PROXY_AUTH` | *(none)* | Upstream auth (`user:pass`) |
 | `NORA_CONAN_PROXY_TIMEOUT` | `30` | Proxy timeout in seconds |
-| `NORA_CONAN_PROXY_TIMEOUT_DOWNLOAD` | `120` | Timeout for binary downloads in seconds |
+| `NORA_CONAN_PROXY_TIMEOUT_DL` | `120` | Timeout for binary downloads in seconds |
 | `NORA_CONAN_METADATA_TTL` | `300` | Metadata cache TTL in seconds |
 
 ### Rate Limiting
@@ -228,7 +238,7 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 | `NORA_CURATION_BLOCKLIST_PATH` | *(none)* | Path to blocklist JSON file |
 | `NORA_CURATION_BYPASS_TOKEN` | *(none)* | Token to bypass curation checks |
 | `NORA_CURATION_REQUIRE_INTEGRITY` | `false` | Require integrity metadata in allowlist entries |
-| `NORA_CURATION_INTERNAL_NAMESPACES` | *(none)* | Comma-separated glob patterns for internal namespaces |
+| `NORA_CURATION_INTERNAL_NS` | *(none)* | Comma-separated glob patterns for internal namespaces |
 | `NORA_CURATION_MIN_RELEASE_AGE` | *(none)* | Global min release age (`7d`, `12h`, `2w`) |
 | `NORA_CURATION_NPM_MIN_RELEASE_AGE` | *(none)* | npm-specific min release age override |
 | `NORA_CURATION_PYPI_MIN_RELEASE_AGE` | *(none)* | PyPI-specific min release age override |
@@ -242,6 +252,20 @@ These are standard environment variables — not prefixed with `NORA_`. See [Out
 |----------|---------|-------------|
 | `NORA_SECRETS_PROVIDER` | `env` | Secrets provider: `env`, `aws-secrets`, `vault`, `k8s` |
 | `NORA_SECRETS_CLEAR_ENV` | `false` | Clear env vars after reading (env provider) |
+
+### TLS
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_TLS_CA_CERT` | *(none)* | Path to PEM-encoded CA certificate bundle (appended to system CAs) |
+
+### Circuit Breaker
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_CB_ENABLED` | `false` | Enable upstream circuit breaker |
+| `NORA_CB_THRESHOLD` | `5` | Consecutive failures before opening the circuit |
+| `NORA_CB_RESET_TIMEOUT` | `30` | Seconds before probing a failed upstream |
 
 ---
 
@@ -281,6 +305,7 @@ enabled = false
 anonymous_read = false
 htpasswd_file = "users.htpasswd"
 token_storage = "data/tokens"
+# trusted_proxies = "127.0.0.1,::1"  # IPs/CIDRs whose X-Forwarded-For is trusted
 
 # =============================================================================
 # Secrets
@@ -307,6 +332,9 @@ general_burst = 200
 [docker]
 enabled = true
 proxy_timeout = 60
+read_timeout = 60
+metadata_ttl = -1              # -1 = forever, 0 = always refetch, >0 = seconds
+serve_stale = true
 
 [[docker.upstreams]]
 url = "https://registry-1.docker.io"
@@ -392,7 +420,7 @@ enabled = false
 proxy = "https://registry.terraform.io"
 # proxy_auth = "user:pass"
 proxy_timeout = 30
-proxy_timeout_download = 120
+proxy_timeout_dl = 120
 
 # =============================================================================
 # Ansible Galaxy Registry
@@ -430,7 +458,7 @@ enabled = false
 proxy = "https://center2.conan.io"
 # proxy_auth = "user:pass"
 proxy_timeout = 30
-proxy_timeout_download = 120
+proxy_timeout_dl = 120
 metadata_ttl = 300
 
 # =============================================================================
@@ -459,6 +487,25 @@ dry_run = false
 # [[retention.rules]]
 # registry = "*"
 # older_than_days = 180
+
+# =============================================================================
+# TLS (Custom CA Certificates)
+# =============================================================================
+[tls]
+# ca_cert = "/etc/nora/ca-bundle.pem"  # PEM-encoded CA bundle (appended to system CAs)
+
+# =============================================================================
+# Circuit Breaker
+# =============================================================================
+[circuit_breaker]
+enabled = false
+failure_threshold = 5
+reset_timeout = 30
+
+# Per-registry overrides:
+# [circuit_breaker.overrides."docker:https://registry-1.docker.io"]
+# failure_threshold = 10
+# reset_timeout = 120
 
 # =============================================================================
 # Curation (Package Access Control)
@@ -505,6 +552,8 @@ In Kubernetes, mount credentials from a Secret into the container environment in
 ## See Also
 
 - [Authentication](/configuration/authentication/) -- user management and API tokens
+- [Circuit Breaker](/configuration/circuit-breaker/) -- upstream failure detection
 - [Curation](/configuration/curation/) -- package access control
-- [Rate Limits](/configuration/rate-limits/) -- rate limiting tuning
+- [Docker Proxy](/configuration/docker-proxy/) -- upstream Docker registry configuration
+- [TLS / HTTPS](/configuration/tls/) -- custom CA certificates
 - [Production Deployment](/deployment/production/) -- production deployment guide

--- a/docs-site/src/content/docs/configuration/tls.md
+++ b/docs-site/src/content/docs/configuration/tls.md
@@ -1,0 +1,113 @@
+---
+title: TLS / HTTPS
+description: Configure custom CA certificates for upstream registry connections
+---
+
+
+NORA uses the system CA certificate store by default for all outbound HTTPS connections to upstream registries. If your upstreams use self-signed certificates or you are behind a corporate TLS-inspecting proxy, you can provide a custom CA bundle.
+
+---
+
+## Environment Variable
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_TLS_CA_CERT` | *(none)* | Path to PEM-encoded CA certificate bundle (appended to system CAs) |
+
+The certificates in this file are **appended** to the system CA store -- they do not replace it.
+
+---
+
+## config.toml
+
+```toml
+[tls]
+ca_cert = "/etc/nora/ca-bundle.pem"
+```
+
+---
+
+## Use Cases
+
+### Corporate TLS-Inspecting Proxy
+
+Organizations that inspect outbound HTTPS traffic with a proxy (e.g., Zscaler, Bluecoat) replace upstream TLS certificates with ones signed by an internal CA. Without adding this CA to NORA, all upstream connections fail with certificate verification errors.
+
+```bash
+export NORA_TLS_CA_CERT="/etc/ssl/corporate-ca.pem"
+```
+
+### Self-Signed Upstream Registries
+
+Private registries using self-signed certificates need their CA added to NORA:
+
+```bash
+export NORA_TLS_CA_CERT="/etc/nora/private-registry-ca.pem"
+```
+
+---
+
+## Docker Compose Example
+
+Mount the CA bundle as a volume and set the environment variable:
+
+```yaml
+services:
+  nora:
+    image: getnora/nora:latest
+    environment:
+      NORA_TLS_CA_CERT: "/etc/nora/ca-bundle.pem"
+    volumes:
+      - ./ca-bundle.pem:/etc/nora/ca-bundle.pem:ro
+    ports:
+      - "4000:4000"
+```
+
+---
+
+## Kubernetes Example
+
+Mount the CA bundle from a ConfigMap:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nora-ca
+data:
+  ca-bundle.pem: |
+    -----BEGIN CERTIFICATE-----
+    MIIDxTCCAq2gAwIBAgIQAqxcJmoLQ...
+    -----END CERTIFICATE-----
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora
+spec:
+  template:
+    spec:
+      containers:
+        - name: nora
+          image: getnora/nora:latest
+          env:
+            - name: NORA_TLS_CA_CERT
+              value: /etc/nora/ca-bundle.pem
+          volumeMounts:
+            - name: ca-bundle
+              mountPath: /etc/nora/ca-bundle.pem
+              subPath: ca-bundle.pem
+              readOnly: true
+      volumes:
+        - name: ca-bundle
+          configMap:
+            name: nora-ca
+```
+
+---
+
+## See Also
+
+- [Settings](/configuration/settings/) -- complete environment variable reference
+- [Outbound Proxy](/configuration/http-proxy/) -- HTTP/SOCKS5 proxy configuration
+- [Docker Proxy](/configuration/docker-proxy/) -- upstream Docker registry configuration

--- a/docs-site/src/content/docs/deployment/upgrade-guide.md
+++ b/docs-site/src/content/docs/deployment/upgrade-guide.md
@@ -1,0 +1,111 @@
+---
+title: Upgrade Guide
+description: Upgrading NORA between versions — migration notes and rollback procedures
+---
+
+## v0.8 to v0.9
+
+v0.9 is backward-compatible for all features and storage. The only action required is updating renamed environment variables if you use any of the [renamed names](#renamed-environment-variables) listed below.
+
+### What changed
+
+| Feature | Impact | Action required |
+|---------|--------|-----------------|
+| Docker namespace isolation | Storage layout adds namespace prefix | None — lazy migration is automatic |
+| Circuit breaker | New feature, disabled by default | None |
+| Docker metadata TTL + stale-while-error | New feature, opt-in | None |
+| Streaming read_timeout | New feature, opt-in | None |
+| SIGHUP hot reload for curation | New capability | None |
+| linux/arm64 binary | New platform | None |
+
+### Docker namespace migration
+
+v0.9 introduces per-upstream namespace prefixes for Docker storage keys to isolate data from different upstream registries.
+
+**Old layout (v0.8):**
+```
+docker/{name}/blobs/{digest}
+docker/{name}/manifests/{ref}.json
+```
+
+**New layout (v0.9):**
+```
+docker/{namespace}/{name}/blobs/{digest}
+docker/{namespace}/{name}/manifests/{ref}.json
+```
+
+The namespace is derived from the upstream URL (e.g., `registry-1.docker.io` becomes `docker.io`) or set explicitly via the `namespace` field in `[[docker.upstreams]]`.
+
+**Migration is automatic and lazy:**
+- When NORA serves a request, it first checks the namespaced path.
+- If not found, it falls back to the legacy flat path.
+- No background migration runs at startup.
+- Existing cached data continues to be served without interruption.
+
+:::note
+Locally pushed images (not proxied from an upstream) are unaffected — they have no namespace prefix.
+:::
+
+### Upgrade steps
+
+1. Stop the running NORA instance.
+2. Replace the binary or update the container image to v0.9.
+3. Start NORA with your existing configuration.
+
+```bash
+# Binary upgrade
+curl -fsSL https://github.com/getnora-io/nora/releases/latest/download/nora-linux-amd64 -o nora
+chmod +x nora
+./nora
+```
+
+No data migration scripts are needed.
+
+### Rollback
+
+To roll back from v0.9 to v0.8:
+
+1. Stop the v0.9 instance.
+2. Replace the binary or image with v0.8.
+3. Start NORA.
+
+:::caution
+Any Docker images cached **after** upgrading to v0.9 are stored under the new namespaced layout. v0.8 will not find these entries — they appear as cache misses and are re-fetched from upstream on next access. Locally pushed artifacts are unaffected.
+:::
+
+### New environment variables
+
+v0.9 adds these optional variables (all disabled or inactive by default):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_CB_ENABLED` | `false` | Enable circuit breaker |
+| `NORA_CB_THRESHOLD` | `5` | Failures before opening |
+| `NORA_CB_RESET_TIMEOUT` | `30` | Seconds before probing |
+| `NORA_DOCKER_READ_TIMEOUT` | `60` | Per-chunk read timeout (seconds) |
+| `NORA_DOCKER_METADATA_TTL` | `-1` | Metadata cache TTL in seconds |
+| `NORA_DOCKER_SERVE_STALE` | `true` | Serve cached manifests when upstream is down |
+
+See [Settings](/configuration/settings/) for the full reference.
+
+### Renamed environment variables
+
+v0.9 shortens several variable names to follow the `NORA_{SECTION}_{FIELD}` convention (under 30 characters):
+
+| Old name | New name |
+|----------|----------|
+| `NORA_TERRAFORM_ENABLED` | `NORA_TF_ENABLED` |
+| `NORA_TERRAFORM_PROXY` | `NORA_TF_PROXY` |
+| `NORA_TERRAFORM_PROXY_TIMEOUT` | `NORA_TF_PROXY_TIMEOUT` |
+| `NORA_TERRAFORM_METADATA_TTL` | `NORA_TF_METADATA_TTL` |
+| `NORA_TERRAFORM_PROXY_TIMEOUT_DOWNLOAD` | `NORA_TF_PROXY_TIMEOUT_DL` |
+| `NORA_CONAN_PROXY_TIMEOUT_DOWNLOAD` | `NORA_CONAN_PROXY_TIMEOUT_DL` |
+| `NORA_CURATION_INTERNAL_NAMESPACES` | `NORA_CURATION_INTERNAL_NS` |
+
+The old names are no longer recognized. Update your configuration if you use any of these.
+
+## See Also
+
+- [Settings](/configuration/settings/) — full environment variable reference
+- [Circuit Breaker](/configuration/circuit-breaker/) — new in v0.9
+- [Docker Proxy](/configuration/docker-proxy/) — namespace isolation details

--- a/docs-site/src/content/docs/observability/audit-log.md
+++ b/docs-site/src/content/docs/observability/audit-log.md
@@ -1,0 +1,133 @@
+---
+title: Audit Log
+description: Track all registry operations with structured JSONL audit logging
+---
+
+NORA records registry operations in a structured audit log. Each entry is a JSON object written to a single line (JSONL format).
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `NORA_AUDIT_LOG` | `file` | Output mode: `file`, `stdout`, `both`, or `off` |
+
+```toml
+# config.toml
+[audit]
+mode = "file"       # "file", "stdout", "both", "off"
+```
+
+**Modes:**
+
+| Mode | Behavior |
+|------|----------|
+| `file` | Write to `{storage_path}/audit.jsonl` |
+| `stdout` | Write to stderr (12-factor compatible, works with log aggregators) |
+| `both` | Write to both file and stderr |
+| `off` | Disable audit logging |
+
+## Log format
+
+Each line is a JSON object with these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ts` | string | ISO 8601 timestamp (UTC) |
+| `action` | string | `push`, `pull`, `delete`, `cache_hit`, `proxy_fetch`, `overwrite`, `retention-apply` |
+| `actor` | string | Origin of the operation: `api` (HTTP request), `scheduler` (retention), or `cli` |
+| `artifact` | string | Package name or image reference |
+| `registry` | string | Registry type: `docker`, `npm`, `pypi`, `maven`, etc. |
+| `detail` | string | Additional context (version, digest, size) |
+
+### Example entries
+
+```json
+{"ts":"2026-05-18T10:30:45.123Z","action":"push","actor":"api","artifact":"myapp","registry":"docker","detail":"sha256:abc123"}
+{"ts":"2026-05-18T10:31:02.456Z","action":"pull","actor":"api","artifact":"lodash","registry":"npm","detail":"4.17.21"}
+{"ts":"2026-05-18T10:32:15.789Z","action":"delete","actor":"api","artifact":"old-image:v1","registry":"docker","detail":"manifest"}
+{"ts":"2026-05-18T10:33:00.001Z","action":"cache_hit","actor":"api","artifact":"","registry":"maven","detail":""}
+{"ts":"2026-05-18T10:33:05.200Z","action":"proxy_fetch","actor":"api","artifact":"","registry":"npm","detail":""}
+{"ts":"2026-05-18T10:34:10.500Z","action":"overwrite","actor":"api","artifact":"libs/config.yaml","registry":"raw","detail":""}
+```
+
+**Action types:**
+
+| Action | Description |
+|--------|-------------|
+| `push` | Client uploaded a new artifact |
+| `pull` | Client downloaded an artifact from local storage |
+| `delete` | Client deleted an artifact |
+| `cache_hit` | Request served from local cache without contacting upstream |
+| `proxy_fetch` | Artifact fetched from an upstream registry |
+| `overwrite` | Existing artifact replaced (Raw registry) |
+| `retention-apply` | Artifact removed by retention policy |
+
+## File location
+
+When using `file` or `both` mode, the audit log is written to:
+
+```
+{NORA_STORAGE_PATH}/audit.jsonl
+```
+
+Default: `data/audit.jsonl` (relative to the working directory).
+
+The file is created automatically. Parent directories are created if they do not exist.
+
+## Docker Compose example
+
+```yaml
+services:
+  nora:
+    image: ghcr.io/getnora-io/nora:0.9
+    environment:
+      NORA_AUDIT_LOG: both
+      NORA_STORAGE_PATH: /data
+    volumes:
+      - nora-data:/data
+```
+
+Then tail the log:
+
+```bash
+docker exec nora tail -f /data/audit.jsonl | jq .
+```
+
+## Forwarding to a log aggregator
+
+With `stdout` mode, audit entries go to stderr alongside regular logs. Use your container orchestrator's log driver to forward them:
+
+```bash
+# Filter audit entries from container logs
+docker logs nora 2>&1 | grep '"action":' | jq .
+```
+
+For dedicated file-based forwarding (Filebeat, Promtail, Vector):
+
+```yaml
+# filebeat.yml
+filebeat.inputs:
+  - type: log
+    paths:
+      - /data/audit.jsonl
+    json.keys_under_root: true
+    json.add_error_key: true
+```
+
+## Querying the audit log
+
+```bash
+# All pushes today
+grep '"action":"push"' /data/audit.jsonl | jq .
+
+# All Docker operations by user "admin"
+jq -c 'select(.registry == "docker" and .actor == "admin")' /data/audit.jsonl
+
+# Count operations per registry
+jq -r '.registry' /data/audit.jsonl | sort | uniq -c | sort -rn
+```
+
+## See Also
+
+- [Settings](/configuration/settings/) — `NORA_AUDIT_LOG` env var
+- [Prometheus Metrics](/observability/prometheus-metrics/) — quantitative monitoring

--- a/docs-site/src/content/docs/observability/prometheus-metrics.md
+++ b/docs-site/src/content/docs/observability/prometheus-metrics.md
@@ -1,0 +1,117 @@
+---
+title: Prometheus Metrics
+description: Complete reference of all NORA Prometheus metrics available at /metrics
+---
+
+NORA exposes Prometheus-compatible metrics at the `/metrics` endpoint. No authentication is required.
+
+```bash
+curl http://localhost:4000/metrics
+```
+
+## HTTP metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_http_requests_total` | Counter | `registry`, `method`, `status` | Total HTTP requests processed |
+| `nora_http_request_duration_seconds` | Histogram | `registry`, `method` | Request latency (buckets: 1ms to 10s) |
+
+The `registry` label is derived from the request path:
+
+| Path prefix | Label |
+|-------------|-------|
+| `/v2*` | `docker` |
+| `/npm*` | `npm` |
+| `/simple*`, `/packages*` | `pypi` |
+| `/maven2*` | `maven` |
+| `/cargo*` | `cargo` |
+| `/go/*` | `go` |
+| `/raw/*` | `raw` |
+| `/gems/*` | `gems` |
+| `/terraform/*` | `terraform` |
+| `/ansible/*` | `ansible` |
+| `/nuget/*` | `nuget` |
+| `/pub/*` | `pub` |
+| `/conan/*` | `conan` |
+| `/ui*` | `ui` |
+| *(other paths)* | `other` |
+
+## Cache metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_cache_requests_total` | Counter | `registry`, `result` | Cache lookups (`hit` or `miss`) |
+
+## Storage metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_storage_operations_total` | Counter | `operation`, `status` | Storage operations (`get`, `put`, `delete`, `list`) with `ok` or `error` status |
+| `nora_artifacts_total` | Counter | `registry` | Total artifacts stored per registry |
+
+## Circuit breaker metrics
+
+Available when `NORA_CB_ENABLED=true`.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_circuit_breaker_state` | Gauge | `registry` | Current state: `0` = closed, `1` = open, `2` = half-open |
+| `nora_circuit_breaker_rejections_total` | Counter | `registry` | Requests rejected by an open breaker |
+
+## Garbage collection metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `nora_gc_blobs_removed_total` | Counter | Orphaned blobs removed by GC |
+| `nora_gc_bytes_freed_total` | Counter | Bytes freed by GC |
+| `nora_gc_duration_seconds` | Histogram | Duration of GC runs (buckets: 0.1s to 300s) |
+| `nora_gc_last_run_timestamp` | Gauge | Unix timestamp of last GC run |
+| `nora_gc_metadata_phantoms_total` | Counter | Phantom version entries cleaned from metadata |
+
+## Retention metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `nora_retention_versions_deleted_total` | Counter | Versions removed by retention policies |
+| `nora_retention_bytes_freed_total` | Counter | Bytes freed by retention |
+| `nora_retention_duration_seconds` | Histogram | Duration of retention runs (buckets: 0.1s to 300s) |
+| `nora_retention_last_run_timestamp` | Gauge | Unix timestamp of last retention run |
+
+## Grafana example
+
+```promql
+# Request rate by registry (5m window)
+sum by (registry) (rate(nora_http_requests_total[5m]))
+
+# Cache hit ratio
+sum(rate(nora_cache_requests_total{result="hit"}[5m]))
+/
+sum(rate(nora_cache_requests_total[5m]))
+
+# p99 latency per registry
+histogram_quantile(0.99, sum by (le, registry) (rate(nora_http_request_duration_seconds_bucket[5m])))
+
+# Circuit breaker alerts (open state)
+nora_circuit_breaker_state == 1
+
+# GC bytes freed per hour
+increase(nora_gc_bytes_freed_total[1h])
+```
+
+## Scrape configuration
+
+```yaml
+# prometheus.yml
+scrape_configs:
+  - job_name: nora
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['nora:4000']
+    metrics_path: /metrics
+```
+
+## See Also
+
+- [Settings](/configuration/settings/) — `NORA_METRICS_ENABLED` and related options
+- [Circuit Breaker](/configuration/circuit-breaker/) — breaker metrics details
+- [Upgrade Guide](/deployment/upgrade-guide/) — new metrics in v0.9

--- a/docs-site/src/content/docs/ru/configuration/settings.md
+++ b/docs-site/src/content/docs/ru/configuration/settings.md
@@ -62,7 +62,7 @@ NORA использует многоуровневую модель конфиг
 | `NORA_GO_ENABLED` | `true` | Включить прокси модулей Go |
 | `NORA_RAW_ENABLED` | `true` | Включить хранилище необработанных файлов |
 | `NORA_GEMS_ENABLED` | `false` | Включить реестр RubyGems |
-| `NORA_TERRAFORM_ENABLED` | `false` | Включить реестр провайдеров Terraform |
+| `NORA_TF_ENABLED` | `false` | Включить реестр провайдеров Terraform |
 | `NORA_ANSIBLE_ENABLED` | `false` | Включить реестр Ansible Galaxy |
 | `NORA_NUGET_ENABLED` | `false` | Включить реестр NuGet |
 | `NORA_PUB_ENABLED` | `false` | Включить реестр Dart/Flutter pub |
@@ -139,10 +139,10 @@ NORA использует многоуровневую модель конфиг
 
 | Переменная | По умолчанию | Описание |
 |----------|---------|-------------|
-| `NORA_TERRAFORM_PROXY` | `https://registry.terraform.io` | Вышестоящий реестр Terraform |
-| `NORA_TERRAFORM_PROXY_AUTH` | *(нет)* | Аутентификация вышестоящего реестра (`user:pass`) |
-| `NORA_TERRAFORM_PROXY_TIMEOUT` | `30` | Таймаут прокси в секундах |
-| `NORA_TERRAFORM_PROXY_TIMEOUT_DOWNLOAD` | `120` | Таймаут загрузки бинарных файлов в секундах |
+| `NORA_TF_PROXY` | `https://registry.terraform.io` | Вышестоящий реестр Terraform |
+| `NORA_TF_PROXY_AUTH` | *(нет)* | Аутентификация вышестоящего реестра (`user:pass`) |
+| `NORA_TF_PROXY_TIMEOUT` | `30` | Таймаут прокси в секундах |
+| `NORA_TF_PROXY_TIMEOUT_DL` | `120` | Таймаут загрузки бинарных файлов в секундах |
 
 ### Ansible Galaxy
 
@@ -176,7 +176,7 @@ NORA использует многоуровневую модель конфиг
 | `NORA_CONAN_PROXY` | `https://center2.conan.io` | Вышестоящий реестр Conan |
 | `NORA_CONAN_PROXY_AUTH` | *(нет)* | Аутентификация вышестоящего реестра (`user:pass`) |
 | `NORA_CONAN_PROXY_TIMEOUT` | `30` | Таймаут прокси в секундах |
-| `NORA_CONAN_PROXY_TIMEOUT_DOWNLOAD` | `120` | Таймаут загрузки бинарных файлов в секундах |
+| `NORA_CONAN_PROXY_TIMEOUT_DL` | `120` | Таймаут загрузки бинарных файлов в секундах |
 | `NORA_CONAN_METADATA_TTL` | `300` | TTL кэша метаданных в секундах |
 
 ### Ограничение частоты запросов
@@ -217,7 +217,7 @@ NORA использует многоуровневую модель конфиг
 | `NORA_CURATION_BLOCKLIST_PATH` | *(нет)* | Путь к JSON-файлу списка блокировки |
 | `NORA_CURATION_BYPASS_TOKEN` | *(нет)* | Токен для обхода проверок курирования |
 | `NORA_CURATION_REQUIRE_INTEGRITY` | `false` | Требовать метаданные целостности в записях списка разрешений |
-| `NORA_CURATION_INTERNAL_NAMESPACES` | *(нет)* | Разделённые запятой glob-паттерны для внутренних пространств имён |
+| `NORA_CURATION_INTERNAL_NS` | *(нет)* | Разделённые запятой glob-паттерны для внутренних пространств имён |
 | `NORA_CURATION_MIN_RELEASE_AGE` | *(нет)* | Глобальный мин. возраст релиза (`7d`, `12h`, `2w`) |
 | `NORA_CURATION_NPM_MIN_RELEASE_AGE` | *(нет)* | Мин. возраст релиза для npm |
 | `NORA_CURATION_PYPI_MIN_RELEASE_AGE` | *(нет)* | Мин. возраст релиза для PyPI |
@@ -381,7 +381,7 @@ enabled = false
 proxy = "https://registry.terraform.io"
 # proxy_auth = "user:pass"
 proxy_timeout = 30
-proxy_timeout_download = 120
+proxy_timeout_dl = 120
 
 # =============================================================================
 # Ansible Galaxy Registry
@@ -419,7 +419,7 @@ enabled = false
 proxy = "https://center2.conan.io"
 # proxy_auth = "user:pass"
 proxy_timeout = 30
-proxy_timeout_download = 120
+proxy_timeout_dl = 120
 metadata_ttl = 300
 
 # =============================================================================

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -277,7 +277,7 @@ pub struct DockerConfig {
     pub metadata_ttl: i64,
     /// Serve stale cached manifests when upstream is unreachable (default: true).
     #[serde(default = "default_true")]
-    pub stale_while_error: bool,
+    pub serve_stale: bool,
     #[serde(default)]
     pub upstreams: Vec<DockerUpstream>,
 }
@@ -421,7 +421,7 @@ pub struct TerraformConfig {
     pub proxy_timeout: u64,
     /// Separate timeout for binary downloads (default: 120s)
     #[serde(default = "default_go_zip_timeout")]
-    pub proxy_timeout_download: u64,
+    pub proxy_timeout_dl: u64,
     /// Metadata cache TTL in seconds (default: 300 = 5 min).
     /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
@@ -439,7 +439,7 @@ impl Default for TerraformConfig {
             proxy: default_terraform_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
-            proxy_timeout_download: 120,
+            proxy_timeout_dl: 120,
             metadata_ttl: 300,
         }
     }
@@ -567,7 +567,7 @@ pub struct ConanConfig {
     pub proxy_timeout: u64,
     /// Separate timeout for binary downloads (default: 120s)
     #[serde(default = "default_go_zip_timeout")]
-    pub proxy_timeout_download: u64,
+    pub proxy_timeout_dl: u64,
     /// Metadata cache TTL in seconds (default: 300 = 5 min).
     /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
@@ -585,7 +585,7 @@ impl Default for ConanConfig {
             proxy: default_conan_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
-            proxy_timeout_download: 120,
+            proxy_timeout_dl: 120,
             metadata_ttl: 300,
         }
     }
@@ -921,7 +921,7 @@ impl Default for DockerConfig {
             proxy_timeout: 300,
             read_timeout: 60,
             metadata_ttl: -1,
-            stale_while_error: true,
+            serve_stale: true,
             upstreams: vec![DockerUpstream {
                 url: "https://registry-1.docker.io".to_string(),
                 auth: None,
@@ -1171,7 +1171,7 @@ pub enum CurationOnFailure {
 /// - `NORA_CURATION_BLOCKLIST_PATH` — path to blocklist JSON file
 /// - `NORA_CURATION_BYPASS_TOKEN` — token to bypass curation checks
 /// - `NORA_CURATION_REQUIRE_INTEGRITY` — require integrity metadata (default: false)
-/// - `NORA_CURATION_INTERNAL_NAMESPACES` — comma-separated glob patterns
+/// - `NORA_CURATION_INTERNAL_NS` — comma-separated glob patterns
 /// - `NORA_CURATION_MIN_RELEASE_AGE` — minimum release age (e.g., "7d", "24h", "1w")
 /// - `NORA_CURATION_QUARANTINE` — quarantine mode: off/observe/enforce (default: off)
 /// - `NORA_CURATION_QUARANTINE_TTL` — quarantine hold duration (e.g., "14d", "24h")
@@ -1607,7 +1607,7 @@ impl Config {
             "NORA_GO_ENABLED",
             "NORA_RAW_ENABLED",
             "NORA_GEMS_ENABLED",
-            "NORA_TERRAFORM_ENABLED",
+            "NORA_TF_ENABLED",
             "NORA_ANSIBLE_ENABLED",
             "NORA_NUGET_ENABLED",
             "NORA_PUB_ENABLED",
@@ -2022,7 +2022,7 @@ impl Config {
         if let Ok(val) = env::var("NORA_GEMS_ENABLED") {
             self.gems.enabled = val.to_lowercase() == "true" || val == "1";
         }
-        if let Ok(val) = env::var("NORA_TERRAFORM_ENABLED") {
+        if let Ok(val) = env::var("NORA_TF_ENABLED") {
             self.terraform.enabled = val.to_lowercase() == "true" || val == "1";
         }
         if let Ok(val) = env::var("NORA_ANSIBLE_ENABLED") {
@@ -2119,8 +2119,8 @@ impl Config {
                 self.docker.metadata_ttl = ttl;
             }
         }
-        if let Ok(val) = env::var("NORA_DOCKER_STALE_WHILE_ERROR") {
-            self.docker.stale_while_error = !matches!(val.as_str(), "false" | "0");
+        if let Ok(val) = env::var("NORA_DOCKER_SERVE_STALE") {
+            self.docker.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
         // NORA_DOCKER_PROXIES format: "url1,url2" or "url1|auth1,url2|auth2"
         // or "url1|auth1|prefix1,url2||prefix2" (empty auth with prefix)
@@ -2234,23 +2234,23 @@ impl Config {
         }
 
         // Terraform config
-        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY") {
+        if let Ok(val) = env::var("NORA_TF_PROXY") {
             self.terraform.proxy = if val.is_empty() { None } else { Some(val) };
         }
-        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_AUTH") {
+        if let Ok(val) = env::var("NORA_TF_PROXY_AUTH") {
             self.terraform.proxy_auth = if val.is_empty() { None } else { Some(val) };
         }
-        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_TIMEOUT") {
+        if let Ok(val) = env::var("NORA_TF_PROXY_TIMEOUT") {
             if let Ok(timeout) = val.parse() {
                 self.terraform.proxy_timeout = timeout;
             }
         }
-        if let Ok(val) = env::var("NORA_TERRAFORM_PROXY_TIMEOUT_DOWNLOAD") {
+        if let Ok(val) = env::var("NORA_TF_PROXY_TIMEOUT_DL") {
             if let Ok(timeout) = val.parse() {
-                self.terraform.proxy_timeout_download = timeout;
+                self.terraform.proxy_timeout_dl = timeout;
             }
         }
-        if let Ok(val) = env::var("NORA_TERRAFORM_METADATA_TTL") {
+        if let Ok(val) = env::var("NORA_TF_METADATA_TTL") {
             if let Ok(ttl) = val.parse() {
                 self.terraform.metadata_ttl = ttl;
             }
@@ -2322,9 +2322,9 @@ impl Config {
                 self.conan.proxy_timeout = timeout;
             }
         }
-        if let Ok(val) = env::var("NORA_CONAN_PROXY_TIMEOUT_DOWNLOAD") {
+        if let Ok(val) = env::var("NORA_CONAN_PROXY_TIMEOUT_DL") {
             if let Ok(timeout) = val.parse() {
-                self.conan.proxy_timeout_download = timeout;
+                self.conan.proxy_timeout_dl = timeout;
             }
         }
         if let Ok(val) = env::var("NORA_CONAN_METADATA_TTL") {
@@ -2433,7 +2433,7 @@ impl Config {
         if let Ok(val) = env::var("NORA_CURATION_REQUIRE_INTEGRITY") {
             self.curation.require_integrity = val.to_lowercase() == "true" || val == "1";
         }
-        if let Ok(val) = env::var("NORA_CURATION_INTERNAL_NAMESPACES") {
+        if let Ok(val) = env::var("NORA_CURATION_INTERNAL_NS") {
             self.curation.internal_namespaces = if val.is_empty() {
                 Vec::new()
             } else {

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -631,7 +631,7 @@ async fn package_file_download(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.conan.proxy_timeout_download,
+        state.config.conan.proxy_timeout_dl,
         state.config.conan.proxy_auth.as_deref(),
         &state.circuit_breaker,
         "conan",

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1289,7 +1289,7 @@ async fn get_manifest(
 
     // Stale-while-error: serve stale cached manifest when upstream is unreachable
     if let Some(ref data) = cached {
-        if state.config.docker.stale_while_error {
+        if state.config.docker.serve_stale {
             tracing::warn!(
                 registry = "docker",
                 name = %name,

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -304,7 +304,7 @@ async fn provider_download_binary(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.terraform.proxy_timeout_download,
+        state.config.terraform.proxy_timeout_dl,
         state.config.terraform.proxy_auth.as_deref(),
         &state.circuit_breaker,
         "terraform",

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -131,7 +131,7 @@ fn build_context(
             proxy_timeout: 5,
             read_timeout: 60,
             metadata_ttl: -1,
-            stale_while_error: true,
+            serve_stale: true,
             upstreams: vec![],
         },
         raw: RawConfig {


### PR DESCRIPTION
## Summary

- Add 7 new documentation pages for v0.9 features: circuit breaker, docker proxy, TLS, curation, prometheus metrics, audit log, upgrade guide
- Update settings.md with missing env var sections (circuit breaker, TLS, docker extras, trusted proxies)
- Add Traefik reverse proxy example config
- Update sidebar (astro.config.mjs) with new pages and Observability section
- Shorten env var names to follow `NORA_{SECTION}_{FIELD}` convention (<30 chars)
- Fix 11 documentation coherence mismatches verified against source code

## New pages

| Page | Description |
|------|-------------|
| `configuration/circuit-breaker.md` | State machine, per-registry overrides, metrics |
| `configuration/docker-proxy.md` | Multi-upstream, namespacing, metadata TTL, stale-while-error |
| `configuration/tls.md` | Custom CA certificates for corporate proxies |
| `configuration/curation.md` | Modes, blocklist/allowlist, SIGHUP reload, bypass token |
| `observability/prometheus-metrics.md` | All 16 nora_* metrics with PromQL examples |
| `observability/audit-log.md` | JSONL format, 7 action types, log aggregator integration |
| `deployment/upgrade-guide.md` | v0.8→v0.9 migration, namespace lazy migration, rollback |

## Env var renames

| Old | New |
|-----|-----|
| `NORA_TERRAFORM_*` | `NORA_TF_*` (6 vars) |
| `NORA_*_PROXY_TIMEOUT_DOWNLOAD` | `NORA_*_PROXY_TIMEOUT_DL` |
| `NORA_DOCKER_STALE_WHILE_ERROR` | `NORA_DOCKER_SERVE_STALE` |
| `NORA_CURATION_INTERNAL_NAMESPACES` | `NORA_CURATION_INTERNAL_NS` |

## Test plan

- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy` — PASS
- [x] Semgrep — PASS (0 errors)
- [x] OPSEC check — PASS
- [x] `npm run build` — docs site builds (67 pages)
- [x] Deployed to getnora.dev — all 7 new URLs return 200