### PR TITLE
fix: storage metrics wiring + dashboard hardening

### DIFF
--- a/dist/grafana-dashboard.json
+++ b/dist/grafana-dashboard.json
@@ -1,269 +1,1041 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__requires": [
-    { "type": "grafana", "id": "grafana", "name": "Grafana", "version": "10.0.0" },
-    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" },
-    { "type": "panel", "id": "timeseries", "name": "Time series", "version": "" },
-    { "type": "panel", "id": "stat", "name": "Stat", "version": "" },
-    { "type": "panel", "id": "table", "name": "Table", "version": "" },
-    { "type": "panel", "id": "gauge", "name": "Gauge", "version": "" }
-  ],
   "id": null,
   "uid": "nora-overview",
   "title": "NORA — Artifact Registry",
   "description": "Overview dashboard for NORA artifact registry — HTTP traffic, cache, upstream, storage, security",
-  "tags": ["nora", "registry", "prometheus"],
+  "tags": [
+    "nora",
+    "registry",
+    "prometheus"
+  ],
   "timezone": "browser",
   "editable": true,
   "graphTooltip": 1,
   "refresh": "30s",
   "schemaVersion": 39,
   "version": 1,
-  "time": { "from": "now-1h", "to": "now" },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
   "fiscalYearStartMonth": 0,
   "liveNow": false,
   "templating": {
     "list": [
       {
         "current": {},
-        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-        "definition": "label_values(nora_http_requests_total, registry)",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "P4169E866C3094E38"
+        },
+        "definition": "label_values(nora_http_requests_total{registry!~\"other|ui\"}, registry)",
         "name": "registry",
         "label": "Registry",
         "type": "query",
         "includeAll": true,
         "multi": true,
-        "allValue": ".*",
+        "allValue": "npm|pypi|cargo|go|docker|maven|raw|gems|terraform|ansible|nuget|pub|conan",
         "refresh": 2,
-        "sort": 1
+        "sort": 1,
+        "regex": "/^(?!other$|ui$).*/"
       }
     ]
   },
