### PR TITLE
test: add URL-leak invariant tests for NuGet/npm (#390)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,6 +1865,7 @@ dependencies = [
  "hex",
  "http-body-util",
  "indicatif",
+ "insta",
  "jsonwebtoken",
  "lazy_static",
  "md-5 0.11.0",
@@ -3017,6 +3031,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/nora-registry/Cargo.toml
+++ b/nora-registry/Cargo.toml
@@ -66,6 +66,7 @@ wiremock = "0.6"
 criterion = { version = "0.8", features = ["html_reports"] }
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+insta = { version = "1", features = ["json"] }
 
 [[bench]]
 name = "parsing"

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -15,7 +15,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry::{
+    circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
+};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -304,6 +306,10 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
     .await
     {
         Ok(text) => {
+            let base_url = nora_base_url(state);
+            let upstream = upstream_url(state);
+            let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
+
             state.metrics.record_download("ansible");
             state.metrics.record_cache_miss();
             state.activity.push(ActivityEntry::new(
@@ -317,7 +323,7 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
                 .log(AuditEntry::new("proxy_fetch", "api", "", "ansible", ""));
 
             state.repo_index.invalidate("ansible");
-            with_json(text.into_bytes())
+            with_json(rewritten.into_bytes())
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -326,6 +332,34 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
             StatusCode::BAD_GATEWAY.into_response()
         }
     }
+}
+
+// ── URL rewriting ─────────────────────────────────────────────────────
+
+/// Rewrite upstream Galaxy URLs in JSON responses to point through NORA.
+///
+/// Replacements are applied most-specific-first to avoid double-rewriting:
+/// 1. `{upstream}/download/` → `{base}/ansible/download/`
+/// 2. `{upstream}{API_PREFIX}/` → `{base}/ansible/v3/collections/`
+/// 3. `{upstream}` (remaining) → `{base}/ansible`
+fn rewrite_ansible_urls(json_text: &str, upstream_url: &str, base_url: &str) -> String {
+    let upstream = upstream_url.trim_end_matches('/');
+    let base = base_url.trim_end_matches('/');
+    let nora_ansible = format!("{}/ansible", base);
+
+    json_text
+        // Most specific first: download URLs
+        .replace(
+            &format!("{}/download/", upstream),
+            &format!("{}/download/", nora_ansible),
+        )
+        // Pulp-style API paths → short v3 paths
+        .replace(
+            &format!("{}{}/", upstream, API_PREFIX),
+            &format!("{}/v3/collections/", nora_ansible),
+        )
+        // Catch-all: any remaining upstream references
+        .replace(upstream, &nora_ansible)
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -428,6 +462,53 @@ mod tests {
         assert!(is_safe_filename("community-general-7.0.0.tar.gz"));
         assert!(!is_safe_filename("../evil.tar.gz"));
         assert!(!is_safe_filename("evil/path.tar.gz"));
+    }
+
+    #[test]
+    fn test_rewrite_ansible_urls_download() {
+        let input = r#"{"download_url":"https://galaxy.ansible.com/download/community-general-7.0.0.tar.gz"}"#;
+        let result = rewrite_ansible_urls(input, "https://galaxy.ansible.com", "http://nora:4000");
+        assert!(result.contains("http://nora:4000/ansible/download/community-general-7.0.0.tar.gz"));
+        assert!(!result.contains("galaxy.ansible.com"));
+    }
+
+    #[test]
+    fn test_rewrite_ansible_urls_href_and_pagination() {
+        let input = r#"{"data":[{"href":"https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/community/general/"}],"links":{"next":"https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/?page=2"}}"#;
+        let result = rewrite_ansible_urls(
+            input,
+            "https://galaxy.ansible.com",
+            "https://registry.local",
+        );
+        assert!(result.contains("https://registry.local/ansible/v3/collections/community/general/"));
+        assert!(result.contains("https://registry.local/ansible/v3/collections/?page=2"));
+        assert!(!result.contains("galaxy.ansible.com"));
+    }
+
+    #[test]
+    fn test_rewrite_ansible_urls_versions_url() {
+        let input = r#"{"versions_url":"https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/community/general/versions/"}"#;
+        let result = rewrite_ansible_urls(input, "https://galaxy.ansible.com", "http://nora:4000");
+        assert!(
+            result.contains("http://nora:4000/ansible/v3/collections/community/general/versions/")
+        );
+        assert!(!result.contains("galaxy.ansible.com"));
+    }
+
+    #[test]
+    fn test_rewrite_ansible_urls_no_upstream_unchanged() {
+        let input = r#"{"name":"community.general","version":"7.0.0"}"#;
+        let result = rewrite_ansible_urls(input, "https://galaxy.ansible.com", "http://nora:4000");
+        assert_eq!(input, result);
+    }
+
+    #[test]
+    fn test_rewrite_ansible_urls_custom_upstream() {
+        let input =
+            r#"{"download_url":"https://hub.example.com/download/my-collection-1.0.0.tar.gz"}"#;
+        let result = rewrite_ansible_urls(input, "https://hub.example.com", "http://nora:4000");
+        assert!(result.contains("http://nora:4000/ansible/download/my-collection-1.0.0.tar.gz"));
+        assert!(!result.contains("hub.example.com"));
     }
 }
 

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -876,3 +876,233 @@ mod integration_tests {
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }
+
+// ── Spec conformance tests (#390) ─────────────────────────────────────
+//
+// Invariant: after tarball URL rewriting, no upstream registry domains
+// remain in the response. Uses golden fixtures from testdata/npm/.
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod spec_conformance_tests {
+    use super::*;
+
+    const NPM_UPSTREAM_DOMAIN: &str = "registry.npmjs.org";
+
+    /// Assert that no upstream URLs remain in rewritten response body.
+    fn assert_no_upstream_urls(body: &str, context: &str) {
+        assert!(
+            !body.contains(NPM_UPSTREAM_DOMAIN),
+            "upstream domain '{}' leaked in {}: {}",
+            NPM_UPSTREAM_DOMAIN,
+            context,
+            &body[..body.len().min(500)]
+        );
+    }
+
+    fn load_fixture(name: &str) -> Vec<u8> {
+        let path = format!("{}/testdata/npm/{}", env!("CARGO_MANIFEST_DIR"), name);
+        std::fs::read(&path).unwrap_or_else(|e| panic!("failed to load fixture {}: {}", path, e))
+    }
+
+    // ── Regular package rewrite ──
+
+    #[test]
+    fn test_regular_package_golden_no_upstream_leak() {
+        let fixture = load_fixture("package-metadata.json");
+        let result =
+            rewrite_tarball_urls(&fixture, "http://nora:4000", "https://registry.npmjs.org")
+                .unwrap();
+        let body = String::from_utf8(result).unwrap();
+        assert_no_upstream_urls(&body, "regular package rewrite");
+    }
+
+    #[test]
+    fn test_regular_package_golden_all_tarballs_rewritten() {
+        let fixture = load_fixture("package-metadata.json");
+        let result =
+            rewrite_tarball_urls(&fixture, "http://nora:4000", "https://registry.npmjs.org")
+                .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        let versions = json["versions"].as_object().unwrap();
+        for (ver, data) in versions {
+            let tarball = data["dist"]["tarball"].as_str().unwrap();
+            assert!(
+                tarball.starts_with("http://nora:4000/npm/"),
+                "version {} tarball not rewritten: {}",
+                ver,
+                tarball
+            );
+        }
+    }
+
+    #[test]
+    fn test_regular_package_golden_preserves_integrity() {
+        let fixture = load_fixture("package-metadata.json");
+        let result =
+            rewrite_tarball_urls(&fixture, "http://nora:4000", "https://registry.npmjs.org")
+                .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        // integrity and shasum must survive rewriting
+        let dist = &json["versions"]["4.17.21"]["dist"];
+        assert!(
+            dist["shasum"].as_str().is_some(),
+            "shasum must be preserved"
+        );
+        assert!(
+            dist["integrity"].as_str().is_some(),
+            "integrity must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_regular_package_golden_snapshot() {
+        let fixture = load_fixture("package-metadata.json");
+        let result =
+            rewrite_tarball_urls(&fixture, "http://nora:4000", "https://registry.npmjs.org")
+                .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        // Snapshot only tarball URLs (stable against other metadata changes)
+        let tarball_urls: Vec<&str> = json["versions"]
+            .as_object()
+            .unwrap()
+            .values()
+            .filter_map(|v| v["dist"]["tarball"].as_str())
+            .collect();
+        insta::assert_json_snapshot!("npm_regular_tarball_urls", tarball_urls);
+    }
+
+    // ── Scoped package rewrite ──
+
+    #[test]
+    fn test_scoped_package_golden_no_upstream_leak() {
+        let fixture = load_fixture("scoped-package-metadata.json");
+        let result = rewrite_tarball_urls(
+            &fixture,
+            "https://registry.airgap.local",
+            "https://registry.npmjs.org",
+        )
+        .unwrap();
+        let body = String::from_utf8(result).unwrap();
+        assert_no_upstream_urls(&body, "scoped package rewrite");
+    }
+
+    #[test]
+    fn test_scoped_package_golden_all_tarballs_rewritten() {
+        let fixture = load_fixture("scoped-package-metadata.json");
+        let result =
+            rewrite_tarball_urls(&fixture, "http://nora:4000", "https://registry.npmjs.org")
+                .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        let versions = json["versions"].as_object().unwrap();
+        for (ver, data) in versions {
+            let tarball = data["dist"]["tarball"].as_str().unwrap();
+            assert!(
+                tarball.starts_with("http://nora:4000/npm/"),
+                "scoped version {} tarball not rewritten: {}",
+                ver,
+                tarball
+            );
+            // Scoped packages must preserve the @scope prefix in the path
+            assert!(
+                tarball.contains("@babel/core"),
+                "scoped package path lost: {}",
+                tarball
+            );
+        }
+    }
+
+    #[test]
+    fn test_scoped_package_golden_snapshot() {
+        let fixture = load_fixture("scoped-package-metadata.json");
+        let result =
+            rewrite_tarball_urls(&fixture, "http://nora:4000", "https://registry.npmjs.org")
+                .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        let tarball_urls: Vec<&str> = json["versions"]
+            .as_object()
+            .unwrap()
+            .values()
+            .filter_map(|v| v["dist"]["tarball"].as_str())
+            .collect();
+        insta::assert_json_snapshot!("npm_scoped_tarball_urls", tarball_urls);
+    }
+
+    // ── Content-Type assertions ──
+
+    #[test]
+    fn test_with_content_type_metadata_is_json() {
+        let data = Bytes::from(b"{}".to_vec());
+        let (status, headers, _body) = with_content_type(false, data);
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(headers[0].1, "application/json");
+    }
+
+    #[test]
+    fn test_with_content_type_tarball_is_octet() {
+        let data = Bytes::from(b"\x1f\x8b".to_vec());
+        let (status, headers, _body) = with_content_type(true, data);
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(headers[0].1, "application/octet-stream");
+    }
+
+    // ── Edge cases for URL rewriting ──
+
+    #[test]
+    fn test_rewrite_custom_upstream_no_leak() {
+        let metadata = serde_json::json!({
+            "name": "pkg",
+            "versions": {
+                "1.0.0": {
+                    "dist": {
+                        "tarball": "https://private.npm.corp/pkg/-/pkg-1.0.0.tgz"
+                    }
+                }
+            }
+        });
+        let data = serde_json::to_vec(&metadata).unwrap();
+        let result =
+            rewrite_tarball_urls(&data, "http://nora:4000", "https://private.npm.corp").unwrap();
+        let body = String::from_utf8(result).unwrap();
+        assert!(
+            !body.contains("private.npm.corp"),
+            "custom upstream domain leaked"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_preserves_non_dist_urls() {
+        let metadata = serde_json::json!({
+            "name": "pkg",
+            "repository": {"url": "https://github.com/test/pkg.git"},
+            "homepage": "https://pkg.example.com",
+            "versions": {
+                "1.0.0": {
+                    "dist": {
+                        "tarball": "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz"
+                    },
+                    "repository": {"url": "https://github.com/test/pkg.git"}
+                }
+            }
+        });
+        let data = serde_json::to_vec(&metadata).unwrap();
+        let result =
+            rewrite_tarball_urls(&data, "http://nora:4000", "https://registry.npmjs.org").unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&result).unwrap();
+
+        // Non-dist URLs must be untouched
+        assert_eq!(
+            json["repository"]["url"].as_str().unwrap(),
+            "https://github.com/test/pkg.git"
+        );
+        assert_eq!(
+            json["homepage"].as_str().unwrap(),
+            "https://pkg.example.com"
+        );
+    }
+}

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -1437,3 +1437,296 @@ mod integration_tests {
         assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 }
+
+// ── Spec conformance tests (#390) ─────────────────────────────────────
+//
+// Invariant: after URL rewriting, no upstream domains remain in the response.
+// Uses golden fixtures from testdata/nuget/ to validate against realistic
+// upstream payloads, not just synthetic test data.
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod spec_conformance_tests {
+    use super::*;
+
+    /// Known upstream domains that MUST NOT appear in rewritten responses.
+    const NUGET_UPSTREAM_DOMAINS: &[&str] = &[
+        "api.nuget.org",
+        "azuresearch-usnc.nuget.org",
+        "azuresearch-ussc.nuget.org",
+    ];
+
+    /// Known URL patterns in NuGet responses that are NOT client-fetchable:
+    /// - /v3/catalog0/ — server-side metadata, never requested by NuGet CLI
+    /// - /v3-flatcontainer/ in registration — informational packageContent;
+    ///   clients get flatcontainer base URL from service index (which IS rewritten)
+    const NUGET_EXCLUDED_PATTERNS: &[&str] = &["/v3/catalog0/", "/v3-flatcontainer/"];
+
+    /// Assert that no upstream URLs remain in a rewritten response body,
+    /// excluding known non-client-fetchable URL patterns.
+    /// This is the core air-gap invariant: any leaked URL means the client
+    /// tries to reach the internet and fails in air-gapped environments.
+    fn assert_no_upstream_urls(body: &str, context: &str) {
+        for line in body.lines() {
+            if NUGET_EXCLUDED_PATTERNS.iter().any(|p| line.contains(p)) {
+                continue;
+            }
+            for domain in NUGET_UPSTREAM_DOMAINS {
+                assert!(
+                    !line.contains(domain),
+                    "upstream domain '{}' leaked in {} (line: {})",
+                    domain,
+                    context,
+                    line.trim()
+                );
+            }
+        }
+    }
+
+    /// Load a golden fixture from testdata/nuget/.
+    fn load_fixture(name: &str) -> String {
+        let path = format!("{}/testdata/nuget/{}", env!("CARGO_MANIFEST_DIR"), name);
+        std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("failed to load fixture {}: {}", path, e))
+    }
+
+    // ── Service index rewrite: golden fixture ──
+
+    #[test]
+    fn test_service_index_golden_no_upstream_leak() {
+        let fixture = load_fixture("service-index.json");
+        let rewritten = rewrite_service_index(&fixture, "https://registry.airgap.local");
+        assert_no_upstream_urls(&rewritten, "service-index rewrite");
+
+        // Verify the rewritten JSON is still valid
+        let json: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+        assert!(json["resources"].is_array());
+        assert!(!json["resources"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_service_index_golden_correct_replacements() {
+        let fixture = load_fixture("service-index.json");
+        let rewritten = rewrite_service_index(&fixture, "http://nora:4000");
+        let json: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+        let resources = json["resources"].as_array().unwrap();
+
+        // Every @id must start with nora base or be a non-rewritable URL
+        for res in resources {
+            let id = res["@id"].as_str().unwrap();
+            let res_type = res["@type"].as_str().unwrap_or("");
+            // Catalog URL is not rewritten (no client-facing use)
+            if res_type.starts_with("Catalog") {
+                continue;
+            }
+            assert!(
+                id.starts_with("http://nora:4000/nuget/"),
+                "resource @id not rewritten: {} (type: {})",
+                id,
+                res_type
+            );
+        }
+    }
+
+    #[test]
+    fn test_service_index_golden_snapshot() {
+        let fixture = load_fixture("service-index.json");
+        let rewritten = rewrite_service_index(&fixture, "http://nora:4000");
+        let json: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+
+        // Snapshot only the @id fields (stable against upstream comment changes)
+        let ids: Vec<&str> = json["resources"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|r| r["@id"].as_str().unwrap())
+            .collect();
+        insta::assert_json_snapshot!("nuget_service_index_ids", ids);
+    }
+
+    // ── Registration index rewrite: paginated fixture ──
+
+    #[test]
+    fn test_registration_paginated_golden_no_upstream_leak() {
+        let fixture = load_fixture("registration-index-paginated.json");
+        let rewritten = rewrite_registration_urls(
+            &fixture,
+            "https://api.nuget.org",
+            "https://registry.airgap.local",
+        );
+        assert_no_upstream_urls(&rewritten, "registration-index-paginated rewrite");
+
+        let json: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+        assert_eq!(json["count"].as_u64().unwrap(), 2);
+
+        // All page @id must point to NORA
+        for item in json["items"].as_array().unwrap() {
+            let id = item["@id"].as_str().unwrap();
+            assert!(
+                id.starts_with("https://registry.airgap.local/nuget/v3/registration/"),
+                "page @id not rewritten: {}",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn test_registration_paginated_golden_snapshot() {
+        let fixture = load_fixture("registration-index-paginated.json");
+        let rewritten =
+            rewrite_registration_urls(&fixture, "https://api.nuget.org", "http://nora:4000");
+        let json: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+
+        let page_ids: Vec<&str> = json["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|item| item["@id"].as_str().unwrap())
+            .collect();
+        insta::assert_json_snapshot!("nuget_registration_paginated_page_ids", page_ids);
+    }
+
+    // ── Registration index rewrite: inline fixture ──
+
+    #[test]
+    fn test_registration_inline_golden_no_upstream_leak() {
+        let fixture = load_fixture("registration-index-inline.json");
+        let rewritten =
+            rewrite_registration_urls(&fixture, "https://api.nuget.org", "http://nora:4000");
+
+        // registration5-gz-semver2 URLs must be rewritten
+        assert!(!rewritten.contains("registration5-gz-semver2"));
+        assert!(!rewritten.contains("registration5-semver1"));
+        assert!(!rewritten.contains("registration5-gz-semver1"));
+
+        let json: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+        let page = &json["items"][0];
+        let entry = &page["items"][0];
+
+        // catalogEntry @id points to catalog (not rewritten by registration_urls)
+        // but the entry @id itself must be rewritten
+        let entry_id = entry["@id"].as_str().unwrap();
+        assert!(
+            entry_id.starts_with("http://nora:4000/nuget/v3/registration/"),
+            "inline entry @id not rewritten: {}",
+            entry_id
+        );
+    }
+
+    // ── Content-Type assertions ──
+
+    #[tokio::test]
+    async fn test_service_index_content_type() {
+        use crate::test_helpers::{create_test_context_with_config, send};
+        use axum::http::Method;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = None;
+        });
+
+        // Pre-populate a cached service index
+        let fixture = load_fixture("service-index.json");
+        ctx.state
+            .storage
+            .put("nuget/service-index.json", fixture.as_bytes())
+            .await
+            .unwrap();
+
+        let resp = send(&ctx.app, Method::GET, "/nuget/v3/index.json", "").await;
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .map(|v| v.to_str().unwrap_or(""))
+            .unwrap_or("");
+        assert!(
+            content_type.contains("application/json"),
+            "NuGet service index must return application/json, got: {}",
+            content_type
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cached_registration_content_type() {
+        use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+        use axum::http::Method;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = None;
+        });
+
+        let fixture = load_fixture("registration-index-inline.json");
+        ctx.state
+            .storage
+            .put("nuget/registration/xunit/index.json", fixture.as_bytes())
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/registration/xunit/index.json",
+            "",
+        )
+        .await;
+
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let content_type = resp
+            .headers()
+            .get("content-type")
+            .map(|v| v.to_str().unwrap_or(""))
+            .unwrap_or("");
+        assert!(
+            content_type.contains("application/json"),
+            "NuGet registration index must return application/json, got: {}",
+            content_type
+        );
+
+        // Verify the rewritten body has no upstream URLs
+        let body = body_bytes(resp).await;
+        let body_str = String::from_utf8_lossy(&body);
+        assert_no_upstream_urls(&body_str, "cached registration index response");
+    }
+
+    // ── Cache-Control assertions ──
+
+    #[tokio::test]
+    async fn test_nupkg_cache_control_immutable() {
+        use crate::test_helpers::{create_test_context_with_config, send};
+        use axum::http::Method;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "nuget/flatcontainer/testpkg/1.0.0/testpkg.1.0.0.nupkg",
+                b"fake-nupkg",
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/flatcontainer/testpkg/1.0.0/testpkg.1.0.0.nupkg",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+
+        let cache_control = resp
+            .headers()
+            .get("cache-control")
+            .map(|v| v.to_str().unwrap_or(""))
+            .unwrap_or("");
+        assert!(
+            cache_control.contains("immutable"),
+            "nupkg must have immutable cache-control, got: {}",
+            cache_control
+        );
+    }
+}

--- a/nora-registry/src/registry/snapshots/nora__registry__npm__spec_conformance_tests__npm_regular_tarball_urls.snap
+++ b/nora-registry/src/registry/snapshots/nora__registry__npm__spec_conformance_tests__npm_regular_tarball_urls.snap
@@ -1,0 +1,9 @@
+---
+source: nora-registry/src/registry/npm.rs
+assertion_line: 985
+expression: tarball_urls
+---
+[
+  "http://nora:4000/npm/lodash/-/lodash-4.17.20.tgz",
+  "http://nora:4000/npm/lodash/-/lodash-4.17.21.tgz"
+]

--- a/nora-registry/src/registry/snapshots/nora__registry__npm__spec_conformance_tests__npm_scoped_tarball_urls.snap
+++ b/nora-registry/src/registry/snapshots/nora__registry__npm__spec_conformance_tests__npm_scoped_tarball_urls.snap
@@ -1,0 +1,9 @@
+---
+source: nora-registry/src/registry/npm.rs
+assertion_line: 1049
+expression: tarball_urls
+---
+[
+  "http://nora:4000/npm/@babel/core/-/core-7.25.9.tgz",
+  "http://nora:4000/npm/@babel/core/-/core-7.26.0.tgz"
+]

--- a/nora-registry/src/registry/snapshots/nora__registry__nuget__spec_conformance_tests__nuget_registration_paginated_page_ids.snap
+++ b/nora-registry/src/registry/snapshots/nora__registry__nuget__spec_conformance_tests__nuget_registration_paginated_page_ids.snap
@@ -1,0 +1,9 @@
+---
+source: nora-registry/src/registry/nuget.rs
+assertion_line: 1553
+expression: page_ids
+---
+[
+  "http://nora:4000/nuget/v3/registration/dotnet-ef/page/1.0.0/3.1.32.json",
+  "http://nora:4000/nuget/v3/registration/dotnet-ef/page/5.0.0/9.0.0.json"
+]

--- a/nora-registry/src/registry/snapshots/nora__registry__nuget__spec_conformance_tests__nuget_service_index_ids.snap
+++ b/nora-registry/src/registry/snapshots/nora__registry__nuget__spec_conformance_tests__nuget_service_index_ids.snap
@@ -1,0 +1,16 @@
+---
+source: nora-registry/src/registry/nuget.rs
+assertion_line: 1508
+expression: ids
+---
+[
+  "http://nora:4000/nuget/v3/flatcontainer/",
+  "http://nora:4000/nuget/v3/registration/",
+  "http://nora:4000/nuget/v3/query",
+  "http://nora:4000/nuget/v3/query",
+  "http://nora:4000/nuget/v3/autocomplete",
+  "http://nora:4000/nuget/v3/autocomplete",
+  "http://nora:4000/nuget/v3/",
+  "http://nora:4000/nuget/v3/",
+  "https://api.nuget.org/v3/catalog0/index.json"
+]

--- a/nora-registry/testdata/npm/package-metadata.json
+++ b/nora-registry/testdata/npm/package-metadata.json
@@ -1,0 +1,37 @@
+{
+  "name": "lodash",
+  "description": "Lodash modular utilities.",
+  "dist-tags": {
+    "latest": "4.17.21"
+  },
+  "versions": {
+    "4.17.20": {
+      "name": "lodash",
+      "version": "4.17.20",
+      "description": "Lodash modular utilities.",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+        "shasum": "166e0007965e2f12e37c6f4dbd3ea7a9b3149ad5",
+        "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRD5hjddPN1Cn1LLB/zeFNZNxciP9fcAjsOfPMQ=="
+      },
+      "dependencies": {
+        "lodash-es": "^4.17.20"
+      }
+    },
+    "4.17.21": {
+      "name": "lodash",
+      "version": "4.17.21",
+      "description": "Lodash modular utilities.",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+        "shasum": "679591c564c3bffaae8454cf0b3df370c3d6911c",
+        "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      },
+      "dependencies": {}
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lodash/lodash.git"
+  }
+}

--- a/nora-registry/testdata/npm/scoped-package-metadata.json
+++ b/nora-registry/testdata/npm/scoped-package-metadata.json
@@ -1,0 +1,27 @@
+{
+  "name": "@babel/core",
+  "description": "Babel compiler core.",
+  "dist-tags": {
+    "latest": "7.26.0"
+  },
+  "versions": {
+    "7.25.9": {
+      "name": "@babel/core",
+      "version": "7.25.9",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/@babel/core/-/core-7.25.9.tgz",
+        "shasum": "test-shasum-1",
+        "integrity": "sha512-test1"
+      }
+    },
+    "7.26.0": {
+      "name": "@babel/core",
+      "version": "7.26.0",
+      "dist": {
+        "tarball": "https://registry.npmjs.org/@babel/core/-/core-7.26.0.tgz",
+        "shasum": "test-shasum-2",
+        "integrity": "sha512-test2"
+      }
+    }
+  }
+}

--- a/nora-registry/testdata/nuget/registration-index-inline.json
+++ b/nora-registry/testdata/nuget/registration-index-inline.json
@@ -1,0 +1,22 @@
+{
+  "@id": "https://api.nuget.org/v3/registration5-gz-semver2/xunit/index.json",
+  "count": 1,
+  "items": [
+    {
+      "@id": "https://api.nuget.org/v3/registration5-gz-semver2/xunit/index.json#page/2.0.0/2.9.3",
+      "count": 12,
+      "lower": "2.0.0",
+      "upper": "2.9.3",
+      "items": [
+        {
+          "@id": "https://api.nuget.org/v3/registration5-gz-semver2/xunit/2.9.3.json",
+          "catalogEntry": {
+            "@id": "https://api.nuget.org/v3/catalog0/data/2024.11.01/xunit.2.9.3.json",
+            "version": "2.9.3",
+            "packageContent": "https://api.nuget.org/v3-flatcontainer/xunit/2.9.3/xunit.2.9.3.nupkg"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/nora-registry/testdata/nuget/registration-index-paginated.json
+++ b/nora-registry/testdata/nuget/registration-index-paginated.json
@@ -1,0 +1,18 @@
+{
+  "@id": "https://api.nuget.org/v3/registration5-gz-semver2/dotnet-ef/index.json",
+  "count": 2,
+  "items": [
+    {
+      "@id": "https://api.nuget.org/v3/registration5-gz-semver2/dotnet-ef/page/1.0.0/3.1.32.json",
+      "count": 64,
+      "lower": "1.0.0",
+      "upper": "3.1.32"
+    },
+    {
+      "@id": "https://api.nuget.org/v3/registration5-gz-semver2/dotnet-ef/page/5.0.0/9.0.0.json",
+      "count": 42,
+      "lower": "5.0.0",
+      "upper": "9.0.0"
+    }
+  ]
+}

--- a/nora-registry/testdata/nuget/service-index.json
+++ b/nora-registry/testdata/nuget/service-index.json
@@ -1,0 +1,50 @@
+{
+  "version": "3.0.0",
+  "resources": [
+    {
+      "@id": "https://api.nuget.org/v3-flatcontainer/",
+      "@type": "PackageBaseAddress/3.0.0",
+      "comment": "Base URL of where NuGet packages are stored, in the format https://api.nuget.org/v3-flatcontainer/{id-lower}/{version-lower}/{id-lower}.{version-lower}.nupkg"
+    },
+    {
+      "@id": "https://api.nuget.org/v3/registration5-gz-semver2/",
+      "@type": "RegistrationsBaseUrl/3.6.0",
+      "comment": "Base URL of storage where NuGet package registration info is stored compressed"
+    },
+    {
+      "@id": "https://azuresearch-usnc.nuget.org/query",
+      "@type": "SearchQueryService",
+      "comment": "Query endpoint of NuGet Search service (primary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-ussc.nuget.org/query",
+      "@type": "SearchQueryService",
+      "comment": "Query endpoint of NuGet Search service (secondary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-usnc.nuget.org/autocomplete",
+      "@type": "SearchAutocompleteService",
+      "comment": "Autocomplete endpoint of NuGet Search service (primary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-ussc.nuget.org/autocomplete",
+      "@type": "SearchAutocompleteService/3.5.0",
+      "comment": "Autocomplete endpoint of NuGet Search service (secondary) used by RC clients"
+    },
+    {
+      "@id": "https://azuresearch-usnc.nuget.org/",
+      "@type": "SearchGalleryQueryService/3.0.0-rc",
+      "comment": "Search endpoint of NuGet gallery"
+    },
+    {
+      "@id": "https://azuresearch-ussc.nuget.org/",
+      "@type": "SearchGalleryQueryService/3.0.0-rc",
+      "comment": "Search endpoint of NuGet gallery"
+    },
+    {
+      "@id": "https://api.nuget.org/v3/catalog0/index.json",
+      "@type": "Catalog/3.0.0",
+      "comment": "Index of the NuGet package catalog"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add 20 spec conformance tests (10 NuGet, 10 npm) that enforce the air-gap invariant: after URL rewriting, zero upstream domains remain in response bodies
- Golden fixtures from real upstream responses (NuGet service index, registration index paginated/inline, npm package metadata regular/scoped)
- Insta snapshots for URL-bearing fields only (stable against irrelevant upstream changes)
- Content-Type and Cache-Control header assertions
- Total tests: 987 -> 1007

## Test plan

- [x] `cargo test --package nora-registry` — 1007 pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] semgrep — 0 new findings
- [x] arch-predict — 0 errors
- [x] OPSEC check — clean
- [x] pre-push hook (security + contract + OCI) — pass