### PR TITLE
feat(nuget): serve stale cached metadata in air-gap mode

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -490,6 +490,9 @@ pub struct NugetConfig {
     /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
     pub metadata_ttl: i64,
+    /// Serve stale cached metadata when upstream is unreachable (default: true).
+    #[serde(default = "default_true")]
+    pub serve_stale: bool,
     /// Upstream NuGet search service URL
     #[serde(default = "default_nuget_search")]
     pub search_service: String,
@@ -518,6 +521,7 @@ impl Default for NugetConfig {
             proxy_auth: None,
             proxy_timeout: 30,
             metadata_ttl: 300,
+            serve_stale: true,
             search_service: default_nuget_search(),
             autocomplete: default_nuget_autocomplete(),
         }
@@ -2285,6 +2289,9 @@ impl Config {
             if let Ok(ttl) = val.parse() {
                 self.nuget.metadata_ttl = ttl;
             }
+        }
+        if let Ok(val) = env::var("NORA_NUGET_SERVE_STALE") {
+            self.nuget.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
         if let Ok(val) = env::var("NORA_NUGET_SEARCH_SERVICE") {
             if !val.is_empty() {

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -223,13 +223,16 @@ async fn registration_index(
     let base_url = nora_base_url(&state);
     let upstream = upstream_url(&state);
 
+    // Read cache eagerly so stale data is available on upstream failure.
+    let cached_data = state.storage.get(&storage_key).await.ok();
+
     // TTL cache — rewrite URLs on read (cache may contain pre-fix entries)
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
                 state.metrics.record_download("nuget");
                 state.metrics.record_cache_hit();
-                let text = String::from_utf8_lossy(&data);
+                let text = String::from_utf8_lossy(data);
                 let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
                 return with_json(rewritten.into_bytes());
             }
@@ -275,7 +278,8 @@ async fn registration_index(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "NuGet registration error");
-            StatusCode::BAD_GATEWAY.into_response()
+            let rewrite = Some((upstream.as_str(), base_url.as_str()));
+            serve_stale_or_not_found(&state, cached_data, "registration_index", rewrite)
         }
     }
 }
@@ -305,13 +309,16 @@ async fn registration_page(
         id_lower, lower, upper
     );
 
+    // Read cache eagerly so stale data is available on upstream failure.
+    let cached_data = state.storage.get(&storage_key).await.ok();
+
     // TTL cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
                 state.metrics.record_download("nuget");
                 state.metrics.record_cache_hit();
-                let text = String::from_utf8_lossy(&data);
+                let text = String::from_utf8_lossy(data);
                 let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
                 return with_json(rewritten.into_bytes());
             }
@@ -355,7 +362,8 @@ async fn registration_page(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "NuGet registration page error");
-            StatusCode::BAD_GATEWAY.into_response()
+            let rewrite = Some((upstream.as_str(), base_url.as_str()));
+            serve_stale_or_not_found(&state, cached_data, "registration_page", rewrite)
         }
     }
 }
@@ -390,8 +398,11 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
 
     let storage_key = format!("nuget/flatcontainer/{}/index.json", id_lower);
 
+    // Read cache eagerly so stale data is available on upstream failure.
+    let cached_data = state.storage.get(&storage_key).await.ok();
+
     // TTL cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
                 state.metrics.record_download("nuget");
@@ -439,7 +450,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "NuGet version list error");
-            StatusCode::BAD_GATEWAY.into_response()
+            serve_stale_or_not_found(&state, cached_data, "version_list", None)
         }
     }
 }
@@ -622,9 +633,60 @@ async fn flatcontainer_download(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "NuGet download error");
-            StatusCode::BAD_GATEWAY.into_response()
+            // Binary was not cached and upstream is unreachable — package not available here.
+            StatusCode::NOT_FOUND.into_response()
         }
     }
