### PR TITLE
ci: add @ertime037 as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owner for everything
-* @devitway
+* @devitway @ertime037


### PR DESCRIPTION
## Summary
- Add @ertime037 as code owner alongside @devitway in `.github/CODEOWNERS`
- Required for OpenSSF Scorecard branch protection compliance

## Test plan
- [x] Verify CODEOWNERS syntax is valid
- [x] Confirm both owners are listed for all paths