### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,36 @@
 # Changelog
 ## [Unreleased]
 
+## [0.9.1] - 2026-05-21
+
+### Added
+- **NuGet gzip registration** — `RegistrationsBaseUrl/3.6.0` responses compressed with gzip per NuGet V3 spec (#421)
+- **NuGet semVerLevel filtering** — search and autocomplete hide SemVer 2.0 packages when `semVerLevel` not specified (#421)
+- **NuGet service index generation** — generate service index from scratch instead of rewriting upstream, ensures all `@id` URLs point to Nora (#404, #405)
+- **NuGet Chocolatey/PowerShell aliases** — `/chocolatey/` and `/powershell/` path aliases for NuGet V3 endpoints (#412, #419)
+- **NuGet local autocomplete fallback** — autocomplete works in air-gap mode using cached package index (#414, #417)
+- **NuGet serve-stale** — serve cached metadata when upstream is unreachable, with `X-Nora-Stale` header (#409, #410, #411)
+- **NuGet deprecation/vulnerability pass-through** — registration responses preserve deprecation and vulnerability metadata from upstream (#425)
+- **Cargo ETag + HTTP 304** — sparse index responses include SHA-256 ETag; `If-None-Match` returns 304 Not Modified (#397)
+- **Upstream URL leak detection metric** — Prometheus counter `nora_upstream_url_leak_total{registry, leak_type}` fires when response bodies/headers contain upstream registry URLs (#386, #426)
+- **NuGet E2E test suite** — 11 dotnet client fixture projects covering restore, analyzers, source generators, native RID, SemVer2, version ranges, case insensitivity, lock files, deep transitive deps, and Chocolatey alias
+
 ### Fixed
-- **PyPI file hash key** — renamed `digests` to `hashes` to support `PEP 691` specification (#389)
+- **NuGet URL rewriting** — registration index/page `@id` and `packageContent` URLs no longer leak `api.nuget.org` (#388, #392, #393, #394, #400)
+- **NuGet background fetch** — index fetch routed through `proxy_fetch_text` to respect proxy and circuit breaker settings (#413, #416)
+- **NuGet upstream URL stripping** — strip path component from upstream proxy URL to prevent double-path (#407, #408)
+- **NuGet serve_stale config** — respect `serve_stale` config flag in search/autocomplete fallback (#423)
+- **PyPI PEP 691 typed structs** — replaced ad-hoc JSON manipulation with typed Serde structs for spec conformance (#390, #398)
+- **PyPI file hash key** — renamed `digests` to `hashes` to support PEP 691 specification (#389, #399)
+- **npm scoped package tarball key** — correct tarball storage key for `@scope/package` in UI detail view (#402, #403)
+- **Air-gap URL leaks** — fixed upstream URL leaks across NuGet, Terraform, and Ansible registries (#400)
+- **Curation test serialization** — serialize env-override tests with mutex to prevent flaky parallel failures (#406)
+
+### Changed
+- **NuGet search endpoint discovery** — dynamically discover search/autocomplete endpoints from upstream service index instead of hardcoding (#370, #418)
+- **NuGet metadata proxy timeout** — reduced from default to 2s for faster fallback to cache (#415, #420)
+- **URL-leak invariant tests** — added URL-leak detection tests for NuGet and npm registries (#390, #395)
+- 1049 total tests (up from 994)
 
 ## [0.9.0] - 2026-05-16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "arc-swap",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.9.0",
+        version = "0.9.1",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/tests/nuget-client/.gitignore
+++ b/tests/nuget-client/.gitignore
@@ -1,0 +1,10 @@
+# Generated at test time by run-tests.sh
+NuGet.Config
+11-ChocolateyAlias/NuGet.Config
+
+# dotnet build artifacts
+*/obj/
+*/bin/
+
+# Lock file generated during test
+09-LockFile/packages.lock.json

--- a/tests/nuget-client/01-BasicRestore/01-BasicRestore.csproj
+++ b/tests/nuget-client/01-BasicRestore/01-BasicRestore.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/02-FrameworkCompat/02-FrameworkCompat.csproj
+++ b/tests/nuget-client/02-FrameworkCompat/02-FrameworkCompat.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/03-NativeRid/03-NativeRid.csproj
+++ b/tests/nuget-client/03-NativeRid/03-NativeRid.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.10" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/04-Analyzers/04-Analyzers.csproj
+++ b/tests/nuget-client/04-Analyzers/04-Analyzers.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/04-Analyzers/Program.cs
+++ b/tests/nuget-client/04-Analyzers/Program.cs
@@ -1,0 +1,9 @@
+namespace Analyzers;
+
+public class Program
+{
+    public static void Main()
+    {
+        System.Console.WriteLine("Hello");
+    }
+}

--- a/tests/nuget-client/05-SourceGen/05-SourceGen.csproj
+++ b/tests/nuget-client/05-SourceGen/05-SourceGen.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/05-SourceGen/Program.cs
+++ b/tests/nuget-client/05-SourceGen/Program.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace SourceGen;
+
+[JsonSerializable(typeof(Forecast))]
+public partial class AppJsonContext : JsonSerializerContext { }
+
+public record Forecast(string Summary, int Temp);
+
+public class Program
+{
+    public static void Main()
+    {
+        var f = new Forecast("Hot", 35);
+        Console.WriteLine(JsonSerializer.Serialize(f, AppJsonContext.Default.Forecast));
+    }
+}

--- a/tests/nuget-client/06-SemVer2/06-SemVer2.csproj
+++ b/tests/nuget-client/06-SemVer2/06-SemVer2.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.1.24431.7" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/07-VersionRanges/07-VersionRanges.csproj
+++ b/tests/nuget-client/07-VersionRanges/07-VersionRanges.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0,14.0)" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/08-CaseInsensitive/08-CaseInsensitive.csproj
+++ b/tests/nuget-client/08-CaseInsensitive/08-CaseInsensitive.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NEWTONSOFT.JSON" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/09-LockFile/09-LockFile.csproj
+++ b/tests/nuget-client/09-LockFile/09-LockFile.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/10-DeepTransitive/10-DeepTransitive.csproj
+++ b/tests/nuget-client/10-DeepTransitive/10-DeepTransitive.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.11" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/11-ChocolateyAlias/11-ChocolateyAlias.csproj
+++ b/tests/nuget-client/11-ChocolateyAlias/11-ChocolateyAlias.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+</Project>

--- a/tests/nuget-client/run-tests.sh
+++ b/tests/nuget-client/run-tests.sh
@@ -70,6 +70,12 @@ export MSBUILDDISABLENODEREUSE=1
 cleanup() {
     [ -n "$NORA_PID" ] && kill "$NORA_PID" 2>/dev/null && wait "$NORA_PID" 2>/dev/null || true
     rm -rf "$STORAGE_DIR" "$NUGET_PACKAGES"
+    # Clean generated NuGet.Config and build artifacts
+    rm -f "$SCRIPT_DIR/NuGet.Config"
+    rm -f "$SCRIPT_DIR/11-ChocolateyAlias/NuGet.Config"
+    for d in "$SCRIPT_DIR"/[0-9]*; do
+        rm -rf "$d/obj" "$d/bin" 2>/dev/null || true
+    done
 }
 trap cleanup EXIT
 
@@ -174,6 +180,29 @@ start_nora env \
     NORA_NUGET_METADATA_TTL=300
 
 pass "Nora started on port $PORT"
+
+# Generate NuGet.Config pointing all projects to Nora
+cat > "$SCRIPT_DIR/NuGet.Config" <<NUGETCFG
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nora" value="$BASE/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+NUGETCFG
+
+# 11-ChocolateyAlias uses the /chocolatey/ alias endpoint
+cat > "$SCRIPT_DIR/11-ChocolateyAlias/NuGet.Config" <<CHOCOCFG
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nora-choco" value="$BASE/chocolatey/v3/index.json" />
+  </packageSources>
+</configuration>
+CHOCOCFG
+
 echo ""
 
 # =========================================================================


### PR DESCRIPTION
## Summary

- NuGet V3 spec compliance sprint: 15 fixes (#377-#425) — URL rewriting, gzip registration, semVerLevel, Chocolatey aliases, serve-stale, autocomplete fallback, deprecation pass-through
- Cargo ETag + HTTP 304 for sparse index (#397)
- Upstream URL leak detection Prometheus metric (#386)
- PyPI PEP 691 typed structs (#389, #398)
- 11 dotnet E2E test fixture projects + CHANGELOG update

## Quality

- `make release VERSION=0.9.1` — all gates passed (version-check, fmt, clippy, 1049 tests, coherence, lock-audit, verify-changelog)
- NuGet E2E 35/36 PASS including air-gap stale serve