### PR TITLE
perf(nuget): reduce metadata proxy timeout to 2s

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -486,6 +486,11 @@ pub struct NugetConfig {
     pub proxy_auth: Option<String>,
     #[serde(default = "default_timeout")]
     pub proxy_timeout: u64,
+    /// Timeout for metadata requests (registration, version list) in seconds.
+    /// Metadata responses are small JSON; lower timeout improves air-gap stale
+    /// restore by letting the circuit breaker open faster. Default: 2s.
+    #[serde(default = "default_nuget_metadata_timeout")]
+    pub metadata_proxy_timeout: u64,
     /// Metadata cache TTL in seconds (default: 300 = 5 min).
     /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
@@ -513,6 +518,10 @@ fn default_nuget_autocomplete() -> String {
     "https://azuresearch-usnc.nuget.org/autocomplete".to_string()
 }
 
+fn default_nuget_metadata_timeout() -> u64 {
+    2
+}
+
 impl Default for NugetConfig {
     fn default() -> Self {
         Self {
@@ -520,6 +529,7 @@ impl Default for NugetConfig {
             proxy: default_nuget_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
+            metadata_proxy_timeout: 2,
             metadata_ttl: 300,
             serve_stale: true,
             search_service: default_nuget_search(),
@@ -2283,6 +2293,11 @@ impl Config {
         if let Ok(val) = env::var("NORA_NUGET_PROXY_TIMEOUT") {
             if let Ok(timeout) = val.parse() {
                 self.nuget.proxy_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_NUGET_METADATA_TIMEOUT") {
+            if let Ok(timeout) = val.parse() {
+                self.nuget.metadata_proxy_timeout = timeout;
             }
         }
         if let Ok(val) = env::var("NORA_NUGET_METADATA_TTL") {

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -248,7 +248,7 @@ async fn registration_index(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.nuget.proxy_timeout,
+        state.config.nuget.metadata_proxy_timeout,
         state.config.nuget.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
@@ -336,7 +336,7 @@ async fn registration_page(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.nuget.proxy_timeout,
+        state.config.nuget.metadata_proxy_timeout,
         state.config.nuget.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
@@ -422,7 +422,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.nuget.proxy_timeout,
+        state.config.nuget.metadata_proxy_timeout,
         state.config.nuget.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,


### PR DESCRIPTION
Closes #415

## Summary
- Split NuGet proxy timeout into binary downloads (30s, unchanged) and metadata requests (2s, new default)
- Registration index, registration page, and version list use the shorter timeout
- Circuit breaker opens in ~25s instead of ~305s when upstream is unreachable
- Air-gap stale restore for 130 packages: ~5min → ~25s

## Changes
- **config.rs**: Added `metadata_proxy_timeout` field to `NugetConfig` (default: 2s), env var `NORA_NUGET_METADATA_TIMEOUT`
- **nuget.rs**: Three metadata handlers (`registration_index`, `registration_page`, `version_list`) now use `metadata_proxy_timeout`; binary download (`flatcontainer_download`) keeps `proxy_timeout` (30s)

## Math
- Before: 5 failures × (30s timeout + 1s sleep + 30s retry) = 305s before CB opens
- After: 5 failures × (2s timeout + 1s sleep + 2s retry) = 25s before CB opens
- After CB opens: remaining packages serve stale instantly

## Test plan
- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test` — 1039 tests pass
- [x] Pre-commit, semgrep, arch-predict — pass