### PR TITLE
feat: add upstream URL leak detection metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1869,6 +1869,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "md-5 0.11.0",
+ "memchr",
  "object_store",
  "parking_lot",
  "percent-encoding",

--- a/nora-registry/Cargo.toml
+++ b/nora-registry/Cargo.toml
@@ -58,6 +58,7 @@ percent-encoding = "2"
 subtle = "2"
 tokio-util = "0.7"
 arc-swap = "1"
+memchr = "2"
 
 [dev-dependencies]
 proptest = "1"

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -1162,6 +1162,7 @@ Jd74nq6dNCjpWG4drIsyhqX+
                 ctx.state.config.circuit_breaker.clone(),
             ),
             digest_store: ctx.state.digest_store.clone(),
+            leak_finders: ctx.state.leak_finders.clone(),
         });
 
         // Rebuild router with new state

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1683,6 +1683,75 @@ impl Config {
         }
     }
 
+    /// Collect all configured upstream hostnames for leak detection (#386).
+    ///
+    /// Returns `(registry_name, hostname)` pairs extracted from proxy URLs.
+    /// Used once at startup to pre-compile substring searchers.
+    pub fn upstream_hostnames(&self) -> Vec<(String, String)> {
+        let mut result = Vec::new();
+
+        let extract_host = |url: &str| -> Option<String> {
+            let without_scheme = url
+                .strip_prefix("https://")
+                .or_else(|| url.strip_prefix("http://"))
+                .unwrap_or(url);
+            let host = without_scheme.split('/').next()?;
+            let host = host.split(':').next()?;
+            if host.is_empty() || host == "localhost" || host == "127.0.0.1" {
+                return None;
+            }
+            Some(host.to_lowercase())
+        };
+
+        // Simple proxy: Option<String>
+        let simple = [
+            ("npm", self.npm.proxy.as_deref()),
+            ("pypi", self.pypi.proxy.as_deref()),
+            ("cargo", self.cargo.proxy.as_deref()),
+            ("go", self.go.proxy.as_deref()),
+            ("gems", self.gems.proxy.as_deref()),
+            ("terraform", self.terraform.proxy.as_deref()),
+            ("ansible", self.ansible.proxy.as_deref()),
+            ("nuget", self.nuget.proxy.as_deref()),
+            ("pub", self.pub_dart.proxy.as_deref()),
+            ("conan", self.conan.proxy.as_deref()),
+        ];
+        for (name, url) in simple {
+            if let Some(url) = url {
+                if let Some(host) = extract_host(url) {
+                    result.push((name.to_string(), host));
+                }
+            }
+        }
+
+        // NuGet extra search/autocomplete URLs
+        if let Some(host) = extract_host(&self.nuget.search_service) {
+            result.push(("nuget".to_string(), host));
+        }
+        if let Some(host) = extract_host(&self.nuget.autocomplete) {
+            result.push(("nuget".to_string(), host));
+        }
+
+        // Docker upstreams: Vec<DockerUpstream>
+        for upstream in &self.docker.upstreams {
+            if let Some(host) = extract_host(&upstream.url) {
+                result.push(("docker".to_string(), host));
+            }
+        }
+
+        // Maven proxies: Vec<MavenProxyEntry>
+        for proxy in &self.maven.proxies {
+            if let Some(host) = extract_host(proxy.url()) {
+                result.push(("maven".to_string(), host));
+            }
+        }
+
+        // Deduplicate
+        result.sort();
+        result.dedup();
+        result
+    }
+
     /// Validate configuration and return (warnings, errors).
     ///
     /// Warnings are logged but do not prevent startup.
