### PR TITLE
fix(pypi): PEP-691 json format, rename `digests` to `hashes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **PyPI file hash key** — renamed `digests` to `hashes` to support `PEP 691` specification (#383)
+
 ## [0.9.0] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## [Unreleased]
 
 ### Fixed
-- **PyPI file hash key** — renamed `digests` to `hashes` to support `PEP 691` specification (#383)
+- **PyPI file hash key** — renamed `digests` to `hashes` to support `PEP 691` specification (#389)
 
 ## [0.9.0] - 2026-05-16
 

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -505,7 +505,7 @@ fn versions_json_response(normalized: &str, files: &[FileEntry], base_url: &str)
                 "url": format!("{}/simple/{}/{}", base_url, normalized, f.filename),
             });
             if let Some(hash) = &f.sha256 {
-                entry["digests"] = serde_json::json!({"sha256": hash});
+                entry["hashes"] = serde_json::json!({"sha256": hash});
             }
             entry
         })
@@ -1151,9 +1151,9 @@ mod integration_tests {
         let body = body_bytes(response).await;
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["name"], "flask");
-        assert!(json["files"].as_array().unwrap().len() == 1);
+        assert_eq!(json["files"].as_array().unwrap().len(), 1);
         assert_eq!(json["files"][0]["filename"], "flask-2.0.tar.gz");
-        assert_eq!(json["files"][0]["digests"]["sha256"], "deadbeef");
+        assert_eq!(json["files"][0]["hashes"]["sha256"], "deadbeef");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Rename `digests` to `hashes`

## Why

https://github.com/getnora-io/nora/issues/383

## Checklist

- [x] Tests pass (`cargo test`)
- [x] No new clippy warnings (`cargo clippy -- -D warnings`)
- [x] Updated CHANGELOG.md (if user-facing change)
- [x] New registry? See CONTRIBUTING.md checklist
