### PR TITLE
fix(ci): install nfpm to RUNNER_TEMP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,8 +235,10 @@ jobs:
       - name: Install nfpm
         run: |
           NFPM_VERSION=2.46.3
-          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | sudo tar xz -C /usr/local/bin nfpm
-          nfpm --version
+          mkdir -p "$RUNNER_TEMP/bin"
+          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | tar xz -C "$RUNNER_TEMP/bin" nfpm
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/nfpm" --version
 
       - name: Build ${{ matrix.format }} (${{ matrix.arch }})
         run: |


### PR DESCRIPTION
## Summary

- Self-hosted runner has no `sudo` — both `/usr/local/bin` write and `sudo tar` fail
- Install nfpm to `$RUNNER_TEMP/bin` and add to `$GITHUB_PATH`

Follows up on #454 and #453.

## Test plan

- [ ] All 4 package jobs pass (deb/rpm × amd64/arm64)