@@ -3835,5 +3904,69 @@ mod tests {
         assert!(!set.contains(&RegistryType::Maven));
         assert!(!set.contains(&RegistryType::Conan));
         assert!(set.contains(&RegistryType::Docker));
+    }
+
+    #[test]
+    fn test_upstream_hostnames_extracts_from_defaults() {
+        let config = Config::default();
+        let hosts = config.upstream_hostnames();
+        // Default config has proxy URLs for several registries
+        let hostnames: Vec<&str> = hosts.iter().map(|(_, h)| h.as_str()).collect();
+        assert!(hostnames.contains(&"crates.io"), "cargo default missing");
+        assert!(
+            hostnames.contains(&"api.nuget.org"),
+            "nuget default missing"
+        );
+        assert!(
+            hostnames.contains(&"azuresearch-usnc.nuget.org"),
+            "nuget search default missing"
+        );
+        assert!(
+            hostnames.contains(&"proxy.golang.org"),
+            "go default missing"
+        );
+        // localhost should be excluded
+        assert!(!hostnames.contains(&"localhost"));
+        assert!(!hostnames.contains(&"127.0.0.1"));
+    }
+
+    #[test]
+    fn test_upstream_hostnames_deduplicates() {
+        let config = Config::default();
+        let hosts = config.upstream_hostnames();
+        let mut seen = std::collections::HashSet::new();
+        for pair in &hosts {
+            assert!(seen.insert(pair), "duplicate: {:?}", pair);
+        }
+    }
+
+    #[test]
+    fn test_upstream_hostnames_docker_upstreams() {
+        let toml = r#"
+            [server]
+            host = "127.0.0.1"
+            port = 4000
+
+            [storage]
+            path = "/tmp/nora-test"
+
+            [docker]
+            enabled = true
+
+            [[docker.upstreams]]
+            url = "https://registry-1.docker.io"
+
+            [[docker.upstreams]]
+            url = "https://ghcr.io"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        let hosts = config.upstream_hostnames();
+        let docker_hosts: Vec<&str> = hosts
+            .iter()
+            .filter(|(r, _)| r == "docker")
+            .map(|(_, h)| h.as_str())
+            .collect();
+        assert!(docker_hosts.contains(&"registry-1.docker.io"));
+        assert!(docker_hosts.contains(&"ghcr.io"));
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -174,6 +174,8 @@ pub struct AppState {
     pub oidc: Option<auth::OidcValidator>,
     pub(crate) circuit_breaker: circuit_breaker::CircuitBreakerRegistry,
     pub digest_store: std::sync::Arc<digest_quarantine::DigestStore>,
+    /// Pre-compiled upstream hostname searchers for leak detection (#386)
+    pub leak_finders: metrics::LeakFinders,
 }
 
 impl AppState {
@@ -962,6 +964,8 @@ async fn run_server(mut config: Config, storage: Storage) {
         bypass_token,
     }));
 
+    let leak_finders = metrics::LeakFinders::new(config.upstream_hostnames());
+
     let state = Arc::new(AppState {
         storage,
         config,
@@ -983,6 +987,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         oidc: oidc_validator,
         circuit_breaker: circuit_breaker::CircuitBreakerRegistry::new(cb_config),
         digest_store,
+        leak_finders,
     });
 
     // Shared lock: GC and Retention must not run concurrently (both call storage.delete)
@@ -1053,6 +1058,10 @@ async fn run_server(mut config: Config, storage: Storage) {
         ))
         .layer(middleware::from_fn(request_id::request_id_middleware))
         .layer(middleware::from_fn(metrics::metrics_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            metrics::leak_detection_middleware,
+        ))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::auth_middleware,

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -3,7 +3,7 @@
 
 use axum::{
     body::Body,
-    extract::MatchedPath,
+    extract::{MatchedPath, State},
     http::Request,
     middleware::Next,
     response::{IntoResponse, Response},
@@ -11,6 +11,7 @@ use axum::{
     Router,
 };
 use lazy_static::lazy_static;
+use memchr::memmem;
 use prometheus::{
     register_histogram_vec, register_int_counter_vec, Encoder, HistogramVec, IntCounterVec,
     TextEncoder,
@@ -70,6 +71,66 @@ lazy_static! {
         "Total requests rejected by circuit breaker",
         &["registry"]
     ).expect("failed to create CIRCUIT_BREAKER_REJECTIONS metric at startup");
+
+    /// Upstream URL leak detections in responses (#386)
+    pub static ref UPSTREAM_URL_LEAK_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "nora_response_upstream_url_leak_total",
+        "Upstream hostname detected in outgoing response body",
+        &["registry"]
+    ).expect("failed to create UPSTREAM_URL_LEAK_TOTAL metric at startup");
+}
+
+/// Maximum response body size to scan for upstream URL leaks (2 MB).
+const LEAK_SCAN_MAX_BYTES: usize = 2 * 1024 * 1024;
+
+/// Pre-compiled substring searchers for upstream hostname leak detection.
+///
+/// Built once at startup from `Config::upstream_hostnames()` and stored in `AppState`.
+#[derive(Clone)]
+pub struct LeakFinders {
+    entries: Arc<Vec<LeakFinderEntry>>,
+}
+
+#[derive(Clone)]
+struct LeakFinderEntry {
+    registry: String,
+    hostname: String,
+    finder: memmem::Finder<'static>,
+}
+
+impl LeakFinders {
+    /// Build leak finders from (registry, hostname) pairs.
+    pub fn new(hostnames: Vec<(String, String)>) -> Self {
+        let entries = hostnames
+            .into_iter()
+            .map(|(registry, hostname)| {
+                let finder = memmem::Finder::new(hostname.as_bytes()).into_owned();
+                LeakFinderEntry {
+                    registry,
+                    hostname,
+                    finder,
+                }
+            })
+            .collect();
+        Self {
+            entries: Arc::new(entries),
+        }
+    }
+
+    /// Scan bytes for any upstream hostname. Returns first match.
+    fn scan(&self, haystack: &[u8]) -> Option<(&str, &str)> {
+        for entry in self.entries.iter() {
+            if entry.finder.find(haystack).is_some() {
+                return Some((&entry.registry, &entry.hostname));
+            }
+        }
+        None
+    }
+
+    /// Returns true if no finders are configured.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
 }
 
 /// Routes for metrics endpoint
