### PR TITLE
fix(ci): update nfpm to 2.46.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,8 +234,8 @@ jobs:
 
       - name: Install nfpm
         run: |
-          NFPM_VERSION=2.41.1
-          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_linux_amd64.tar.gz" | tar xz -C /usr/local/bin nfpm
+          NFPM_VERSION=2.46.3
+          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | tar xz -C /usr/local/bin nfpm
           nfpm --version
 
       - name: Build ${{ matrix.format }} (${{ matrix.arch }})


### PR DESCRIPTION
## Summary

- nfpm 2.41.1 tarball returns 404 (removed from GitHub Releases), breaking all 4 package jobs
- Asset naming changed upstream: `linux_amd64` → `Linux_x86_64`
- Updated to nfpm 2.46.3 (latest)

## Test plan

- [ ] Package (deb-amd64) passes
- [ ] Package (rpm-amd64) passes
- [ ] Package (deb-arm64) passes
- [ ] Package (rpm-arm64) passes