### PR TITLE
fix(pypi): restore lost #389 cherry-pick (digests → hashes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **PyPI file hash key** — renamed `digests` to `hashes` to support `PEP 691` specification (#389)
+
 ## [0.9.0] - 2026-05-16
 
 ### Added

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -3437,6 +3437,8 @@ mod tests {
 
     #[test]
     fn test_curation_env_override_per_registry_quarantine() {
+        // Clear global quarantine env var to avoid race with test_curation_env_override_quarantine
+        std::env::remove_var("NORA_CURATION_QUARANTINE");
         let mut config = Config::default();
         std::env::set_var("NORA_CURATION_DOCKER_QUARANTINE", "enforce");
         std::env::set_var("NORA_CURATION_DOCKER_QUARANTINE_TTL", "7d");

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -505,7 +505,7 @@ fn versions_json_response(normalized: &str, files: &[FileEntry], base_url: &str)
                 "url": format!("{}/simple/{}/{}", base_url, normalized, f.filename),
             });
             if let Some(hash) = &f.sha256 {
-                entry["digests"] = serde_json::json!({"sha256": hash});
+                entry["hashes"] = serde_json::json!({"sha256": hash});
             }
             entry
         })
@@ -1151,9 +1151,9 @@ mod integration_tests {
         let body = body_bytes(response).await;
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["name"], "flask");
-        assert!(json["files"].as_array().unwrap().len() == 1);
+        assert_eq!(json["files"].as_array().unwrap().len(), 1);
         assert_eq!(json["files"][0]["filename"], "flask-2.0.tar.gz");
-        assert_eq!(json["files"][0]["digests"]["sha256"], "deadbeef");
+        assert_eq!(json["files"][0]["hashes"]["sha256"], "deadbeef");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Cherry-pick of #389 by @makavity — original squash merge `37a6c14` was orphaned after history rewrite
- Restores PEP 691 fix: `digests` → `hashes` field name in PyPI JSON responses
- Preserves original author attribution

## Context

PR #389 was merged but the commit became unreachable from `main` after a force-push. This cherry-pick restores the contribution with proper authorship.