### PR TITLE
fix(nuget): route background index fetch through proxy_fetch_text

### DIFF
--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -590,7 +590,6 @@ async fn flatcontainer_download(
                 let state2 = Arc::clone(&state);
                 let proxy_url2 = proxy_url.clone();
                 let id2 = id_lower.clone();
-                let client2 = state.http_client.clone();
                 tokio::spawn(async move {
                     if state2.storage.stat(&index_key).await.is_none() {
                         let url = format!(
@@ -598,11 +597,19 @@ async fn flatcontainer_download(
                             proxy_url2.trim_end_matches('/'),
                             id2
                         );
-                        if let Ok(resp) = client2.get(&url).send().await {
-                            if let Ok(body) = resp.bytes().await {
-                                let _ = state2.storage.put(&index_key, &body).await;
-                                state2.repo_index.invalidate("nuget");
-                            }
+                        if let Ok(text) = proxy_fetch_text(
+                            &state2.http_client,
+                            &url,
+                            state2.config.nuget.proxy_timeout,
+                            state2.config.nuget.proxy_auth.as_deref(),
+                            None,
+                            &state2.circuit_breaker,
+                            "nuget",
+                        )
+                        .await
+                        {
+                            let _ = state2.storage.put(&index_key, text.as_bytes()).await;
+                            state2.repo_index.invalidate("nuget");
                         }
                     }
                 });


### PR DESCRIPTION
## Summary

- Background flatcontainer index fetch in `nuget.rs` used a bare `client.get()` call, bypassing proxy authentication and circuit breaker
- Replaced with `proxy_fetch_text()` which routes through the standard proxy path with auth, timeout, and circuit breaker
- Fixes an issue where background cache warming would fail silently in environments requiring proxy authentication

Closes #413

## Test plan

- [x] `cargo test` — 1039 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] Pre-push hooks pass (semgrep, negative security, API contract, OCI conformance)
- [ ] Manual: configure `NORA_NUGET_PROXY_AUTH`, verify background fetch uses credentials