### PR TITLE
fix(nuget): rewrite all registration base URL variants in service index

### DIFF
--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -712,14 +712,24 @@ fn rewrite_service_index(json_text: &str, base_url: &str) -> String {
     let nora_autocomplete = format!("{}/v3/autocomplete", nora_nuget);
 
     // Rewrite major service URLs to route through NORA
+    let nora_registration = format!("{}/v3/registration/", nora_nuget);
     json_text
         .replace(
             "https://api.nuget.org/v3-flatcontainer/",
             &format!("{}/v3/flatcontainer/", nora_nuget),
         )
+        // Rewrite all registration base URL variants (nuget.org serves 5)
+        .replace(
+            "https://api.nuget.org/v3/registration5-semver1/",
+            &nora_registration,
+        )
+        .replace(
+            "https://api.nuget.org/v3/registration5-gz-semver1/",
+            &nora_registration,
+        )
         .replace(
             "https://api.nuget.org/v3/registration5-gz-semver2/",
-            &format!("{}/v3/registration/", nora_nuget),
+            &nora_registration,
         )
         // Rewrite search endpoints to proxy through NORA
         .replace("https://azuresearch-usnc.nuget.org/query", &nora_query)
@@ -810,6 +820,36 @@ mod tests {
         assert!(result.contains("https://artifact.company.local/nuget/v3/registration/"));
         assert!(!result.contains("http://artifact.company.local"));
         assert!(!result.contains("api.nuget.org"));
+    }
+
+    #[test]
+    fn test_rewrite_service_index_all_registration_variants() {
+        // nuget.org serves 5 registration base URL variants plus URL templates
+        let input = r#"{"resources":[
+            {"@id":"https://api.nuget.org/v3/registration5-semver1/","@type":"RegistrationsBaseUrl"},
+            {"@id":"https://api.nuget.org/v3/registration5-semver1/","@type":"RegistrationsBaseUrl/3.0.0-rc"},
+            {"@id":"https://api.nuget.org/v3/registration5-semver1/","@type":"RegistrationsBaseUrl/3.0.0-beta"},
+            {"@id":"https://api.nuget.org/v3/registration5-gz-semver1/","@type":"RegistrationsBaseUrl/3.4.0"},
+            {"@id":"https://api.nuget.org/v3/registration5-gz-semver2/","@type":"RegistrationsBaseUrl/3.6.0"},
+            {"@id":"https://api.nuget.org/v3/registration5-gz-semver2/","@type":"RegistrationsBaseUrl/Versioned"},
+            {"@id":"https://api.nuget.org/v3/registration5-semver1/{id-lower}/index.json","@type":"PackageDisplayMetadataUriTemplate/3.0.0-rc"},
+            {"@id":"https://api.nuget.org/v3/registration5-semver1/{id-lower}/{version-lower}.json","@type":"PackageVersionDisplayMetadataUriTemplate/3.0.0-rc"}
+        ]}"#;
+        let result = rewrite_service_index(input, "https://registry.company.local");
+        // All registration URLs should be rewritten
+        assert!(
+            !result.contains("api.nuget.org"),
+            "leaked upstream URL in: {result}"
+        );
+        // All should point to NORA registration endpoint
+        assert!(result.contains("https://registry.company.local/nuget/v3/registration/"));
+        // URL templates should also be rewritten (prefix match)
+        assert!(
+            result.contains("registry.company.local/nuget/v3/registration/{id-lower}/index.json")
+        );
+        assert!(result.contains(
+            "registry.company.local/nuget/v3/registration/{id-lower}/{version-lower}.json"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add rewrites for `registration5-semver1` and `registration5-gz-semver1` in `rewrite_service_index()`
- nuget.org service index serves 5 RegistrationsBaseUrl entries but only `registration5-gz-semver2` was rewritten
- Clients selecting the unrewritten variants bypassed NORA entirely — broken in air-gap

Closes #388

## Details

nuget.org `v3/index.json` contains these registration base URLs:

| Variant | @type | Was rewritten? |
|---------|-------|---------------|
| `registration5-semver1/` | RegistrationsBaseUrl, /3.0.0-rc, /3.0.0-beta | **No** |
| `registration5-gz-semver1/` | RegistrationsBaseUrl/3.4.0 | **No** |
| `registration5-gz-semver2/` | RegistrationsBaseUrl/3.6.0, /Versioned | Yes |

URL templates (`{id-lower}/index.json`, `{id-lower}/{version-lower}.json`) are also covered by prefix match.

## Test plan

- [x] New test: `test_rewrite_service_index_all_registration_variants` — all 5 variants + URL templates
- [x] All 6 existing rewrite tests still pass
- [x] Full test suite: 976 tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [x] Semgrep: no new findings