### PR TITLE
fix(npm): correct tarball key for scoped packages in UI detail

### DIFF
--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -574,7 +574,14 @@ pub async fn get_npm_detail(
                     }
 
                     // Check if tarball is actually cached on disk
-                    let tarball_key = format!("npm/{}/tarballs/{}-{}.tgz", name, name, version);
+                    // For scoped packages (@scope/name), tarball uses just the "name" part
+                    let name_part = if name.contains('/') {
+                        name.rsplit('/').next().unwrap_or(name)
+                    } else {
+                        name
+                    };
+                    let tarball_key =
+                        format!("npm/{}/tarballs/{}-{}.tgz", name, name_part, version);
                     let (size, cached) = if let Some(meta) = storage.stat(&tarball_key).await {
                         (meta.size, true)
                     } else {


### PR DESCRIPTION
## Summary

- `get_npm_detail()` constructed incorrect storage key for scoped npm packages (e.g. `@babel/core`), using the full scoped name in the tarball filename instead of just the package name part
- This caused `storage.stat()` to always miss for scoped packages, showing cached size as "—" in the web UI
- Extracts `name_part` via `rsplit('/')` to match the key format used by the proxy download handler (`npm.rs`) and garbage collector (`gc.rs`)

Fixes #402

## Test plan

- [x] 1032 unit tests pass (`cargo test --package nora-registry`)
- [x] clippy clean, fmt clean
- [x] Semgrep: 0 new findings
- [x] Pre-push: security (10/0), contract (23/0), OCI (12/0)
- [ ] Manual: verify scoped package detail page shows correct cached size