-  "annotations": { "list": [] },
+  "annotations": {
+    "list": []
+  },
   "panels": [
     {
       "title": "Request Rate",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "reqps", "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 100 }, { "color": "red", "value": 500 }] } },
+        "defaults": {
+          "unit": "reqps",
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 100
+              },
+              {
+                "color": "red",
+                "value": 500
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "targets": [{ "expr": "sum(rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))", "legendFormat": "req/s" }],
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "targets": [
+        {
+          "expr": "sum(rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "req/s",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 1
     },
     {
       "title": "Error Rate (5xx)",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "max": 1, "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.01 }, { "color": "red", "value": 0.05 }] } },
+        "defaults": {
+          "unit": "percentunit",
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.05
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "targets": [{ "expr": "sum(rate(nora_http_requests_total{registry=~\"$registry\",status=~\"5..\"}[5m])) / sum(rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))", "legendFormat": "error %" }],
-      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "targets": [
+        {
+          "expr": "sum(rate(nora_http_requests_total{registry=~\"$registry\",status=~\"5..\"}[5m])) / sum(rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "error %",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 2
     },
     {
       "title": "P50 Latency",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "red", "value": 2 }] } },
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "targets": [{ "expr": "histogram_quantile(0.5, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))", "legendFormat": "p50" }],
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.5, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 3
     },
     {
       "title": "P99 Latency",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "s", "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 5 }] } },
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "targets": [{ "expr": "histogram_quantile(0.99, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))", "legendFormat": "p99" }],
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 4
     },
     {
       "title": "Cache Hit Rate",
       "type": "gauge",
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "percentunit", "min": 0, "max": 1, "thresholds": { "steps": [{ "color": "red", "value": null }, { "color": "yellow", "value": 0.5 }, { "color": "green", "value": 0.8 }] } },
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.5
+              },
+              {
+                "color": "green",
+                "value": 0.8
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "targets": [{ "expr": "sum(rate(nora_cache_requests_total{registry=~\"$registry\",result=\"hit\"}[5m])) / sum(rate(nora_cache_requests_total{registry=~\"$registry\"}[5m]))", "legendFormat": "hit rate" }],
-      "options": { "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "targets": [
+        {
+          "expr": "sum(rate(nora_cache_requests_total{registry=~\"$registry\",result=\"hit\"}[5m])) / sum(rate(nora_cache_requests_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "hit rate",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 5
     },
     {
       "title": "Storage Used",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
       "fieldConfig": {
-        "defaults": { "unit": "bytes", "thresholds": { "steps": [{ "color": "green", "value": null }, { "color": "yellow", "value": 10737418240 }, { "color": "red", "value": 107374182400 }] } },
+        "defaults": {
+          "unit": "bytes",
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 10737418240
+              },
+              {
+                "color": "red",
+                "value": 107374182400
+              }
+            ]
+          }
+        },
         "overrides": []
       },
-      "targets": [{ "expr": "sum(nora_storage_bytes{registry=~\"$registry\"})", "legendFormat": "total" }],
-      "options": { "colorMode": "background", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "targets": [
+        {
+          "expr": "nora_storage_bytes{registry=\"total\"}",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 6
     },
     {
       "title": "HTTP Request Rate by Registry",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "stacking": { "mode": "normal" } } }, "overrides": [] },
-      "targets": [{ "expr": "sum by (registry) (rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))", "legendFormat": "{{ registry }}" }],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] } }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (registry) (rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "{{ registry }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "id": 7
     },
     {
       "title": "HTTP Latency (p50 / p95 / p99)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
       "targets": [
-        { "expr": "histogram_quantile(0.50, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))", "legendFormat": "p50" },
-        { "expr": "histogram_quantile(0.95, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))", "legendFormat": "p95" },
-        { "expr": "histogram_quantile(0.99, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))", "legendFormat": "p99" }
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(nora_http_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
       ],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "id": 8
     },
     {
       "title": "Error Rate by Registry (5xx)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "percentunit", "custom": { "drawStyle": "line", "fillOpacity": 15 } }, "overrides": [] },
-      "targets": [{ "expr": "sum by (registry) (rate(nora_http_requests_total{registry=~\"$registry\",status=~\"5..\"}[5m])) / sum by (registry) (rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))", "legendFormat": "{{ registry }}" }],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right" } }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (registry) (rate(nora_http_requests_total{registry=~\"$registry\",status=~\"5..\"}[5m])) / sum by (registry) (rate(nora_http_requests_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "{{ registry }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right"
+        }
+      },
+      "id": 9
     },
     {
       "title": "Upstream Proxy Latency by Registry",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 10 } }, "overrides": [] },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 12
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10
+          }
+        },
+        "overrides": []
+      },
       "targets": [
-        { "expr": "histogram_quantile(0.50, sum by (registry, le) (rate(nora_upstream_request_duration_seconds_bucket{registry=~\"$registry\"}[5m]))","legendFormat": "{{ registry }} p50" },
-        { "expr": "histogram_quantile(0.99, sum by (registry, le) (rate(nora_upstream_request_duration_seconds_bucket{registry=~\"$registry\"}[5m]))","legendFormat": "{{ registry }} p99" }
+        {
+          "expr": "histogram_quantile(0.50, sum by (registry, le) (rate(nora_upstream_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])))",
+          "legendFormat": "{{ registry }} p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (registry, le) (rate(nora_upstream_request_duration_seconds_bucket{registry=~\"$registry\"}[5m])))",
+          "legendFormat": "{{ registry }} p99",
+          "refId": "B"
+        }
       ],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "id": 10
     },
     {
       "title": "Cache Hit / Miss Rate",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "bars", "fillOpacity": 60, "stacking": { "mode": "normal" } } }, "overrides": [
-        { "matcher": { "id": "byName", "options": "miss" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
-        { "matcher": { "id": "byName", "options": "hit" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] }
-      ] },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "miss"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hit"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "targets": [
-        { "expr": "sum(rate(nora_cache_requests_total{registry=~\"$registry\",result=\"hit\"}[5m]))", "legendFormat": "hit" },
-        { "expr": "sum(rate(nora_cache_requests_total{registry=~\"$registry\",result=\"miss\"}[5m]))", "legendFormat": "miss" }
+        {
+          "expr": "sum(rate(nora_cache_requests_total{registry=~\"$registry\",result=\"hit\"}[5m]))",
+          "legendFormat": "hit",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(rate(nora_cache_requests_total{registry=~\"$registry\",result=\"miss\"}[5m]))",
+          "legendFormat": "miss",
+          "refId": "B"
+        }
       ],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "id": 11
     },
     {
       "title": "Downloads / Uploads by Registry",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15, "stacking": { "mode": "normal" } } }, "overrides": [] },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
       "targets": [
-        { "expr": "sum by (registry) (rate(nora_downloads_total{registry=~\"$registry\"}[5m]))", "legendFormat": "{{ registry }} downloads" },
-        { "expr": "sum by (registry) (rate(nora_uploads_total{registry=~\"$registry\"}[5m]))", "legendFormat": "{{ registry }} uploads" }
+        {
+          "expr": "sum by (registry) (rate(nora_downloads_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "{{ registry }} downloads",
+          "refId": "A"
+        },
+        {
+          "expr": "sum by (registry) (rate(nora_uploads_total{registry=~\"$registry\"}[5m]))",
+          "legendFormat": "{{ registry }} uploads",
+          "refId": "B"
+        }
       ],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["mean", "max"] } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "mean",
