### PR TITLE
feat(nuget): add Chocolatey and PowerShell Gallery path aliases

### DIFF
--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -890,7 +890,9 @@ async fn run_server(config: Config, storage: Storage) {
                 registry_routes = registry_routes.merge(registry::ansible_routes())
             }
             RegistryType::Nuget => {
-                registry_routes = registry_routes.merge(registry::nuget_routes())
+                registry_routes = registry_routes
+                    .merge(registry::nuget_routes())
+                    .merge(registry::nuget_alias_routes())
             }
             RegistryType::PubDart => {
                 registry_routes = registry_routes.merge(registry::pub_dart_routes())

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -25,6 +25,7 @@ pub use gems::routes as gems_routes;
 pub use go::routes as go_routes;
 pub use maven::routes as maven_routes;
 pub use npm::routes as npm_routes;
+pub use nuget::alias_routes as nuget_alias_routes;
 pub use nuget::routes as nuget_routes;
 pub use pub_dart::routes as pub_dart_routes;
 pub use pypi::routes as pypi_routes;

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -48,30 +48,38 @@ struct SearchParams {
 pub const INDEX_PATTERN: (&str, &str) = ("nuget/flatcontainer/", ".nupkg");
 
 pub fn routes() -> Router<Arc<AppState>> {
+    routes_with_prefix("nuget")
+}
+
+/// Alias routes for Chocolatey and PowerShell Gallery clients.
+/// These serve the same NuGet V3 handlers under alternate path prefixes.
+/// The service index points back to /nuget/ paths, so clients follow those
+/// URLs after initial discovery — storage and caching stay unified.
+pub fn alias_routes() -> Router<Arc<AppState>> {
+    routes_with_prefix("chocolatey").merge(routes_with_prefix("pwsh"))
+}
+
+fn routes_with_prefix(prefix: &str) -> Router<Arc<AppState>> {
     Router::new()
-        // Service index
-        .route("/nuget/v3/index.json", get(service_index))
-        // Search (proxy to upstream SearchQueryService)
-        .route("/nuget/v3/query", get(search_query))
-        // Autocomplete (proxy to upstream SearchAutocompleteService)
-        .route("/nuget/v3/autocomplete", get(autocomplete_query))
-        // Registration index
+        .route(&format!("/{prefix}/v3/index.json"), get(service_index))
+        .route(&format!("/{prefix}/v3/query"), get(search_query))
         .route(
-            "/nuget/v3/registration/{id}/index.json",
+            &format!("/{prefix}/v3/autocomplete"),
+            get(autocomplete_query),
+        )
+        .route(
+            &format!("/{prefix}/v3/registration/{{id}}/index.json"),
             get(registration_index),
         )
-        // Registration page (paginated version ranges)
         .route(
-            "/nuget/v3/registration/{id}/page/{lower}/{*upper}",
+            &format!("/{prefix}/v3/registration/{{id}}/page/{{lower}}/{{*upper}}"),
             get(registration_page),
         )
-        // Flat container: version list + package download (single wildcard)
         .route(
-            "/nuget/v3/flatcontainer/{*path}",
+            &format!("/{prefix}/v3/flatcontainer/{{*path}}"),
             get(flatcontainer_handler),
         )
-        // Catch-all: any unhandled /nuget/v3/ path → 404 + diagnostic log
-        .route("/nuget/v3/{*path}", get(nuget_catchall))
+        .route(&format!("/{prefix}/v3/{{*path}}"), get(nuget_catchall))
 }
 
 // ── Service index ──────────────────────────────────────────────────────

--- a/nora-registry/src/registry_type.rs
+++ b/nora-registry/src/registry_type.rs
@@ -138,7 +138,7 @@ impl RegistryType {
             "gems" | "rubygems" => Some(Self::Gems),
             "terraform" => Some(Self::Terraform),
             "ansible" => Some(Self::Ansible),
-            "nuget" => Some(Self::Nuget),
+            "nuget" | "chocolatey" | "choco" | "powershellgallery" | "pwsh" => Some(Self::Nuget),
             "pub" | "pub_dart" | "dart" => Some(Self::PubDart),
             "conan" => Some(Self::Conan),
             _ => None,


### PR DESCRIPTION
Closes #412

## Summary
- Clients configured with `chocolatey` or `pwsh` source URLs can now reach the NuGet V3 service index via `/chocolatey/v3/` and `/pwsh/v3/` paths
- The service index returns canonical `/nuget/` URLs, so storage and caching remain unified after initial discovery
- `RegistryType::from_str_opt` now accepts `chocolatey`, `choco`, `powershellgallery`, and `pwsh` as aliases for NuGet

## Changes
- **nuget.rs**: Refactored `routes()` into `routes_with_prefix()` helper, added `alias_routes()` for `/chocolatey/` and `/pwsh/` prefixes
- **registry_type.rs**: Added Chocolatey/PowerShell Gallery aliases to `from_str_opt`
- **mod.rs**: Exported `nuget_alias_routes`
- **main.rs**: Merged alias routes when NuGet is enabled

## Test plan
- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test` — 1039 tests pass
- [x] Pre-commit, semgrep, arch-predict — pass