### PR TITLE
fix(ci): sudo for nfpm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
       - name: Install nfpm
         run: |
           NFPM_VERSION=2.46.3
-          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | tar xz -C /usr/local/bin nfpm
+          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | sudo tar xz -C /usr/local/bin nfpm
           nfpm --version
 
       - name: Build ${{ matrix.format }} (${{ matrix.arch }})


### PR DESCRIPTION
## Summary

- Self-hosted runner lacks write permission to `/usr/local/bin`
- Add `sudo` to `tar xz -C /usr/local/bin`

Follows up on #453 (nfpm 2.46.3 upgrade).

## Test plan

- [ ] Package (deb-amd64) passes