### PR TITLE
feat(ui): Ansible Galaxy 2-level namespace browsing

### DIFF
--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -873,6 +873,85 @@ pub async fn get_go_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoInfo>
     (result, false)
 }
 
+/// List Ansible Galaxy namespaces or collections within a namespace.
+///
+/// - `path == ""` → group all `ansible/download/*.tar.gz` by namespace, return `Vec<RepoInfo>`
+///   where `name` = namespace, `versions` = collection count.
+/// - `path == "community"` → filter by namespace, group by collection name, return `Vec<RepoInfo>`
+///   where `name` = collection name, `versions` = version count.
+///
+/// Filenames follow the Galaxy convention: `{namespace}-{name}-{version}.tar.gz`.
+/// Namespace and name are `[a-z0-9_]+`, so the first `-` is an unambiguous separator.
+/// Does NOT call `storage.stat` — avoids latency on large collection counts.
+pub async fn get_ansible_namespace_listing(storage: &Storage, path: &str) -> Vec<RepoInfo> {
+    let keys = storage.list("ansible/download/").await;
+
+    if keys.is_empty() {
+        return vec![];
+    }
+
+    // Parse filenames: {ns}-{name}-{version}.tar.gz
+    // splitn(3, '-') → [ns, name, version_with_ext]
+    struct Parsed {
+        namespace: String,
+        collection: String,
+    }
+    let mut parsed: Vec<Parsed> = Vec::new();
+    for key in &keys {
+        if let Some(filename) = key
+            .strip_prefix("ansible/download/")
+            .and_then(|f| f.strip_suffix(".tar.gz"))
+        {
+            let parts: Vec<&str> = filename.splitn(3, '-').collect();
+            if parts.len() == 3 && !parts[0].is_empty() && !parts[1].is_empty() {
+                parsed.push(Parsed {
+                    namespace: parts[0].to_string(),
+                    collection: parts[1].to_string(),
+                });
+            }
+        }
+    }
+
+    if path.is_empty() {
+        // Root: group by namespace, count distinct collections per namespace
+        let mut ns_collections: HashMap<String, std::collections::HashSet<String>> = HashMap::new();
+        for p in &parsed {
+            ns_collections
+                .entry(p.namespace.clone())
+                .or_default()
+                .insert(p.collection.clone());
+        }
+        let mut result: Vec<RepoInfo> = ns_collections
+            .into_iter()
+            .map(|(ns, cols)| RepoInfo {
+                name: ns,
+                versions: cols.len(),
+                ..Default::default()
+            })
+            .collect();
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        result
+    } else {
+        // Namespace level: filter by namespace, group by collection name, count versions
+        let mut col_counts: HashMap<String, usize> = HashMap::new();
+        for p in &parsed {
+            if p.namespace == path {
+                *col_counts.entry(p.collection.clone()).or_insert(0) += 1;
+            }
+        }
+        let mut result: Vec<RepoInfo> = col_counts
+            .into_iter()
+            .map(|(col, count)| RepoInfo {
+                name: col,
+                versions: count,
+                ..Default::default()
+            })
+            .collect();
+        result.sort_by(|a, b| a.name.cmp(&b.name));
+        result
+    }
+}
+
 pub async fn get_go_detail(
     storage: &Storage,
     module: &str,
@@ -956,6 +1035,7 @@ pub async fn get_generic_detail(
         "conan" => get_conan_detail(storage, &name_lower, show_prerelease, show_all).await,
         "gems" => get_gems_detail(storage, &name_lower, show_prerelease, show_all).await,
         "pub" => get_pub_detail(storage, &name_lower, show_prerelease, show_all).await,
+        "ansible" => get_ansible_detail(storage, &name_lower, show_prerelease, show_all).await,
         _ => {
             get_storage_scan_detail(storage, registry, &name_lower, show_prerelease, show_all).await
         }
@@ -1297,6 +1377,65 @@ async fn get_pub_detail(
             }
         }
     }
