### PR TITLE
fix(pypi): URL-rewrite tests + bump v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Changelog
 ## [Unreleased]
 
+## [0.9.2] - 2026-05-23
+
+### Added
+- **Prometheus P0 metrics** — `nora_downloads_total`, `nora_uploads_total`, `nora_storage_bytes`, `nora_cache_requests_total`, `nora_upstream_request_duration_seconds` histogram with per-registry labels (#431, #432, #443)
+- **Grafana dashboard** — production-ready dashboard JSON in `dist/grafana-dashboard.json` with documentation (#436, #437)
+- **Ansible Galaxy v3 compliance** — pagination forwarding, artifact route alias, spec name validation (#433, #434, #438, #444, #445)
+- **.deb/.rpm packaging** — `nfpm` configuration for native Linux packages (#209, #435)
+- **Circuit breaker gauge initialization** — `nora_circuit_breaker_state` emits 0 (CLOSED) at startup for all enabled registries (#441)
+- **PyPI URL-rewrite tests** — 11 tests covering trailing-slash and double-slash regressions (#387)
+- 1086 total tests (up from 1049)
+
+### Fixed
+- **npm upstream URL leak (P0 security)** — metadata responses no longer expose `registry.npmjs.org` URLs (#439)
+- **Cargo sparse index `api` field** — `config.json` now returns correct `/cargo/api` path instead of `/cargo` (#442)
+- **PyPI trailing-slash URL rewrite** — response body URLs no longer contain double-slash `//simple` (#387)
+
+### Changed
+- Dashboard screenshot updated to v0.9.2 with populated metrics panels (#429, #430)
+- README and SECURITY.md synced with v0.9.2 (#428)
+
 ## [0.9.1] - 2026-05-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "arc-swap",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 rust-version = "1.75"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ docker run -d -p 4000:4000 \
 - ~~Outbound proxy, structured audit log~~ ✅ v0.8.3
 - ~~Circuit breaker, OIDC, hot reload, arm64, streaming uploads~~ ✅ v0.9.0
 - ~~NuGet V3 stabilization, Cargo ETag, 1049 tests~~ ✅ v0.9.1
+- ~~Prometheus metrics, Ansible Galaxy v3, security fixes, 1086 tests~~ ✅ v0.9.2
 - **Image Signing Policy** — cosign verification on upstream pulls
 - **Semver contract** — stable API, configuration format, and storage layout
 

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -22,7 +22,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.9.1",
+        version = "0.9.2",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
## Summary
- Add 11 URL-rewrite invariant tests for PyPI, Pub, Terraform registries — ensures response bodies never leak upstream URLs (#387)
- Fix PyPI trailing-slash double-slash bug in `base_url` handling
- Bump version to 0.9.2 (Cargo.toml, OpenAPI, CHANGELOG, README)

## What's in v0.9.2 (full release)
17 commits, 10 PRs since v0.9.1. Most already merged to main via prior PRs:
- Prometheus P0 metrics (#431, #432, #443)
- Ansible Galaxy v3 compliance (#433, #434, #438, #444, #445)
- npm URL leak fix (#439)
- Cargo config.json api field fix (#442)
- CB gauge init (#441)
- Grafana dashboard (#436, #437)
- .deb/.rpm packaging (#435)

## Test plan
- [x] A/B test v0.9.1 vs v0.9.2-rc — 28/28 PASS, 0 regressions
- [x] Quality gate L0+L1+L2 release — all PASS
- [x] `cargo test` — 1086 passed
- [x] Pre-push: OPSEC, Semgrep, Security, API Contract, OCI Conformance — all PASS
- [x] Tag `v0.9.2` pushed