+            "max"
+          ]
+        }
+      },
+      "id": 12
     },
     {
-      "title": "Storage by Registry",
+      "title": "Storage Total",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 28 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "line", "fillOpacity": 25, "stacking": { "mode": "normal" } } }, "overrides": [] },
-      "targets": [{ "expr": "nora_storage_bytes{registry=~\"$registry\"}", "legendFormat": "{{ registry }}" }],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] } }
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "stacking": {
+              "mode": "normal"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "nora_storage_bytes{registry=\"total\"}",
+          "legendFormat": "total",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 13
     },
     {
       "title": "Circuit Breaker State",
       "type": "table",
-      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 28 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": {}, "overrides": [
-        { "matcher": { "id": "byName", "options": "Value" }, "properties": [
-          { "id": "mappings", "value": [{ "type": "value", "options": { "0": { "text": "CLOSED", "color": "green" }, "1": { "text": "OPEN", "color": "red" }, "2": { "text": "HALF_OPEN", "color": "yellow" } } }] },
-          { "id": "custom.displayMode", "value": "color-background" }
-        ] }
-      ] },
-      "targets": [{ "expr": "nora_circuit_breaker_state", "legendFormat": "{{ registry }}", "format": "table", "instant": true }],
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "0": {
+                        "text": "CLOSED",
+                        "color": "green"
+                      },
+                      "1": {
+                        "text": "OPEN",
+                        "color": "red"
+                      },
+                      "2": {
+                        "text": "HALF_OPEN",
+                        "color": "yellow"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              }
+            ]
+          }
+        ]
+      },
+      "targets": [
+        {
+          "expr": "nora_circuit_breaker_state",
+          "legendFormat": "{{ registry }}",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
       "transformations": [
-        { "id": "organize", "options": { "excludeByName": { "Time": true, "__name__": true, "instance": true, "job": true }, "renameByName": { "registry": "Registry", "Value": "State" } } }
-      ]
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "instance": true,
+              "job": true
+            },
+            "renameByName": {
+              "registry": "Registry",
+              "Value": "State"
+            }
+          }
+        }
+      ],
+      "id": 14
     },
     {
       "title": "Security Alerts",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 28 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 60 } }, "overrides": [
-        { "matcher": { "id": "byName", "options": "URL leaks" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] },
-        { "matcher": { "id": "byName", "options": "CB rejections" }, "properties": [{ "id": "color", "value": { "fixedColor": "orange", "mode": "fixed" } }] }
-      ] },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 28
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "URL leaks"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CB rejections"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "targets": [
-        { "expr": "sum(rate(nora_response_upstream_url_leak_total{registry=~\"$registry\"}[5m]))", "legendFormat": "URL leaks" },
-        { "expr": "sum(rate(nora_circuit_breaker_rejections_total{registry=~\"$registry\"}[5m]))", "legendFormat": "CB rejections" }
+        {
+          "expr": "increase(nora_response_upstream_url_leak_total{registry=~\"$registry\"}[5m])",
+          "legendFormat": "URL leaks",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(nora_circuit_breaker_rejections_total{registry=~\"$registry\"}[5m])",
+          "legendFormat": "CB rejections",
+          "refId": "B"
+        }
       ],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "id": 15
     },
     {
       "title": "Retention & GC",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "bytes", "custom": { "drawStyle": "bars", "fillOpacity": 40 } }, "overrides": [] },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 40