+    versions.sort_by(|a, b| b.version.cmp(&a.version));
+    let (versions, prerelease_count, total_stable) =
+        apply_prerelease_filter(versions, show_prerelease, show_all);
+    PackageDetail {
+        versions,
+        prerelease_count,
+        total_stable,
+        metadata: PackageMetadata::default(),
+    }
+}
+
+/// Ansible Galaxy collection detail: list versions of `{ns}.{name}`.
+/// Files stored as `ansible/download/{ns}-{name}-{ver}.tar.gz`.
+async fn get_ansible_detail(
+    storage: &Storage,
+    name: &str,
+    show_prerelease: bool,
+    show_all: bool,
+) -> PackageDetail {
+    // name comes as "community.general" → split to (ns, collection)
+    let (ns, col) = match name.split_once('.') {
+        Some(pair) => pair,
+        None => {
+            return PackageDetail {
+                versions: vec![],
+                prerelease_count: 0,
+                total_stable: 0,
+                metadata: PackageMetadata::default(),
+            };
+        }
+    };
+
+    let keys = storage.list("ansible/download/").await;
+    let prefix = format!("{}-{}-", ns, col);
+    let mut versions = Vec::new();
+
+    for key in &keys {
+        if let Some(filename) = key
+            .strip_prefix("ansible/download/")
+            .and_then(|f| f.strip_suffix(".tar.gz"))
+        {
+            if let Some(version) = filename.strip_prefix(&prefix) {
+                if !version.is_empty() {
+                    let (size, published) = if let Some(meta) = storage.stat(key).await {
+                        (meta.size, format_timestamp(meta.modified))
+                    } else {
+                        (0, "N/A".to_string())
+                    };
+                    versions.push(VersionInfo {
+                        version: version.to_string(),
+                        size,
+                        published,
+                        cached: true,
+                    });
+                }
+            }
+        }
+    }
+
     versions.sort_by(|a, b| b.version.cmp(&a.version));
     let (versions, prerelease_count, total_stable) =
         apply_prerelease_filter(versions, show_prerelease, show_all);

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -144,7 +144,8 @@ pub fn routes() -> Router<Arc<AppState>> {
         // New registries (v0.7 — generic list pages)
         .route("/ui/gems", get(generic_registry_list))
         .route("/ui/terraform", get(generic_registry_list))
-        .route("/ui/ansible", get(generic_registry_list))
+        .route("/ui/ansible", get(ansible_browse_root))
+        .route("/ui/ansible/{*path}", get(ansible_browse))
         .route("/ui/nuget", get(generic_registry_list))
         .route("/ui/nuget/{name}", get(generic_registry_detail))
         .route("/ui/pub", get(generic_registry_list))
@@ -153,7 +154,6 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/ui/conan/{name}", get(generic_registry_detail))
         .route("/ui/gems/{name}", get(generic_registry_detail))
         .route("/ui/terraform/{name}", get(generic_registry_detail))
-        .route("/ui/ansible/{name}", get(generic_registry_detail))
         // Token management UI (protected by auth middleware)
         .route("/ui/tokens", get(tokens_page))
         // Token management API (HTMX endpoints)
@@ -677,6 +677,96 @@ async fn generic_registry_detail(
         &base_url,
         auth_enabled,
     ))
+}
+
+// Ansible Galaxy hierarchical browsing (namespace → collection → versions)
+async fn ansible_browse_root(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<LangQuery>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    let lang = extract_lang(
+        &Query(query),
+        headers.get("cookie").and_then(|v| v.to_str().ok()),
+    );
+    let auth_enabled = state.auth.is_some();
+
+    let entries = api::get_ansible_namespace_listing(&state.storage, "").await;
+    let total = entries.len();
+
+    Html(templates::render_ansible_dir(
+        "",
+        &entries,
+        total,
+        lang,
+        auth_enabled,
+    ))
+}
+
+async fn ansible_browse(
+    State(state): State<Arc<AppState>>,
+    Path(path): Path<String>,
+    Query(query): Query<DetailQuery>,
+    headers: axum::http::HeaderMap,
+) -> impl IntoResponse {
+    let lang = {
+        let lang_q = LangQuery {
+            lang: query.lang.clone(),
+        };
+        extract_lang(
+            &Query(lang_q),
+            headers.get("cookie").and_then(|v| v.to_str().ok()),
+        )
+    };
+    let auth_enabled = state.auth.is_some();
+
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    match segments.len() {
+        // /ui/ansible/community → list collections in namespace
+        1 => {
+            let entries = api::get_ansible_namespace_listing(&state.storage, &path).await;
+            let total = entries.len();
+            Html(templates::render_ansible_dir(
+                &path,
+                &entries,
+                total,
+                lang,
+                auth_enabled,
+            ))
+        }
+        // /ui/ansible/community/general → version detail
+        2 => {
+            let base_url = resolve_base_url(&state);
+            let show_prerelease = query.prerelease.unwrap_or(false);
+            let show_all = query.all.unwrap_or(false);
+            let full_name = format!("{}.{}", segments[0], segments[1]);
+            let detail = get_generic_detail(
+                &state.storage,
+                "ansible",
+                &full_name,
+                show_prerelease,
+                show_all,
+            )
+            .await;
+            Html(render_package_detail(
+                "ansible",
+                &full_name,
+                &detail,
+                lang,
+                &base_url,
+                auth_enabled,
+            ))
+        }
+        // Deeper paths: 404
+        _ => Html(templates::render_ansible_dir(
+            &path,
+            &[],
+            0,
+            lang,
+            auth_enabled,
+        )),
+    }
 }
 
 // ==================== Token Management Handlers ====================

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -920,6 +920,131 @@ pub fn render_go_dir(
     )
 }
 
