### PR TITLE
docs: update CHANGELOG, README, ROADMAP for v0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 ## [0.9.0] - 2026-05-16
 
 ### Added
+- **OIDC / Workload Identity** — zero-secret auth for GitHub Actions and GitLab CI JWT tokens (#342)
+- **Cache-Control completeness** — extend caching headers to all remaining registries (#340)
+- **Docker streaming blob uploads** — chunked upload processing eliminates OOM on large images (#368)
+- **Docker path-based upstream routing** — route pulls to specific upstreams by image path prefix (#365)
 - **Docker metadata TTL + stale-while-error** — cached manifests revalidate against upstream after configurable TTL; serve stale on upstream failure (#311)
 - **Docker/OCI mirror namespacing** — per-upstream namespace prefix isolates storage keys, with lazy migration from legacy flat layout (#323)
 - **Per-registry circuit breaker overrides** — `[circuit_breaker.overrides."registry:url"]` allows custom thresholds per upstream (#339)
@@ -14,7 +18,7 @@
 
 ### Changed
 - **Manifest response builder** — extracted `manifest_response()` helper, removing 3 duplicate return paths in Docker registry (#338)
-- 957 total tests (unchanged)
+- **Env var naming convention** — shortened 7 environment variables to follow `NORA_{SECTION}_{FIELD}` convention under 30 chars (see [Upgrade Guide](https://getnora.dev/deployment/upgrade-guide/) for the rename table)
 
 ## [0.8.4] - 2026-05-15
 

--- a/README.md
+++ b/README.md
@@ -149,10 +149,9 @@ docker run -d -p 4000:4000 \
 - ~~Min Release Age~~ ✅ v0.7.1
 - ~~Hash Pin Store, auth rate limiting, Cache-Control~~ ✅ v0.8.0
 - ~~Outbound proxy, structured audit log, 994 tests~~ ✅ v0.8.3
-- **Circuit breaker** — per-registry upstream resilience ([#339](https://github.com/getnora-io/nora/issues/339))
-- **OIDC / Workload Identity** — zero-secret auth for CI systems ([#342](https://github.com/getnora-io/nora/issues/342))
-- **Hot reload** — config and curation policy changes without restart ([#343](https://github.com/getnora-io/nora/issues/343))
+- ~~Circuit breaker, OIDC, hot reload, arm64, streaming uploads~~ ✅ v0.9.0
 - **Image Signing Policy** — cosign verification on upstream pulls
+- **Semver contract** — stable API, configuration format, and storage layout
 
 See [ROADMAP.md](ROADMAP.md) for the full roadmap and [CHANGELOG.md](CHANGELOG.md) for release history.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,22 +15,7 @@ For completed milestones, see [CHANGELOG.md](CHANGELOG.md).
 - **v0.7.3** — Docker auth fix, raw directory browser, version consistency gate
 - **v0.8.0** — Hash Pin Store, auth rate limiting, trusted proxies, Cache-Control
 - **v0.8.3** — Outbound HTTP/SOCKS5 proxy, structured audit log, 994 tests
-
-## v0.9 — Resilience & Auth
-
-Focus: upstream resilience, production-grade authentication, operational maturity.
-
-- **Circuit breaker** — per-registry circuit breaker for upstream proxy connections ([#339](https://github.com/getnora-io/nora/issues/339))
-- **Cache-Control completeness** — extend caching headers to remaining registries ([#340](https://github.com/getnora-io/nora/issues/340))
-- **Streaming read_timeout** — per-chunk timeout for large blob downloads ([#341](https://github.com/getnora-io/nora/issues/341))
-- **OIDC / Workload Identity** — zero-secret auth for GitHub Actions and GitLab CI JWT ([#342](https://github.com/getnora-io/nora/issues/342))
-- **Hot reload** — apply curation policy and configuration changes without restart ([#343](https://github.com/getnora-io/nora/issues/343))
-- **Audit log to stdout** — structured JSON logs for multi-replica deployments ([#175](https://github.com/getnora-io/nora/issues/175))
-- **arm64 support** — Linux arm64 binary and multi-arch Docker image ([#193](https://github.com/getnora-io/nora/issues/193))
-- **Docker namespacing** — configurable namespace mapping for mirror mode ([#323](https://github.com/getnora-io/nora/issues/323))
-- **Docker metadata TTL** — stale-while-error for proxy cache ([#311](https://github.com/getnora-io/nora/issues/311))
-- **docker-compose + systemd** — production deployment templates ([#307](https://github.com/getnora-io/nora/issues/307))
-- **thiserror v2** — dependency migration ([#226](https://github.com/getnora-io/nora/issues/226))
+- **v0.9.0** — Circuit breaker, OIDC, hot reload, arm64, streaming uploads, Docker namespacing, metadata TTL, Cache-Control completeness
 
 ## v1.0 — Stability
 


### PR DESCRIPTION
## Summary

- **CHANGELOG.md**: Add missing entries — OIDC (#342), Cache-Control completeness (#340), streaming blob uploads (#368), path-based upstream routing (#365), env var renames
- **README.md**: Mark v0.9.0 features as completed in roadmap section, add semver contract to upcoming
- **ROADMAP.md**: Move all 10 completed v0.9 items to Completed section, remove thiserror v2 (#226, closed NOT_PLANNED)

## Test plan

- [x] No code changes — docs only
- [x] Verify all referenced issue numbers exist and are closed