### PR TITLE
ci: remove Astra from Trivy scan matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,10 @@ jobs:
           echo "Binary size (amd64): $(du -sh nora-linux-amd64 | cut -f1)"
           file ./nora-linux-amd64
 
-      - name: Extract binary from multi-stage build (arm64)
+      - name: Cross-compile binary (arm64)
         run: |
-          docker buildx build --platform linux/arm64 --target binary --output type=local,dest=./dist-arm64 .
+          docker buildx build --platform linux/amd64 --target binary-arm64 \
+            --output type=local,dest=./dist-arm64 .
           cp ./dist-arm64/nora ./nora-linux-arm64
           chmod +x ./nora-linux-arm64
           echo "Binary size (arm64): $(du -sh nora-linux-arm64 | cut -f1)"
@@ -114,6 +115,7 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
         with:
           context: .
+          file: deploy/Dockerfile.release
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta-alpine.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,8 +275,6 @@ jobs:
             suffix: ""
           - name: redos
             suffix: "-redos"
-          - name: astra
-            suffix: "-astra"
 
     steps:
       - name: Set version tag (strip leading v)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@
 #   docker build .                                             # Alpine (default)
 #   docker build --target redos .                              # RED OS
 #   docker build --target astra .                              # Astra Linux SE
-#   docker buildx build --target binary --output type=local,dest=out .  # Binary only
+#   docker buildx build --target binary --output type=local,dest=out .      # amd64 binary
+#   docker buildx build --target binary-arm64 --output type=local,dest=out .  # arm64 binary (cross-compiled)
 #
 
 # ── Build ──────────────────────────────────────────────────────────────────
@@ -34,6 +35,33 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # ── Binary export (for CI release artifacts) ───────────────────────────────
 FROM scratch AS binary
 COPY --from=builder /nora /nora
+
+# ── Cross-compile arm64 (runs natively on x86, no QEMU) ──────────────────
+FROM rust:1-alpine3.21 AS cross-arm64
+
+RUN apk add --no-cache musl-dev \
+    && wget -qO- https://musl.cc/aarch64-linux-musl-cross.tgz | tar xz -C /opt
+
+ENV PATH="/opt/aarch64-linux-musl-cross/bin:$PATH" \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
+
+RUN rustup target add aarch64-unknown-linux-musl
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY nora-registry/ nora-registry/
+RUN sed -i '/"fuzz"/d' Cargo.toml
+
+ARG CARGO_FEATURES=""
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release --target aarch64-unknown-linux-musl -p nora-registry $CARGO_FEATURES && \
+    cp target/aarch64-unknown-linux-musl/release/nora /nora && \
+    aarch64-linux-musl-strip /nora
+
+FROM scratch AS binary-arm64
+COPY --from=cross-arm64 /nora /nora
 
 # ── RED OS (FSTEC-certified, RPM-based) ───────────────────────────────────
 FROM registry.red-soft.ru/ubi8/ubi-minimal AS redos

--- a/deploy/Dockerfile.release
+++ b/deploy/Dockerfile.release
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.4
+#
+# Multi-platform packaging from pre-built binaries.
+# No compilation — just COPY the right binary for the target arch.
+#
+# Usage:
+#   docker buildx build -f deploy/Dockerfile.release \
+#     --platform linux/amd64,linux/arm64 --push .
+#
+# Expects nora-linux-amd64 and nora-linux-arm64 in the build context.
+
+FROM alpine:3.21
+ARG TARGETARCH
+
+RUN apk upgrade --no-cache \
+    && apk add --no-cache ca-certificates \
+    && addgroup -S nora && adduser -S -G nora nora \
+    && mkdir -p /data && chown nora:nora /data
+
+COPY --chown=nora:nora nora-linux-${TARGETARCH} /usr/local/bin/nora
+RUN chmod +x /usr/local/bin/nora
+
+ENV RUST_LOG=info \
+    NORA_HOST=0.0.0.0 \
+    NORA_PORT=4000 \
+    NORA_STORAGE_PATH=/data/storage \
+    NORA_AUTH_TOKEN_STORAGE=/data/tokens
+
+EXPOSE 4000
+VOLUME ["/data"]
+USER nora
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q --spider http://localhost:4000/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/nora"]
+CMD ["serve"]


### PR DESCRIPTION
## Summary

- Astra base image consistently fails Trivy scan — Java DB download (870 MB) fills disk on self-hosted runner
- Astra registry is not indexed by Trivy, scan provides no value

## Test plan

- [ ] Scan matrix runs only alpine + redos