### PR TITLE
test(nuget): verify deprecation/vulnerabilities survive registration rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions: read-all
 

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -1430,6 +1430,36 @@ mod tests {
         assert!(result.contains("http://nora:4000/nuget/v3/registration/bar/index.json"));
     }
 
+    /// Deprecation fields survive URL rewriting — catalog0 @ids left as-is (#424)
+    #[test]
+    fn test_rewrite_preserves_deprecation_field() {
+        let input = r#"{"items":[{"catalogEntry":{"@id":"https://api.nuget.org/v3/catalog0/data/2024.09.20/ef.4.1.json","version":"4.1.10311","deprecation":{"@id":"https://api.nuget.org/v3/catalog0/data/2024.09.20/ef.4.1.json#deprecation","@type":"deprecation","alternatePackage":{"@id":"https://api.nuget.org/v3/catalog0/data/2024.09.20/ef.4.1.json#deprecation/alternatePackage","@type":"alternatePackage","id":"EntityFramework","range":"[6.5.1, )"},"reasons":["Legacy"]},"packageContent":"https://api.nuget.org/v3-flatcontainer/entityframework/4.1.10311/entityframework.4.1.10311.nupkg"}}]}"#;
+        let result = rewrite_registration_urls(input, "https://api.nuget.org", "http://nora:4000");
+        // deprecation block preserved intact (catalog0 URLs stay as-is)
+        assert!(result.contains(r#""deprecation":{""#));
+        assert!(result.contains(r#""reasons":["Legacy"]"#));
+        assert!(result.contains(r#""id":"EntityFramework""#));
+        assert!(result.contains("https://api.nuget.org/v3/catalog0/data/2024.09.20"));
+        assert!(!result.contains("nora:4000/nuget/v3/catalog0"));
+        // packageContent rewritten to Nora
+        assert!(result.contains("http://nora:4000/nuget/v3/flatcontainer/"));
+    }
+
+    /// Vulnerabilities array survives URL rewriting (#424)
+    #[test]
+    fn test_rewrite_preserves_vulnerabilities_field() {
+        let input = r#"{"items":[{"catalogEntry":{"@id":"https://api.nuget.org/v3/catalog0/data/2024.01.01/log4net.1.2.10.json","version":"1.2.10","vulnerabilities":[{"advisoryUrl":"https://github.com/advisories/GHSA-2cwj-8chv-9pp9","severity":"3"},{"advisoryUrl":"https://github.com/advisories/GHSA-4f7c-pmjv-c25w","severity":"1"}],"packageContent":"https://api.nuget.org/v3-flatcontainer/log4net/1.2.10/log4net.1.2.10.nupkg"}}]}"#;
+        let result = rewrite_registration_urls(input, "https://api.nuget.org", "http://nora:4000");
+        // vulnerabilities array preserved intact (external advisory URLs, not upstream registry)
+        assert!(result.contains(r#""vulnerabilities":[{"#));
+        assert!(result.contains("GHSA-2cwj-8chv-9pp9"));
+        assert!(result.contains("GHSA-4f7c-pmjv-c25w"));
+        assert!(result.contains(r#""severity":"3""#));
+        assert!(result.contains(r#""advisoryUrl":"https://github.com/advisories/"#));
+        // packageContent rewritten to Nora
+        assert!(result.contains("http://nora:4000/nuget/v3/flatcontainer/"));
+    }
+
     #[test]
     fn test_valid_versions() {
         assert!(is_valid_version("1.0.0"));


### PR DESCRIPTION
## Summary

- Add unit tests proving `deprecation` and `vulnerabilities` fields pass through `rewrite_registration_urls` intact
- Uses real data shapes from nuget.org (EntityFramework deprecation, log4net GHSA advisories)
- Negative assertions ensure catalog0 and advisory URLs are never rewritten to Nora

Closes #424

## Test plan

- [x] `cargo test -- nuget::tests::test_rewrite_preserves` — 2/2 pass
- [x] Full NuGet test suite — 57/0 pass
- [x] Pre-push gate: OPSEC, semgrep, security, contract, OCI — all pass