+}
+
+// ── Stale-while-error helper ──────────────────────────────────────────
+
+/// Serve stale cached metadata when upstream is unreachable, or 404 if no cache.
+///
+/// If `rewrite_ctx` is `Some((upstream, base_url))`, registration URL rewriting
+/// is applied to the stale response (for registration endpoints).
+fn serve_stale_or_not_found(
+    state: &AppState,
+    cached: Option<Bytes>,
+    label: &str,
+    rewrite_ctx: Option<(&str, &str)>,
+) -> Response {
+    if let Some(data) = cached {
+        if state.config.nuget.serve_stale {
+            tracing::warn!(
+                registry = "nuget",
+                endpoint = label,
+                "Upstream unreachable, serving stale cached metadata"
+            );
+            let body = if let Some((upstream, base_url)) = rewrite_ctx {
+                let text = String::from_utf8_lossy(&data);
+                rewrite_registration_urls(&text, upstream, base_url).into_bytes()
+            } else {
+                data.to_vec()
+            };
+            return (
+                StatusCode::OK,
+                [
+                    (
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static("application/json"),
+                    ),
+                    (
+                        header::CACHE_CONTROL,
+                        HeaderValue::from_static("public, max-age=0, must-revalidate"),
+                    ),
+                    (
+                        axum::http::header::HeaderName::from_static("x-nora-stale"),
+                        axum::http::header::HeaderValue::from_static("true"),
+                    ),
+                ],
+                body,
+            )
+                .into_response();
+        }
+    }
+    // No cached data or serve_stale disabled — package not available here.
+    StatusCode::NOT_FOUND.into_response()
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -1115,6 +1177,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[doc = "No cache + unreachable upstream → 404 (not 502) since #410"]
     async fn test_nuget_unreachable_proxy() {
         let ctx = create_test_context_with_config(|cfg| {
             cfg.nuget.enabled = true;
@@ -1128,7 +1191,123 @@ mod integration_tests {
             "",
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Stale cache + unreachable upstream + serve_stale=true → 200 with X-Nora-Stale header (#409)
+    #[tokio::test]
+    async fn test_serve_stale_version_list() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.nuget.proxy_timeout = 1;
+            cfg.nuget.metadata_ttl = 0; // force TTL expiry
+            cfg.nuget.serve_stale = true;
+        });
+        // Seed cache
+        let versions = br#"{"versions":["1.0.0","2.0.0"]}"#;
+        ctx.state
+            .storage
+            .put("nuget/flatcontainer/test-package/index.json", versions)
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/flatcontainer/test-package/index.json",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("x-nora-stale").map(|v| v.as_bytes()),
+            Some(b"true".as_slice())
+        );
+        let body = body_bytes(resp).await;
+        assert!(body.starts_with(b"{\"versions\""));
+    }
+
+    /// Stale cache + unreachable upstream + serve_stale=false → 404 (#409)
+    #[tokio::test]
+    async fn test_serve_stale_disabled_returns_404() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.nuget.proxy_timeout = 1;
+            cfg.nuget.metadata_ttl = 0;
+            cfg.nuget.serve_stale = false;
+        });
+        // Seed cache
+        ctx.state
+            .storage
+            .put(
+                "nuget/flatcontainer/test-package/index.json",
+                br#"{"versions":["1.0.0"]}"#,
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/flatcontainer/test-package/index.json",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert!(resp.headers().get("x-nora-stale").is_none());
+    }
+
+    /// Uncached .nupkg + unreachable upstream → 404 (not 502) (#410)
+    #[tokio::test]
+    async fn test_uncached_nupkg_returns_404_not_502() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.nuget.proxy_timeout = 1;
+        });
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/flatcontainer/nosuch-pkg/1.0.0/nosuch-pkg.1.0.0.nupkg",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Stale registration index is served with URL rewriting (#409)
+    #[tokio::test]
+    async fn test_serve_stale_registration_index() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.nuget.enabled = true;
+            cfg.nuget.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.nuget.proxy_timeout = 1;
+            cfg.nuget.metadata_ttl = 0;
+            cfg.nuget.serve_stale = true;
+        });
+        // Seed registration cache
+        let reg_json =
+            br#"{"items":[{"@id":"http://127.0.0.1:1/v3/registration/test-pkg/index.json"}]}"#;
+        ctx.state
+            .storage
+            .put("nuget/registration/test-pkg/index.json", reg_json)
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/nuget/v3/registration/test-pkg/index.json",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("x-nora-stale").map(|v| v.as_bytes()),
+            Some(b"true".as_slice())
+        );
     }
 
     #[tokio::test]
@@ -1445,6 +1624,7 @@ mod integration_tests {
     }
 
     #[tokio::test]
+    #[doc = "No cache + unreachable upstream → 404 (not 502) since #410"]
     async fn test_registration_page_unreachable_upstream() {
         let ctx = create_test_context_with_config(|cfg| {
             cfg.nuget.enabled = true;
@@ -1459,7 +1639,7 @@ mod integration_tests {
             "",
         )
         .await;
-        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `serve_stale` option (default: `true`) to NuGet config, matching the existing Docker registry behavior. When upstream is unreachable and cached metadata exists, return it with `X-Nora-Stale: true` header instead of failing.
- Change uncached-binary error from 502 to 404 to prevent NuGet client retry storms (3 retries × 200ms = 47s stall per package).
- Env var: `NORA_NUGET_SERVE_STALE=false` to disable.

## Tested

A/B local test with 130-package benchmark (20 top-level: EF Core, Azure SDK, AWS SDK, gRPC, MassTransit, Hangfire, OpenTelemetry, MongoDB, Redis, Serilog, Polly, MediatR, etc.):

| Stand | Mode | serve_stale | Result | Time |
|-------|------|-------------|--------|------|
| A | proxy (nuget.org) | true | PASS | 14s (cache-hit) |
| B | air-gap (dead upstream) | true | PASS | 3m42s (stale) |
| B | air-gap (dead upstream) | false | FAIL (all 404) | 5.5s |

## Test plan

- [x] `cargo test` — 1034 passed, 0 failed
- [x] `cargo clippy -- -D warnings` — clean
- [x] Stand A proxy restore (cold + cache-hit)
- [x] Stand B air-gap restore with `serve_stale=true` — stale metadata served, `X-Nora-Stale: true` header present
- [x] Stand B air-gap restore with `serve_stale=false` — all packages fail (control)
- [x] Uncached .nupkg returns 404, not 502

Closes #409, closes #410