+          }
+        },
+        "overrides": []
+      },
       "targets": [
-        { "expr": "increase(nora_retention_bytes_freed_total[1h])", "legendFormat": "retention freed" },
-        { "expr": "increase(nora_gc_bytes_freed_total[1h])", "legendFormat": "GC freed" }
+        {
+          "expr": "increase(nora_retention_bytes_freed_total[1h])",
+          "legendFormat": "retention freed",
+          "refId": "A"
+        },
+        {
+          "expr": "increase(nora_gc_bytes_freed_total[1h])",
+          "legendFormat": "GC freed",
+          "refId": "B"
+        }
       ],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "id": 16
     },
     {
       "title": "GC & Retention Last Run",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 36 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "dateTimeFromNow", "thresholds": { "steps": [{ "color": "green", "value": null }] } }, "overrides": [] },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "dateTimeFromNow",
+          "thresholds": {
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
       "targets": [
-        { "expr": "nora_retention_last_run_timestamp * 1000", "legendFormat": "Retention" },
-        { "expr": "nora_gc_last_run_timestamp * 1000", "legendFormat": "GC" }
+        {
+          "expr": "nora_retention_last_run_timestamp * 1000",
+          "legendFormat": "Retention",
+          "refId": "A"
+        },
+        {
+          "expr": "nora_gc_last_run_timestamp * 1000",
+          "legendFormat": "GC",
+          "refId": "B"
+        }
       ],
-      "options": { "colorMode": "value", "graphMode": "none", "reduceOptions": { "calcs": ["lastNotNull"] } }
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ]
+        }
+      },
+      "id": 17
     },
     {
       "title": "Storage Operations",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 36 },
-      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
-      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 15 } }, "overrides": [] },
-      "targets": [{ "expr": "sum by (operation) (rate(nora_storage_operations_total[5m]))", "legendFormat": "{{ operation }}" }],
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "list", "placement": "bottom" } }
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 36
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "P4169E866C3094E38"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops",
+          "decimals": 2,
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 15
+          }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "expr": "sum by (operation) (rate(nora_storage_operations_total[5m]))",
+          "legendFormat": "{{ operation }}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi"
+        },
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        }
+      },
+      "id": 18
     }
   ]
 }

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -107,7 +107,9 @@ impl Storage {
                 Ok(())
             }
             Err(e) => {
-                STORAGE_OPERATIONS.with_label_values(&["put", "error"]).inc();
+                STORAGE_OPERATIONS
+                    .with_label_values(&["put", "error"])
+                    .inc();
                 Err(e)
             }
         }
@@ -124,7 +126,9 @@ impl Storage {
                 Ok(data)
             }
             Err(e) => {
-                STORAGE_OPERATIONS.with_label_values(&["get", "error"]).inc();
+                STORAGE_OPERATIONS
+                    .with_label_values(&["get", "error"])
+                    .inc();
                 Err(e)
             }
         }