@@ -121,6 +182,105 @@ pub async fn metrics_middleware(
         .observe(duration);
 
     response
+}
+
+/// Middleware to detect upstream URL leaks in JSON response bodies (#386).
+///
+/// Scans outgoing JSON responses for configured upstream hostnames.
+/// Detection only — never blocks responses. Increments counter and logs WARN.
+pub async fn leak_detection_middleware(
+    State(state): State<Arc<AppState>>,
+    request: Request<Body>,
+    next: Next,
+) -> Response {
+    let path = request.uri().path().to_string();
+    let response = next.run(request).await;
+
+    // Fast path: skip if no finders configured
+    if state.leak_finders.is_empty() {
+        return response;
+    }
+
+    // Only scan JSON responses
+    let is_json = response
+        .headers()
+        .get(axum::http::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.contains("json"));
+    if !is_json {
+        return response;
+    }
+
+    // Skip if Content-Length exceeds scan limit (avoid consuming body we can't restore)
+    let content_length = response
+        .headers()
+        .get(axum::http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<usize>().ok());
+    if content_length.is_some_and(|len| len > LEAK_SCAN_MAX_BYTES) {
+        return response;
+    }
+
+    let is_gzip = response
+        .headers()
+        .get(axum::http::header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ce| ce.contains("gzip"));
+
+    // Collect response body
+    let (parts, body) = response.into_parts();
+    let body_bytes = match axum::body::to_bytes(body, LEAK_SCAN_MAX_BYTES).await {
+        Ok(bytes) => bytes,
+        Err(_) => {
+            // Body exceeded limit or read failed — can't restore original, return empty.
+            // In practice unreachable: Content-Length pre-check above catches oversized bodies.
+            tracing::debug!("leak_detection: body read exceeded limit, skipping scan");
+            return Response::from_parts(parts, Body::empty());
+        }
+    };
+
+    // Skip tiny bodies
+    if body_bytes.len() < 20 {
+        return Response::from_parts(parts, Body::from(body_bytes));
+    }
+
+    // Decompress gzip if needed, scan decompressed bytes
+    let scan_bytes: Vec<u8>;
+    let haystack = if is_gzip {
+        match decompress_gzip(&body_bytes) {
+            Some(decompressed) => {
+                scan_bytes = decompressed;
+                &scan_bytes
+            }
+            None => &body_bytes[..],
+        }
+    } else {
+        &body_bytes[..]
+    };
+
+    if let Some((registry, hostname)) = state.leak_finders.scan(haystack) {
+        UPSTREAM_URL_LEAK_TOTAL.with_label_values(&[registry]).inc();
+        tracing::warn!(
+            registry = registry,
+            upstream = hostname,
+            path = path.as_str(),
+            body_len = haystack.len(),
+            "upstream URL leak detected in response"
+        );
+    }
+
+    // Return original (possibly gzip-compressed) body unchanged
+    Response::from_parts(parts, Body::from(body_bytes))
+}
+
+/// Decompress gzip bytes; returns None on failure (non-fatal).
+fn decompress_gzip(data: &[u8]) -> Option<Vec<u8>> {
+    use flate2::read::GzDecoder;
+    use std::io::Read;
+    let mut decoder = GzDecoder::new(data);
+    let mut buf = Vec::new();
+    decoder.read_to_end(&mut buf).ok()?;
+    Some(buf)
 }
 
 /// Detect registry type from path
