### PR TITLE
fix(ansible): post-parse validation and Galaxy spec name compliance

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -161,12 +161,16 @@ Caching proxy for galaxy.ansible.com. Collection tarballs are immutably cached.
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Collection list | Full | TTL-cached |
-| Collection detail | Full | TTL-cached |
-| Collection versions | Full | TTL-cached |
-| Version detail | Full | TTL-cached |
-| Tarball download | Full | Immutable cache |
+| API discovery | Full | `/ansible/` and `/ansible/api/` |
+| Collection list | Full | Short v3 and Pulp-style paths |
+| Collection detail | Full | URL rewriting |
+| Collection versions | Full | Paginated |
+| Version detail | Full | Curation checks |
+| Tarball download | Full | Immutable cache, both `/download/` and `/artifacts/` paths |
+| Tarball curation | Full | Blocklist/allowlist, integrity verification |
 | Collection publish | — | Proxy-only (read) |
+
+Namespace and collection name validation follows Galaxy spec (`[a-z0-9_]+`).
 
 Client: `ansible-galaxy collection install ns.name -s http://nora:4000/ansible/`
 

--- a/docs-site/src/content/docs/registries/ansible.md
+++ b/docs-site/src/content/docs/registries/ansible.md
@@ -1,0 +1,107 @@
+---
+title: Ansible Galaxy
+description: Caching proxy for Ansible Galaxy collections (API v3).
+---
+
+The Ansible Galaxy registry provides a transparent caching proxy for [galaxy.ansible.com](https://galaxy.ansible.com). Collection metadata is proxied with URL rewriting, and collection tarballs are immutably cached on first download.
+
+## Client Configuration
+
+Install a collection through NORA:
+
+```bash
+ansible-galaxy collection install community.general \
+  --server http://nora.example.com:4000/ansible/
+```
+
+Install a specific version:
+
+```bash
+ansible-galaxy collection install community.general:==12.2.0 \
+  --server http://nora.example.com:4000/ansible/
+```
+
+In `ansible.cfg`:
+
+```ini
+[galaxy]
+server_list = nora
+
+[galaxy_server.nora]
+url = http://nora.example.com:4000/ansible/
+```
+
+For AWX / Ansible Automation Platform, set the Galaxy Server URL to `http://nora.example.com:4000/ansible/` in the organization or project settings.
+
+## Upstream Proxy
+
+By default, NORA proxies to the public Ansible Galaxy (`https://galaxy.ansible.com`). To use a private Galaxy server (Automation Hub, Pulp):
+
+```bash
+export NORA_ANSIBLE_PROXY=https://hub.internal.example.com
+export NORA_ANSIBLE_PROXY_AUTH=user:password
+```
+
+NORA rewrites all upstream URLs in metadata responses to point through itself, so clients always download through the proxy.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| API discovery | Full | `/ansible/` and `/ansible/api/` |
+| Collection listing | Full | Short v3 and Pulp-style paths |
+| Collection detail | Full | URL rewriting |
+| Version listing | Full | Paginated |
+| Version detail | Full | Curation checks |
+| Tarball download | Full | Immutable cache, both `/download/` and `/artifacts/` paths |
+| Tarball curation | Full | Blocklist/allowlist with integrity verification |
+| Collection publish | -- | Proxy-only (read) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_ANSIBLE_ENABLED` | Enable Ansible Galaxy registry | `false` |
+| `NORA_ANSIBLE_PROXY` | Upstream Galaxy server URL | `https://galaxy.ansible.com` |
+| `NORA_ANSIBLE_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_ANSIBLE_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+
+**config.toml:**
+
+```toml
+[ansible]
+enabled = true
+proxy = "https://galaxy.ansible.com"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/ansible/` | GET | API discovery (`available_versions`) |
+| `/ansible/v3/collections/` | GET | List collections |
+| `/ansible/v3/collections/{ns}/{name}/` | GET | Collection detail |
+| `/ansible/v3/collections/{ns}/{name}/versions/` | GET | Version list (paginated) |
+| `/ansible/v3/collections/{ns}/{name}/versions/{ver}/` | GET | Version detail with `download_url` |
+| `/ansible/download/{ns}-{name}-{ver}.tar.gz` | GET | Download collection tarball |
+
+Full Pulp-style paths (`/ansible/api/v3/plugin/ansible/content/published/collections/index/...`) are also supported as aliases.
+
+## Caching Behavior
+
+- **Metadata** (collection list, detail, versions): proxied on every request with `Cache-Control: public, max-age=60, must-revalidate`.
+- **Tarballs**: cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+
+## Naming Constraints
+
+Ansible Galaxy namespace and collection names follow the pattern `[a-z0-9_]+` -- alphanumeric characters and underscores only. Hyphens are not allowed in namespace or collection names (they are used as separators in tarball filenames).
+
+The tarball filename format is `{namespace}-{name}-{version}.tar.gz`, for example `community-general-12.2.0.tar.gz`.
+
+## Known Limitations
+
+- Proxy-only: publishing collections through NORA is not supported. Use `ansible-galaxy collection publish` directly against Galaxy or Automation Hub.
+- No offline/air-gap mode for metadata: if the upstream is unreachable and the metadata is not cached, requests return 502.
+- Tarballs are cached indefinitely once downloaded. To force re-fetch, delete the file from storage (`ansible/download/{filename}`).

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -212,6 +212,10 @@ async fn download_tarball(
     }
     let (ns, name, ver) = (parts[0], parts[1], parts[2]);
 
+    if !is_valid_name(ns) || !is_valid_name(name) || !is_valid_version(ver) {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
     let storage_key = format!("ansible/download/{}", filename);
 
     // mtime fallback for hosted-only mode (proxy mtime = cache time, not publish time)
@@ -446,9 +450,7 @@ fn is_valid_name(name: &str) -> bool {
         && !name.contains('/')
         && !name.contains('\0')
         && !name.contains("..")
-        && name
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 fn is_valid_version(version: &str) -> bool {
@@ -478,7 +480,7 @@ mod tests {
     fn test_valid_names() {
         assert!(is_valid_name("community"));
         assert!(is_valid_name("ansible"));
-        assert!(is_valid_name("cloud-common"));
+        assert!(is_valid_name("cloud_common"));
     }
 
     #[test]
@@ -486,6 +488,17 @@ mod tests {
         assert!(!is_valid_name(""));
         assert!(!is_valid_name("../evil"));
         assert!(!is_valid_name("foo/bar"));
+        // Galaxy spec: namespaces/names use underscores, not hyphens
+        assert!(!is_valid_name("cloud-common"));
+    }
+
+    #[test]
+    fn test_valid_version() {
+        assert!(is_valid_version("7.0.0"));
+        assert!(is_valid_version("1.2.3"));
+        assert!(!is_valid_version(""));
+        assert!(!is_valid_version("../evil"));
+        assert!(!is_valid_version("foo/bar"));
     }
 
     #[test]
@@ -709,5 +722,32 @@ mod integration_tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_bytes(resp).await;
         assert_eq!(&body[..], b"tarball-v3");
+    }
+
+    #[tokio::test]
+    async fn test_ansible_download_rejects_invalid_name_parts() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+        });
+
+        // Path traversal in namespace
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/download/..%2F-name-1.0.0.tar.gz",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+
+        // Empty name part (double-hyphen)
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/download/community--1.0.0.tar.gz",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -4,12 +4,17 @@
 //! Ansible Galaxy collection proxy (API v3).
 //!
 //! Implements a caching proxy for galaxy.ansible.com:
-//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/
-//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/
-//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/versions/
-//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/index/{ns}/{name}/versions/{ver}/
-//!   GET /ansible/download/{ns}-{name}-{ver}.tar.gz — collection tarball (immutable)
-//!   GET /ansible/api/v3/plugin/ansible/content/published/collections/artifacts/{file} — alias
+//!   GET /ansible/                                         — API discovery
+//!   GET /ansible/v3/collections/                          — collection list (short path)
+//!   GET /ansible/v3/collections/{ns}/{name}/              — collection detail
+//!   GET /ansible/v3/collections/{ns}/{name}/versions/     — version list
+//!   GET /ansible/v3/collections/{ns}/{name}/versions/{ver}/ — version detail
+//!   GET /ansible/download/{ns}-{name}-{ver}.tar.gz        — tarball (immutable)
+//!   GET /ansible/api/v3/.../artifacts/{file}              — tarball alias (Galaxy format)
+//!
+//! Also supports full Pulp-style paths under /ansible/api/v3/plugin/ansible/...
+//!
+//! Namespace and collection names follow Galaxy spec: [a-z0-9_]+ (no hyphens).
 //!
 //! Client config:
 //!   ansible-galaxy collection install community.general -s http://nora:4000/ansible/


### PR DESCRIPTION
## Summary

- Add `is_valid_name`/`is_valid_version` checks to `download_tarball` handler after filename parsing — aligns with the pattern already used in `collection_detail`, `version_list`, and `version_detail` handlers
- Tighten `is_valid_name` to reject hyphens per Galaxy spec — Ansible Galaxy namespaces and collection names use `[a-z0-9_]+` only
- Add unit tests for `is_valid_version` and integration test for invalid download filename rejection

## Root cause

`download_tarball` was the only Ansible handler that parsed user input (filename → namespace/name/version) without validating the parsed components. Other handlers validate path parameters via `is_valid_name`/`is_valid_version` before use.

Additionally, `is_valid_name` accepted hyphens (`c == '-'`), which does not match the Ansible Galaxy naming spec (`[a-z0-9_]+`). Since the tarball format `{ns}-{name}-{ver}.tar.gz` uses hyphens as separators, accepting hyphens within name components would create ambiguity.

## Test plan

- [x] Unit test: `is_valid_name` rejects hyphens, accepts underscores
- [x] Unit test: `is_valid_version` validates format
- [x] Integration test: download rejects path traversal and empty name parts
- [x] All 1059 tests pass
- [x] cargo fmt / clippy clean
- [x] Semgrep: 0 new findings
- [x] arch-predict: 0 errors

Ref: #438