### PR TITLE
feat(metrics): wire P0 Prometheus metrics — cache, upstream duration, downloads, storage

### DIFF
--- a/nora-registry/src/dashboard_metrics.rs
+++ b/nora-registry/src/dashboard_metrics.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
+use crate::metrics::{CACHE_REQUESTS, DOWNLOADS_TOTAL, UPLOADS_TOTAL};
 use crate::registry_type::RegistryType;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -159,19 +160,23 @@ impl DashboardMetrics {
     pub fn record_download(&self, registry: &str) {
         self.downloads.fetch_add(1, Ordering::Relaxed);
         self.registry_downloads.inc(registry);
+        DOWNLOADS_TOTAL.with_label_values(&[registry]).inc();
     }
 
     pub fn record_upload(&self, registry: &str) {
         self.uploads.fetch_add(1, Ordering::Relaxed);
         self.registry_uploads.inc(registry);
+        UPLOADS_TOTAL.with_label_values(&[registry]).inc();
     }
 
-    pub fn record_cache_hit(&self) {
+    pub fn record_cache_hit(&self, registry: &str) {
         self.cache_hits.fetch_add(1, Ordering::Relaxed);
+        CACHE_REQUESTS.with_label_values(&[registry, "hit"]).inc();
     }
 
-    pub fn record_cache_miss(&self) {
+    pub fn record_cache_miss(&self, registry: &str) {
         self.cache_misses.fetch_add(1, Ordering::Relaxed);
+        CACHE_REQUESTS.with_label_values(&[registry, "miss"]).inc();
     }
 
     pub fn cache_hit_rate(&self) -> f64 {
@@ -271,16 +276,16 @@ mod tests {
     #[test]
     fn test_cache_hit_rate_all_hits() {
         let m = DashboardMetrics::new();
-        m.record_cache_hit();
-        m.record_cache_hit();
+        m.record_cache_hit("docker");
+        m.record_cache_hit("docker");
         assert_eq!(m.cache_hit_rate(), 100.0);
     }
 
     #[test]
     fn test_cache_hit_rate_mixed() {
         let m = DashboardMetrics::new();
-        m.record_cache_hit();
-        m.record_cache_miss();
+        m.record_cache_hit("npm");
+        m.record_cache_miss("npm");
         assert_eq!(m.cache_hit_rate(), 50.0);
     }
 
@@ -315,7 +320,7 @@ mod tests {
             m.record_download("docker");
             m.record_download("docker");
             m.record_upload("maven");
-            m.record_cache_hit();
+            m.record_cache_hit("docker");
             m.save().await;
         }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1118,9 +1118,12 @@ async fn run_server(mut config: Config, storage: Storage) {
             registry::docker::cleanup_expired_sessions(&metrics_state.upload_sessions);
             metrics_state.auth_failures.cleanup();
 
-            // Every 60s (every other tick): refresh S3 total_size cache
+            // Every 60s (every other tick): refresh S3 total_size cache + storage gauge
             if tick_count.is_multiple_of(2) {
                 metrics_state.storage.refresh_total_size_cache().await;
+                metrics::STORAGE_BYTES
+                    .with_label_values(&["total"])
+                    .set(metrics_state.storage.total_size().await as i64);
             }
 
             // Every 5 minutes (tick_count % 10 == 0): evict unused publish locks

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -13,8 +13,8 @@ use axum::{
 use lazy_static::lazy_static;
 use memchr::memmem;
 use prometheus::{
-    register_histogram_vec, register_int_counter_vec, Encoder, HistogramVec, IntCounterVec,
-    TextEncoder,
+    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Encoder,
+    HistogramVec, IntCounterVec, IntGaugeVec, TextEncoder,
 };
 use std::sync::Arc;
 use std::time::Instant;
@@ -78,6 +78,35 @@ lazy_static! {
         "Upstream hostname detected in outgoing response body",
         &["registry"]
     ).expect("failed to create UPSTREAM_URL_LEAK_TOTAL metric at startup");
+
+    /// Upstream proxy request latency (#431)
+    pub static ref UPSTREAM_REQUEST_DURATION: HistogramVec = register_histogram_vec!(
+        "nora_upstream_request_duration_seconds",
+        "Upstream proxy request latency in seconds",
+        &["registry", "status"],
+        vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0]
+    ).expect("failed to create UPSTREAM_REQUEST_DURATION metric at startup");
+
+    /// Total artifact downloads by registry (#431)
+    pub static ref DOWNLOADS_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "nora_downloads_total",
+        "Total artifact downloads",
+        &["registry"]
+    ).expect("failed to create DOWNLOADS_TOTAL metric at startup");
+
+    /// Total artifact uploads by registry (#431)
+    pub static ref UPLOADS_TOTAL: IntCounterVec = register_int_counter_vec!(
+        "nora_uploads_total",
+        "Total artifact uploads",
+        &["registry"]
+    ).expect("failed to create UPLOADS_TOTAL metric at startup");
+
+    /// Storage size in bytes by registry (#431)
+    pub static ref STORAGE_BYTES: IntGaugeVec = register_int_gauge_vec!(
+        "nora_storage_bytes",
+        "Storage size in bytes by registry",
+        &["registry"]
+    ).expect("failed to create STORAGE_BYTES metric at startup");
 }
 
 /// Maximum response body size to scan for upstream URL leaks (2 MB).

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -236,7 +236,7 @@ async fn download_tarball(
         }
 
         state.metrics.record_download("ansible");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("ansible");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             filename,
@@ -268,7 +268,7 @@ async fn download_tarball(
     {
         Ok(bytes) => {
             state.metrics.record_download("ansible");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("ansible");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 filename,
@@ -311,7 +311,7 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
             let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
 
             state.metrics.record_download("ansible");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("ansible");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact_name.to_string(),

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -106,7 +106,7 @@ async fn sparse_index(
     let index_key = format!("cargo/index/{}/{}", expected_prefix, crate_name);
     if let Ok(data) = state.storage.get(&index_key).await {
         state.metrics.record_download("cargo");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("cargo");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             crate_name.to_string(),
@@ -147,7 +147,7 @@ async fn sparse_index(
     {
         Ok(data) => {
             state.metrics.record_download("cargo");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("cargo");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 crate_name.to_string(),
@@ -294,7 +294,7 @@ async fn download(
         }
 
         state.metrics.record_download("cargo");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("cargo");
         state.activity.push(ActivityEntry::new(
             ActionType::Pull,
             format!("{}@{}", crate_name, version),
@@ -347,7 +347,7 @@ async fn download(
         Ok(data) => {
             state.spawn_cache("cargo", key.clone(), Bytes::from(data.clone()));
             state.metrics.record_download("cargo");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("cargo");
             state.activity.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("{}@{}", crate_name, version),

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -189,7 +189,7 @@ async fn recipe_latest(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("conan");
                 return with_json(data.to_vec());
             }
         }
@@ -222,7 +222,7 @@ async fn recipe_revisions(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("conan");
                 return with_json(data.to_vec());
             }
         }
@@ -259,7 +259,7 @@ async fn recipe_file_list(
     // Immutable: if cached, serve directly
     if let Ok(data) = state.storage.get(&storage_key).await {
         state.metrics.record_download("conan");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("conan");
         return with_json(data.to_vec());
     }
 
@@ -333,7 +333,7 @@ async fn recipe_file_download(
         }
 
         state.metrics.record_download("conan");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("conan");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
@@ -364,7 +364,7 @@ async fn recipe_file_download(
     {
         Ok(bytes) => {
             state.metrics.record_download("conan");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("conan");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
@@ -421,7 +421,7 @@ async fn package_latest(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("conan");
                 return with_json(data.to_vec());
             }
         }
@@ -472,7 +472,7 @@ async fn package_revisions(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("conan");
                 return with_json(data.to_vec());
             }
         }
@@ -524,7 +524,7 @@ async fn package_file_list(
     // Immutable
     if let Ok(data) = state.storage.get(&storage_key).await {
         state.metrics.record_download("conan");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("conan");
         return with_json(data.to_vec());
     }
 
@@ -607,7 +607,7 @@ async fn package_file_download(
         }
 
         state.metrics.record_download("conan");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("conan");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
@@ -640,7 +640,7 @@ async fn package_file_download(
     {
         Ok(bytes) => {
             state.metrics.record_download("conan");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("conan");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
@@ -686,7 +686,7 @@ async fn fetch_and_cache_json(
     {
         Ok(text) => {
             state.metrics.record_download("conan");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("conan");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact.to_string(),
@@ -729,7 +729,7 @@ async fn fetch_and_cache_immutable_json(
     {
         Ok(text) => {
             state.metrics.record_download("conan");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("conan");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact.to_string(),

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -559,7 +559,7 @@ async fn download_blob(
         }
 
         state.metrics.record_download("docker");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("docker");
         state.activity.push(ActivityEntry::new(
             ActionType::Pull,
             format!("{}@{}", name, &digest[..19.min(digest.len())]),
@@ -600,7 +600,7 @@ async fn download_blob(
         {
             Ok(data) => {
                 state.metrics.record_download("docker");
-                state.metrics.record_cache_miss();
+                state.metrics.record_cache_miss("docker");
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     format!("{}@{}", name, &digest[..19.min(digest.len())]),
@@ -1113,7 +1113,7 @@ async fn get_manifest(
         {
             Ok((data, content_type)) => {
                 state.metrics.record_download("docker");
-                state.metrics.record_cache_miss();
+                state.metrics.record_cache_miss("docker");
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     format!("{}:{}", name, reference),
@@ -1220,7 +1220,7 @@ async fn get_manifest(
             {
                 Ok((data, content_type)) => {
                     state.metrics.record_download("docker");
-                    state.metrics.record_cache_miss();
+                    state.metrics.record_cache_miss("docker");
                     state.activity.push(ActivityEntry::new(
                         ActionType::ProxyFetch,
                         format!("{}:{}", name, reference),
@@ -1326,7 +1326,7 @@ fn serve_cached_manifest(
     }
 
     state.metrics.record_download("docker");
-    state.metrics.record_cache_hit();
+    state.metrics.record_cache_hit("docker");
     state.activity.push(ActivityEntry::new(
         ActionType::Pull,
         format!("{}:{}", name, reference),

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -68,7 +68,7 @@ async fn fetch_index(state: &Arc<AppState>, filename: &str) -> Response {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.gems.metadata_ttl) {
                 state.metrics.record_download("gems");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("gems");
                 state.activity.push(ActivityEntry::new(
                     ActionType::CacheHit,
                     filename.to_string(),
@@ -96,7 +96,7 @@ async fn fetch_index(state: &Arc<AppState>, filename: &str) -> Response {
     {
         Ok(bytes) => {
             state.metrics.record_download("gems");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("gems");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 filename.to_string(),
@@ -151,7 +151,7 @@ async fn compact_index(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.gems.metadata_ttl) {
                 state.metrics.record_download("gems");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("gems");
                 state.activity.push(ActivityEntry::new(
                     ActionType::CacheHit,
                     name.clone(),
@@ -179,7 +179,7 @@ async fn compact_index(
     {
         Ok(text) => {
             state.metrics.record_download("gems");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("gems");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 name,
@@ -259,7 +259,7 @@ async fn download_gem(
         }
 
         state.metrics.record_download("gems");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("gems");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
@@ -285,7 +285,7 @@ async fn download_gem(
     {
         Ok(bytes) => {
             state.metrics.record_download("gems");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("gems");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
@@ -334,7 +334,7 @@ async fn download_gemspec(
     // Immutable cache
     if let Ok(data) = state.storage.get(&storage_key).await {
         state.metrics.record_download("gems");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("gems");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
@@ -363,7 +363,7 @@ async fn download_gemspec(
     {
         Ok(bytes) => {
             state.metrics.record_download("gems");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("gems");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -119,7 +119,7 @@ async fn handle(
         }
 
         state.metrics.record_download("go");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("go");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             format_artifact(&module_encoded, &file),
@@ -192,7 +192,7 @@ async fn handle(
             }
 
             state.metrics.record_download("go");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("go");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format_artifact(&module_encoded, &file),

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -168,7 +168,7 @@ async fn download(
         }
 
         state.metrics.record_download("maven");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("maven");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact_name,
@@ -196,7 +196,7 @@ async fn download(
         {
             Ok(data) => {
                 state.metrics.record_download("maven");
-                state.metrics.record_cache_miss();
+                state.metrics.record_cache_miss("maven");
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     artifact_name,

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -34,10 +34,11 @@ pub use terraform::routes as terraform_routes;
 
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
+use crate::metrics::UPSTREAM_REQUEST_DURATION;
 use crate::AppState;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// 405 Method Not Allowed with `Allow` header (RFC 9110 §15.5.6).
 pub(crate) fn method_not_allowed(allow: &'static str) -> Response {
@@ -109,9 +110,14 @@ where
             request = request.header(key, val);
         }
 
+        let upstream_start = Instant::now();
         match request.send().await {
             Ok(response) => {
+                let elapsed = upstream_start.elapsed().as_secs_f64();
                 if response.status().is_success() {
+                    UPSTREAM_REQUEST_DURATION
+                        .with_label_values(&[registry, "2xx"])
+                        .observe(elapsed);
                     let result = extract(response)
                         .await
                         .map_err(|e| ProxyError::Network(e.to_string()));
@@ -122,17 +128,31 @@ where
                 }
                 let status = response.status().as_u16();
                 if (400..500).contains(&status) {
+                    UPSTREAM_REQUEST_DURATION
+                        .with_label_values(&[registry, "4xx"])
+                        .observe(elapsed);
                     return Err(ProxyError::NotFound);
                 }
                 if attempt == 0 {
+                    UPSTREAM_REQUEST_DURATION
+                        .with_label_values(&[registry, "5xx"])
+                        .observe(elapsed);
                     tracing::debug!(url, status, "upstream 5xx, retrying in 1s");
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     continue;
                 }
+                UPSTREAM_REQUEST_DURATION
+                    .with_label_values(&[registry, "5xx"])
+                    .observe(elapsed);
                 cb.record_failure(registry);
                 return Err(ProxyError::Upstream(status));
             }
             Err(e) => {
+                let elapsed = upstream_start.elapsed().as_secs_f64();
+                let status_label = if e.is_timeout() { "timeout" } else { "error" };
+                UPSTREAM_REQUEST_DURATION
+                    .with_label_values(&[registry, status_label])
+                    .observe(elapsed);
                 if attempt == 0 {
                     tracing::debug!(url, error = %e, "upstream error, retrying in 1s");
                     tokio::time::sleep(Duration::from_secs(1)).await;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -157,7 +157,7 @@ async fn handle_request(
         }
 
         state.metrics.record_download("npm");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("npm");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             package_name,
@@ -200,7 +200,7 @@ async fn handle_request(
                     });
 
                     state.metrics.record_download("npm");
-                    state.metrics.record_cache_miss();
+                    state.metrics.record_cache_miss("npm");
                     state.activity.push(ActivityEntry::new(
                         ActionType::ProxyFetch,
                         package_name,

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -261,7 +261,7 @@ async fn search_query(
             let upstream = upstream_url(&state);
             let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
             state.metrics.record_download("nuget");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("nuget");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("search?{}", qs.chars().take(50).collect::<String>()),
@@ -336,7 +336,7 @@ async fn autocomplete_query(
             let upstream = upstream_url(&state);
             let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
             state.metrics.record_download("nuget");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("nuget");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("autocomplete?{}", qs.chars().take(50).collect::<String>()),
@@ -403,7 +403,7 @@ async fn registration_index(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
                 state.metrics.record_download("nuget");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("nuget");
                 let text = String::from_utf8_lossy(data);
                 let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
                 return with_json_gzip(rewritten.into_bytes());
@@ -430,7 +430,7 @@ async fn registration_index(
     {
         Ok(text) => {
             state.metrics.record_download("nuget");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("nuget");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 id_lower.clone(),
@@ -489,7 +489,7 @@ async fn registration_page(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
                 state.metrics.record_download("nuget");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("nuget");
                 let text = String::from_utf8_lossy(data);
                 let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
                 return with_json_gzip(rewritten.into_bytes());
@@ -518,7 +518,7 @@ async fn registration_page(
     {
         Ok(text) => {
             state.metrics.record_download("nuget");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("nuget");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/page/{}/{}", id_lower, lower, upper),
@@ -578,7 +578,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.nuget.metadata_ttl) {
                 state.metrics.record_download("nuget");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("nuget");
                 return with_json(data.to_vec());
             }
         }
@@ -604,7 +604,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
     {
         Ok(text) => {
             state.metrics.record_download("nuget");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("nuget");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/versions", id_lower),
@@ -688,7 +688,7 @@ async fn flatcontainer_download(
         }
 
         state.metrics.record_download("nuget");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("nuget");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             format!("{}/{}", id_lower, filename),
@@ -743,7 +743,7 @@ async fn flatcontainer_download(
     {
         Ok(bytes) => {
             state.metrics.record_download("nuget");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("nuget");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}", id_lower, filename),

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -322,7 +322,7 @@ async fn download_archive(
         }
 
         state.metrics.record_download("pub");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("pub");
         state.activity.push(ActivityEntry::new(
             ActionType::Pull,
             format!("{}@{}", package, version),
@@ -374,7 +374,7 @@ async fn download_archive(
             state.repo_index.invalidate("pub");
 
             state.metrics.record_download("pub");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("pub");
             state.activity.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("{}@{}", package, version),

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -249,7 +249,7 @@ async fn download_file(
         }
 
         state.metrics.record_download("pypi");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("pypi");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             format!("{}/{}", name, filename),
@@ -301,7 +301,7 @@ async fn download_file(
                     {
                         Ok(data) => {
                             state.metrics.record_download("pypi");
-                            state.metrics.record_cache_miss();
+                            state.metrics.record_cache_miss("pypi");
                             state.activity.push(ActivityEntry::new(
                                 ActionType::ProxyFetch,
                                 format!("{}/{}", name, filename),

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -117,7 +117,7 @@ async fn provider_versions(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("terraform");
                 return with_json(data.to_vec());
             }
         }
@@ -144,7 +144,7 @@ async fn provider_versions(
     {
         Ok(text) => {
             state.metrics.record_download("terraform");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("terraform");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}", ns, ptype),
@@ -212,7 +212,7 @@ async fn provider_download_meta(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("terraform");
                 return with_json(data.to_vec());
             }
         }
@@ -245,7 +245,7 @@ async fn provider_download_meta(
             let rewritten = rewrite_download_url(&text, &base_url, &ns, &ptype, &ver);
 
             state.metrics.record_download("terraform");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("terraform");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
@@ -283,7 +283,7 @@ async fn provider_download_binary(
     // Immutable: if cached, serve directly
     if let Ok(data) = state.storage.get(&storage_key).await {
         state.metrics.record_download("terraform");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("terraform");
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             path.clone(),
@@ -318,7 +318,7 @@ async fn provider_download_binary(
     {
         Ok(bytes) => {
             state.metrics.record_download("terraform");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("terraform");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 path,
@@ -362,7 +362,7 @@ async fn module_versions(
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
-                state.metrics.record_cache_hit();
+                state.metrics.record_cache_hit("terraform");
                 return with_json(data.to_vec());
             }
         }
@@ -390,7 +390,7 @@ async fn module_versions(
     {
         Ok(text) => {
             state.metrics.record_download("terraform");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("terraform");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}/{}", ns, name, provider),
@@ -440,7 +440,7 @@ async fn module_download(
         let rewritten =
             rewrite_module_source_url(&original_url, &base_url, &ns, &name, &provider, &ver);
         state.metrics.record_download("terraform");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("terraform");
         return (
             StatusCode::NO_CONTENT,
             [("x-terraform-get", rewritten.as_str())],
@@ -532,7 +532,7 @@ async fn module_source_download(
     // Immutable: if cached, serve directly
     if let Ok(data) = state.storage.get(&storage_key).await {
         state.metrics.record_download("terraform");
-        state.metrics.record_cache_hit();
+        state.metrics.record_cache_hit("terraform");
         return with_binary(data.to_vec());
     }
 
@@ -566,7 +566,7 @@ async fn module_source_download(
     {
         Ok(bytes) => {
             state.metrics.record_download("terraform");
-            state.metrics.record_cache_miss();
+            state.metrics.record_cache_miss("terraform");
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}/{} v{}", ns, name, provider, ver),


### PR DESCRIPTION
## Summary
- Wire `nora_cache_requests_total` — was declared in metrics.rs but never instrumented. Added `registry` param to `record_cache_hit`/`record_cache_miss` for per-registry labels
- Add `nora_upstream_request_duration_seconds` histogram in `proxy_fetch_core()` — single instrumentation point for all 13 registries. Labels: `registry`, `status` (2xx/4xx/5xx/timeout/error)
- Add `nora_downloads_total` and `nora_uploads_total` counters via `DashboardMetrics` — Prometheus increments alongside existing dashboard persistence
- Add `nora_storage_bytes` gauge updated in tick-loop (60s refresh)

## Changes
- `metrics.rs`: 4 new metric definitions (histogram + 2 counters + 1 gauge)
- `dashboard_metrics.rs`: Prometheus `.inc()` inside `record_download/upload/cache_hit/cache_miss`
- `registry/mod.rs`: `proxy_fetch_core()` instrumented with upstream duration timing
- `main.rs`: STORAGE_BYTES gauge set in existing tick-loop
- 12 registry modules: `record_cache_hit()`→`record_cache_hit("registry")` (signature change)

## Test plan
- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test --package nora-registry` — 1057 tests pass
- [x] Semgrep — no new findings
- [x] Negative security tests — 10 pass / 0 fail
- [x] API contract tests — 28 pass / 0 fail
- [x] OCI conformance — 12 pass / 0 fail

Closes #431