@@ -227,5 +387,66 @@ mod tests {
         assert_eq!(detect_registry("/raw/data/file.bin"), "raw");
         // Bare prefix without trailing slash should not match
         assert_eq!(detect_registry("/rawdata/file"), "other");
+    }
+
+    #[test]
+    fn test_leak_finders_detects_upstream_hostname() {
+        let finders = LeakFinders::new(vec![
+            ("nuget".to_string(), "api.nuget.org".to_string()),
+            ("npm".to_string(), "registry.npmjs.org".to_string()),
+        ]);
+        let body = br#"{"@id":"https://api.nuget.org/v3/registration/newtonsoft.json"}"#;
+        let result = finders.scan(body);
+        assert!(result.is_some());
+        let (registry, hostname) = result.unwrap();
+        assert_eq!(registry, "nuget");
+        assert_eq!(hostname, "api.nuget.org");
+    }
+
+    #[test]
+    fn test_leak_finders_no_match_returns_none() {
+        let finders = LeakFinders::new(vec![("nuget".to_string(), "api.nuget.org".to_string())]);
+        let body = br#"{"@id":"http://localhost:4000/nuget/v3/registration/newtonsoft.json"}"#;
+        assert!(finders.scan(body).is_none());
+    }
+
+    #[test]
+    fn test_leak_finders_empty_has_no_match() {
+        let finders = LeakFinders::new(vec![]);
+        assert!(finders.is_empty());
+        assert!(finders.scan(b"anything").is_none());
+    }
+
+    #[test]
+    fn test_decompress_gzip_roundtrip() {
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        let original = b"hello upstream api.nuget.org world";
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(original).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let decompressed = decompress_gzip(&compressed).unwrap();
+        assert_eq!(decompressed, original);
+    }
+
+    #[test]
+    fn test_leak_finders_detects_in_decompressed_gzip() {
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        let finders = LeakFinders::new(vec![("nuget".to_string(), "api.nuget.org".to_string())]);
+        let body = br#"{"packageContent":"https://api.nuget.org/v3-flatcontainer/pkg/1.0.0/pkg.1.0.0.nupkg"}"#;
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(body).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        // Compressed bytes should NOT match (gzip obfuscates)
+        assert!(finders.scan(&compressed).is_none());
+
+        // Decompressed bytes should match
+        let decompressed = decompress_gzip(&compressed).unwrap();
+        let result = finders.scan(&decompressed);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().0, "nuget");
     }
 }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -223,6 +223,8 @@ fn build_context(
         bypass_token,
     }));
 
+    let leak_finders = crate::metrics::LeakFinders::new(config.upstream_hostnames());
+
     let state = Arc::new(AppState {
         storage,
         config,
@@ -246,6 +248,7 @@ fn build_context(
         digest_store: std::sync::Arc::new(crate::digest_quarantine::DigestStore::empty(
             &storage_path,
         )),
+        leak_finders,
     });
 
     // Build router identical to run_server() but without TcpListener / rate-limiting


### PR DESCRIPTION
## Summary

- Response middleware scans JSON bodies for configured upstream hostnames
- Detection only — increments Prometheus counter `nora_response_upstream_url_leak_total` and logs WARN, never blocks responses
- Pre-compiled `memchr::memmem` finders built once at startup from config
- Handles gzip-encoded NuGet registration responses (decompresses before scan)
- Content-Length pre-check skips oversized bodies (2MB cap)

## Design decisions

- **Single label `registry`** on the metric (no upstream hostname) — avoids leaking internal infrastructure details on the public `/metrics` endpoint
- **gzip decompression** before scanning — NuGet registration uses `Content-Encoding: gzip`, scanning compressed bytes would miss all NuGet leaks
- **2MB body cap** with Content-Length pre-check — prevents buffering oversized responses; if Content-Length exceeds limit, response passes through untouched

## Test plan

- [x] 8 unit tests: scan match/no-match, empty finders, gzip roundtrip, gzip scan, config extraction (defaults, dedup, Docker upstreams)
- [x] `cargo fmt --check && cargo clippy -- -D warnings` clean
- [x] 1057 existing tests pass
- [ ] Level 1 gate (negative-security, api-contract, oci-conformance) after CI

Closes #386