+/// Renders Ansible Galaxy namespace browser with breadcrumbs
+pub fn render_ansible_dir(
+    path: &str,
+    entries: &[RepoInfo],
+    total: usize,
+    lang: Lang,
+    auth_enabled: bool,
+) -> String {
+    let t = get_translations(lang);
+
+    // Build breadcrumbs: Ansible Galaxy / community / general
+    let mut breadcrumbs =
+        r#"<a href="/ui/ansible" class="text-blue-400 hover:text-blue-300">Ansible Galaxy</a>"#
+            .to_string();
+    if !path.is_empty() {
+        let segments: Vec<&str> = path.split('/').collect();
+        for (i, seg) in segments.iter().enumerate() {
+            let crumb_path = segments[..=i].join("/");
+            if i == segments.len() - 1 {
+                let _ = write!(
+                    breadcrumbs,
+                    r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
+                    html_escape(seg)
+                );
+            } else {
+                let _ = write!(
+                    breadcrumbs,
+                    r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/ansible/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+                    crumb_path,
+                    html_escape(seg)
+                );
+            }
+        }
+    }
+
+    let folder_icon = r#"<svg class="w-4 h-4 flex-shrink-0 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"/></svg>"#;
+
+    let rows: String = entries
+        .iter()
+        .map(|entry| {
+            let href = if path.is_empty() {
+                format!("/ui/ansible/{}", encode_uri_component(&entry.name))
+            } else {
+                format!(
+                    "/ui/ansible/{}/{}",
+                    path,
+                    encode_uri_component(&entry.name)
+                )
+            };
+            format!(
+                r##"
+                <tr class="hover:bg-slate-700 cursor-pointer" onclick="window.location='{}'">
+                    <td class="px-3 md:px-6 py-3 md:py-4">
+                        <div class="flex items-center gap-3">{}<a href="{}" class="text-blue-400 hover:text-blue-300 font-medium">{}</a></div>
+                    </td>
+                    <td class="px-3 md:px-6 py-3 md:py-4 text-slate-400">{}</td>
+                </tr>
+            "##,
+                href,
+                folder_icon,
+                href,
+                html_escape(&entry.name),
+                entry.versions,
+            )
+        })
+        .collect();
+
+    let title_display = if path.is_empty() {
+        "Ansible Galaxy".to_string()
+    } else {
+        html_escape(path.rsplit('/').next().unwrap_or(path))
+    };
+
+    // Column header: "Items" at root (namespace count), "Versions" at namespace level
+    let col_count_label = if path.is_empty() { t.items } else { t.versions };
+
+    let showing = t.showing_all.replace("{count}", &total.to_string());
+
+    let content = format!(
+        r##"
+        <div class="mb-6">
+            <div class="flex items-center mb-4 text-sm">{breadcrumbs}</div>
+            <div class="flex items-center">
+                <svg class="w-6 h-6 md:w-8 md:h-8 mr-3 text-slate-400 flex-shrink-0" fill="currentColor" viewBox="0 0 24 24">{icon}</svg>
+                <h1 class="text-xl md:text-2xl font-bold text-slate-200">{title}</h1>
+            </div>
+        </div>
+
+        <div class="bg-[#1e293b] rounded-lg shadow-sm border border-slate-700 overflow-x-auto">
+            <table class="w-full">
+                <thead class="bg-slate-800 border-b border-slate-700">
+                    <tr>
+                        <th class="px-3 md:px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">{col_name}</th>
+                        <th class="px-3 md:px-6 py-3 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider">{col_count}</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-slate-700">
+                    {rows}
+                </tbody>
+            </table>
+            <div class="mt-4 mb-4 ml-4 text-sm text-slate-500">{showing}</div>
+        </div>
+    "##,
+        breadcrumbs = breadcrumbs,
+        icon = icons::ANSIBLE,
+        title = title_display,
+        col_name = t.name,
+        col_count = col_count_label,
+        rows = rows,
+        showing = showing,
+    );
+
+    layout_dark(
+        &format!(
+            "Ansible Galaxy — {}",
+            if path.is_empty() { "Browse" } else { path }
+        ),
+        &content,
+        Some("ansible"),
+        "",
+        lang,
+        auth_enabled,
+    )
+}
+
 /// Renders package detail page (npm, cargo, pypi)
 pub fn render_package_detail(
     registry_type: &str,
@@ -1038,7 +1163,28 @@ pub fn render_package_detail(
     };
 
     // Build breadcrumbs — make each path segment clickable for hierarchical names
-    let breadcrumb_html = if name.contains('/') {
+    let breadcrumb_html = if registry_type == "ansible" && name.contains('.') {
+        // Ansible: community.general → Ansible Galaxy / community / general
+        let parts: Vec<&str> = name.splitn(2, '.').collect();
+        let mut crumbs = format!(
+            r#"<a href="/ui/ansible" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+            registry_title
+        );
+        let _ = write!(
+            crumbs,
+            r#"<span class="mx-2 text-slate-500">/</span><a href="/ui/ansible/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,
+            encode_uri_component(parts[0]),
+            html_escape(parts[0])
+        );
+        if parts.len() > 1 {
+            let _ = write!(
+                crumbs,
+                r#"<span class="mx-2 text-slate-500">/</span><span class="text-slate-200 font-medium">{}</span>"#,
+                html_escape(parts[1])
+            );
+        }
+        crumbs
+    } else if name.contains('/') {
         let segments: Vec<&str> = name.split('/').collect();
         let mut crumbs = format!(
             r#"<a href="/ui/{}" class="text-blue-400 hover:text-blue-300">{}</a>"#,


### PR DESCRIPTION
## Summary

- Replace flat Ansible collection list with hierarchical namespace browsing
- `/ui/ansible` → namespace list (community, ansible, amazon, ...)
- `/ui/ansible/{ns}` → collections in namespace
- `/ui/ansible/{ns}/{col}` → version detail with install command
- Single wildcard handler with match on segment count (0/1/2)
- No `storage.stat` in namespace listing — avoids latency on large collection counts
- Breadcrumbs: `Ansible Galaxy / community / general`

Closes #463

## Test plan

- [x] `cargo test` — 1086 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt --check` — clean
- [x] Semgrep — no new findings in changed files
- [x] OPSEC — clean
- [x] Negative security — 10/10 pass
- [x] API contract — 28/28 pass
- [x] OCI conformance — 12/12 pass
- [x] Deployed and verified on demo.getnora.io