@@ -134,7 +138,9 @@ impl Storage {
         validate_storage_key(key)?;
         match self.inner.delete(key).await {
             Ok(()) => {
-                STORAGE_OPERATIONS.with_label_values(&["delete", "ok"]).inc();
+                STORAGE_OPERATIONS
+                    .with_label_values(&["delete", "ok"])
+                    .inc();
                 if let Some(ref pins) = self.pin_store {
                     pins.remove(key);
                 }
@@ -208,7 +214,9 @@ impl Storage {
                 Ok(())
             }
             Err(e) => {
-                STORAGE_OPERATIONS.with_label_values(&["put", "error"]).inc();
+                STORAGE_OPERATIONS
+                    .with_label_values(&["put", "error"])
+                    .inc();
                 Err(e)
             }
         }

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub use local::LocalStorage;
 pub use s3::S3Storage;
 
 use crate::hash_pin_store::HashPinStore;
+use crate::metrics::STORAGE_OPERATIONS;
 use crate::validation::{validate_storage_key, ValidationError};
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -97,29 +98,55 @@ impl Storage {
 
     pub async fn put(&self, key: &str, data: &[u8]) -> Result<()> {
         validate_storage_key(key)?;
-        self.inner.put(key, data).await?;
-        if let Some(ref pins) = self.pin_store {
-            pins.record(key, data);
+        match self.inner.put(key, data).await {
+            Ok(()) => {
+                STORAGE_OPERATIONS.with_label_values(&["put", "ok"]).inc();
+                if let Some(ref pins) = self.pin_store {
+                    pins.record(key, data);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS.with_label_values(&["put", "error"]).inc();
+                Err(e)
+            }
         }
-        Ok(())
     }
 
     pub async fn get(&self, key: &str) -> Result<Bytes> {
         validate_storage_key(key)?;
-        let data = self.inner.get(key).await?;
-        if let Some(ref pins) = self.pin_store {
-            pins.verify(key, &data);
+        match self.inner.get(key).await {
+            Ok(data) => {
+                STORAGE_OPERATIONS.with_label_values(&["get", "ok"]).inc();
+                if let Some(ref pins) = self.pin_store {
+                    pins.verify(key, &data);
+                }
+                Ok(data)
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS.with_label_values(&["get", "error"]).inc();
+                Err(e)
+            }
         }
-        Ok(data)
     }
 
     pub async fn delete(&self, key: &str) -> Result<()> {
         validate_storage_key(key)?;
-        self.inner.delete(key).await?;
-        if let Some(ref pins) = self.pin_store {
-            pins.remove(key);
+        match self.inner.delete(key).await {
+            Ok(()) => {
+                STORAGE_OPERATIONS.with_label_values(&["delete", "ok"]).inc();
+                if let Some(ref pins) = self.pin_store {
+                    pins.remove(key);
+                }
+                Ok(())
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS
+                    .with_label_values(&["delete", "error"])
+                    .inc();
+                Err(e)
+            }
         }
-        Ok(())
     }
 
     pub async fn list(&self, prefix: &str) -> Vec<String> {
@@ -175,6 +202,15 @@ impl Storage {
     /// not updated (re-reading gigabytes just to hash is wasteful).
     pub async fn put_from_path(&self, key: &str, src: &Path) -> Result<()> {
         validate_storage_key(key)?;
-        self.inner.put_from_path(key, src).await
+        match self.inner.put_from_path(key, src).await {
+            Ok(()) => {
+                STORAGE_OPERATIONS.with_label_values(&["put", "ok"]).inc();
+                Ok(())
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS.with_label_values(&["put", "error"]).inc();
+                Err(e)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Wire `STORAGE_OPERATIONS` counter into storage put/get/delete/put_from_path — previously declared but never incremented
- Fix Grafana dashboard: resolve datasource variable, fix PromQL syntax errors, filter system labels, improve number formatting

## Details

### storage/mod.rs
Increment `nora_storage_operations_total{operation, status}` on every storage call with `ok`/`error` status.

### grafana-dashboard.json
- Replace `${DS_PROMETHEUS}` with direct datasource UID (API imports don't resolve `__inputs`)
- Add panel `id` and target `refId` fields
- Fix missing closing paren in Upstream Proxy Latency PromQL
- Add `decimals: 2` to reqps/ops panels
- Security Alerts: `increase()` instead of `rate()` for whole numbers
- Filter `other`/`ui` system labels from registry variable
- Storage panels: hardcode `registry="total"` (per-registry breakdown: #440)

## Related issues

- Closes #440 (partial — dashboard workaround, code change tracked separately)
- Related: #439 (npm URL leaks), #441 (CB state metric), #442 (cargo API 404)

## Test plan

- [ ] Verify `nora_storage_operations_total` appears in `/metrics` after put/get
- [ ] Import dashboard JSON to Grafana — all 18 panels render with data
- [ ] Confirm `other`/`ui` not visible in registry dropdown
- [ ] Confirm upstream latency panel shows data (PromQL fix)