### PR TITLE
fix(terraform): strip internal fields from client responses (#465)

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -457,10 +457,21 @@ pub struct AnsibleConfig {
     pub proxy_auth: Option<String>,
     #[serde(default = "default_timeout")]
     pub proxy_timeout: u64,
+    /// Metadata cache TTL in seconds (default: 3600 = 1 hour).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
+    #[serde(default = "default_ansible_metadata_ttl")]
+    pub metadata_ttl: i64,
+    /// Serve stale cached metadata when upstream is unreachable (default: true).
+    #[serde(default = "default_true")]
+    pub serve_stale: bool,
 }
 
 fn default_ansible_proxy() -> Option<String> {
     Some("https://galaxy.ansible.com".to_string())
+}
+
+fn default_ansible_metadata_ttl() -> i64 {
+    3600
 }
 
 impl Default for AnsibleConfig {
@@ -470,6 +481,8 @@ impl Default for AnsibleConfig {
             proxy: default_ansible_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
+            metadata_ttl: 3600,
+            serve_stale: true,
         }
     }
 }
@@ -2350,6 +2363,14 @@ impl Config {
             if let Ok(timeout) = val.parse() {
                 self.ansible.proxy_timeout = timeout;
             }
+        }
+        if let Ok(val) = env::var("NORA_ANSIBLE_METADATA_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.ansible.metadata_ttl = ttl;
+            }
+        }
+        if let Ok(val) = env::var("NORA_ANSIBLE_SERVE_STALE") {
+            self.ansible.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
 
         // NuGet config

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -111,7 +111,12 @@ async fn collection_list(
     let base = format!("{}{}/", proxy_url.trim_end_matches('/'), API_PREFIX);
     let url = append_query(&base, raw_query.as_deref());
 
-    proxy_json(&state, &url, "ansible-collections").await
+    let cache_key = match extract_page_param(raw_query.as_deref()) {
+        Some(page) => format!("ansible/metadata/collections-page-{}.json", page),
+        None => "ansible/metadata/collections.json".to_string(),
+    };
+
+    proxy_json(&state, &url, "ansible-collections", &cache_key).await
 }
 
 // ── Collection detail ──────────────────────────────────────────────────
@@ -133,7 +138,8 @@ async fn collection_detail(
         name
     );
 
-    proxy_json(&state, &url, &format!("{}.{}", ns, name)).await
+    let cache_key = format!("ansible/metadata/{}/{}.json", ns, name);
+    proxy_json(&state, &url, &format!("{}.{}", ns, name), &cache_key).await
 }
 
 // ── Version listing ────────────────────────────────────────────────────
@@ -157,7 +163,21 @@ async fn version_list(
     );
     let url = append_query(&base, raw_query.as_deref());
 
-    proxy_json(&state, &url, &format!("{}.{}/versions", ns, name)).await
+    let cache_key = match extract_page_param(raw_query.as_deref()) {
+        Some(page) => format!(
+            "ansible/metadata/{}/{}/versions-page-{}.json",
+            ns, name, page
+        ),
+        None => format!("ansible/metadata/{}/{}/versions.json", ns, name),
+    };
+
+    proxy_json(
+        &state,
+        &url,
+        &format!("{}.{}/versions", ns, name),
+        &cache_key,
+    )
+    .await
 }
 
 // ── Version detail ─────────────────────────────────────────────────────
@@ -194,7 +214,14 @@ async fn version_detail(
         ver
     );
 
-    proxy_json(&state, &url, &format!("{}.{} v{}", ns, name, ver)).await
+    let cache_key = format!("ansible/metadata/{}/{}/{}.json", ns, name, ver);
+    proxy_json(
+        &state,
+        &url,
+        &format!("{}.{} v{}", ns, name, ver),
+        &cache_key,
+    )
+    .await
 }
 
 // ── Tarball download (immutable) ───────────────────────────────────────
@@ -312,9 +339,38 @@ async fn download_tarball(
     }
 }
 
-// ── Generic JSON proxy ─────────────────────────────────────────────────
+// ── Generic JSON proxy with metadata caching ─────────────────────────
 
-async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Response {
+/// Proxy a Galaxy API JSON request with metadata caching and serve-stale.
+///
+/// `cache_key` is the storage path for the cached response (e.g.
+/// `ansible/metadata/community/general.json`).
+async fn proxy_json(
+    state: &Arc<AppState>,
+    url: &str,
+    artifact_name: &str,
+    cache_key: &str,
+) -> Response {
+    let base_url = nora_base_url(state);
+    let upstream = upstream_url(state);
+
+    // Read cache eagerly so stale data is available on upstream failure.
+    let cached_data = state.storage.get(cache_key).await.ok();
+
+    // TTL check — serve fresh cache without hitting upstream.
+    if let Some(ref data) = cached_data {
+        if let Some(meta) = state.storage.stat(cache_key).await {
+            if crate::cache_ttl::is_within_ttl(meta.modified, state.config.ansible.metadata_ttl) {
+                state.metrics.record_download("ansible");
+                state.metrics.record_cache_hit("ansible");
+                let text = String::from_utf8_lossy(data);
+                let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
+                return with_json(rewritten.into_bytes());
+            }
+        }
+    }
+
+    // Cache miss or stale — fetch from upstream.
     match proxy_fetch_text(
         &state.http_client,
         url,
@@ -327,10 +383,6 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
     .await
     {
         Ok(text) => {
-            let base_url = nora_base_url(state);
-            let upstream = upstream_url(state);
-            let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
-
             state.metrics.record_download("ansible");
             state.metrics.record_cache_miss("ansible");
             state.activity.push(ActivityEntry::new(
@@ -343,6 +395,10 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "ansible", ""));
 
+            // Cache raw response (before URL rewriting) for serve-stale.
+            state.spawn_cache("ansible", cache_key.to_string(), Bytes::from(text.clone()));
+
+            let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
             state.repo_index.invalidate("ansible");
             with_json(rewritten.into_bytes())
         }
@@ -350,9 +406,50 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str) -> Respons
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "Ansible Galaxy upstream error");
-            StatusCode::BAD_GATEWAY.into_response()
+            serve_stale_or_bad_gateway(state, cached_data, cache_key, &upstream, &base_url)
         }
     }
+}
+
+/// Serve stale cached metadata when upstream is unreachable, or 502 if no cache.
+fn serve_stale_or_bad_gateway(
+    state: &AppState,
+    cached: Option<Bytes>,
+    label: &str,
+    upstream: &str,
+    base_url: &str,
+) -> Response {
+    if let Some(data) = cached {
+        if state.config.ansible.serve_stale {
+            tracing::warn!(
+                registry = "ansible",
+                endpoint = label,
+                "Upstream unreachable, serving stale cached metadata"
+            );
+            let text = String::from_utf8_lossy(&data);
+            let rewritten = rewrite_ansible_urls(&text, upstream, base_url);
+            return (
+                StatusCode::OK,
+                [
+                    (
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static("application/json"),
+                    ),
+                    (
+                        header::CACHE_CONTROL,
+                        HeaderValue::from_static("public, max-age=0, must-revalidate"),
+                    ),
+                    (
+                        axum::http::header::HeaderName::from_static("x-nora-stale"),
+                        axum::http::header::HeaderValue::from_static("true"),
+                    ),
+                ],
+                rewritten.into_bytes(),
+            )
+                .into_response();
+        }
+    }
+    StatusCode::BAD_GATEWAY.into_response()
 }
 
 // ── URL rewriting ─────────────────────────────────────────────────────
@@ -402,6 +499,22 @@ fn append_query(base_url: &str, raw_query: Option<&str>) -> String {
         }
         _ => base_url.to_string(),
     }
+}
+
+/// Extract `page` or `offset` parameter from a query string for cache key differentiation.
+fn extract_page_param(raw_query: Option<&str>) -> Option<String> {
+    let q = raw_query?;
+    for pair in q.split('&') {
+        if let Some(val) = pair
+            .strip_prefix("page=")
+            .or_else(|| pair.strip_prefix("offset="))
+        {
+            if !val.is_empty() && val.len() <= 10 && val.chars().all(|c| c.is_ascii_digit()) {
+                return Some(val.to_string());
+            }
+        }
+    }
+    None
 }
 
 fn upstream_url(state: &AppState) -> String {
@@ -580,6 +693,20 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_page_param() {
+        assert_eq!(extract_page_param(Some("page=2")), Some("2".to_string()));
+        assert_eq!(
+            extract_page_param(Some("limit=10&offset=20")),
+            Some("20".to_string())
+        );
+        assert_eq!(extract_page_param(Some("limit=10")), None);
+        assert_eq!(extract_page_param(None), None);
+        assert_eq!(extract_page_param(Some("")), None);
+        // Reject non-numeric
+        assert_eq!(extract_page_param(Some("page=abc")), None);
+    }
+
+    #[test]
     fn test_rewrite_preserves_pagination_query_params() {
         let input = r#"{"links":{"next":"https://galaxy.ansible.com/api/v3/plugin/ansible/content/published/collections/index/community/general/versions/?limit=10&offset=20"}}"#;
         let result = rewrite_ansible_urls(input, "https://galaxy.ansible.com", "http://nora:4000");
@@ -754,5 +881,126 @@ mod integration_tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// Stale cache + unreachable upstream + serve_stale=true → 200 with X-Nora-Stale header (#466)
+    #[tokio::test]
+    async fn test_serve_stale_collection_detail() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+            cfg.ansible.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.ansible.proxy_timeout = 1;
+            cfg.ansible.metadata_ttl = 0; // force TTL expiry → always stale
+            cfg.ansible.serve_stale = true;
+        });
+
+        // Pre-populate cache
+        ctx.state
+            .storage
+            .put(
+                "ansible/metadata/community/general.json",
+                br#"{"name":"community.general","namespace":{"name":"community"}}"#,
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/v3/collections/community/general/",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("x-nora-stale").map(|v| v.as_bytes()),
+            Some(b"true".as_ref()),
+        );
+        let body = body_bytes(resp).await;
+        assert!(String::from_utf8_lossy(&body).contains("community.general"));
+    }
+
+    /// Stale cache + unreachable upstream + serve_stale=false → 502 (#466)
+    #[tokio::test]
+    async fn test_serve_stale_disabled_returns_502() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+            cfg.ansible.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.ansible.proxy_timeout = 1;
+            cfg.ansible.metadata_ttl = 0;
+            cfg.ansible.serve_stale = false;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "ansible/metadata/community/general.json",
+                br#"{"name":"community.general"}"#,
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/v3/collections/community/general/",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert!(resp.headers().get("x-nora-stale").is_none());
+    }
+
+    /// Fresh cache (within TTL) → 200 without upstream request (#466)
+    #[tokio::test]
+    async fn test_fresh_cache_served_without_upstream() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+            cfg.ansible.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.ansible.proxy_timeout = 1;
+            cfg.ansible.metadata_ttl = -1; // cache forever
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "ansible/metadata/community/general.json",
+                br#"{"name":"community.general","cached":true}"#,
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/v3/collections/community/general/",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        // No stale header — cache is fresh
+        assert!(resp.headers().get("x-nora-stale").is_none());
+        let body = body_bytes(resp).await;
+        assert!(String::from_utf8_lossy(&body).contains("community.general"));
+    }
+
+    /// No cache + unreachable upstream → 502 (not stale, just unavailable)
+    #[tokio::test]
+    async fn test_no_cache_unreachable_returns_502() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.ansible.enabled = true;
+            cfg.ansible.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.ansible.proxy_timeout = 1;
+            cfg.ansible.serve_stale = true;
+        });
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/ansible/v3/collections/community/general/",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 }

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -213,7 +213,7 @@ async fn provider_download_meta(
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
                 state.metrics.record_cache_hit("terraform");
-                return with_json(data.to_vec());
+                return with_json(strip_nora_internal_fields(&data));
             }
         }
     }
@@ -257,7 +257,7 @@ async fn provider_download_meta(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "terraform", ""));
 
             state.spawn_cache("terraform", storage_key, Bytes::from(rewritten.clone()));
-            with_json(rewritten.into_bytes())
+            with_json(strip_nora_internal_fields(rewritten.as_bytes()))
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -492,8 +492,13 @@ async fn module_download(
                     &ver,
                 );
 
-                // Cache the original upstream URL for module_source_download
-                state.spawn_cache("terraform", source_url_key, Bytes::from(original_url));
+                // Cache the inner URL (stripping VCS prefix like git::) for module_source_download
+                let (_, inner_url) = strip_vcs_prefix(&original_url);
+                state.spawn_cache(
+                    "terraform",
+                    source_url_key,
+                    Bytes::from(inner_url.to_string()),
+                );
 
                 return (
                     StatusCode::NO_CONTENT,
@@ -839,8 +844,9 @@ fn rewrite_download_url(
 /// Rewrite X-Terraform-Get URL to point through NORA.
 ///
 /// HTTP/HTTPS URLs are rewritten to NORA's module source proxy endpoint.
-/// Non-HTTP URLs (git::, hg::, relative paths) are returned as-is since
-/// they cannot be proxied through a simple HTTP cache.
+/// VCS-prefixed URLs like `git::https://...` have their inner URL extracted
+/// and rewritten (the VCS prefix is dropped since NORA proxies via HTTP).
+/// Non-HTTP URLs (s3::, ssh://, relative paths) are returned as-is.
 fn rewrite_module_source_url(
     original_url: &str,
     base_url: &str,
@@ -849,7 +855,17 @@ fn rewrite_module_source_url(
     provider: &str,
     ver: &str,
 ) -> String {
-    if original_url.starts_with("http://") || original_url.starts_with("https://") {
+    let (vcs_prefix, inner_url) = strip_vcs_prefix(original_url);
+
+    if inner_url.starts_with("http://") || inner_url.starts_with("https://") {
+        if !vcs_prefix.is_empty() {
+            tracing::warn!(
+                module = %format!("{}/{}/{}", ns, name, provider),
+                version = %ver,
+                vcs = vcs_prefix.trim_end_matches("::"),
+                "Module uses VCS prefix — source download via HTTP proxy may not work"
+            );
+        }
         format!(
             "{}/terraform/v1/modules/download/{}/{}/{}/{}/source",
             base_url.trim_end_matches('/'),
@@ -859,9 +875,40 @@ fn rewrite_module_source_url(
             ver
         )
     } else {
-        // git::, hg::, s3::, relative paths — pass through as-is
+        // s3::, ssh://, relative paths — pass through as-is
         original_url.to_string()
     }
+}
+
+/// Strip internal `_nora_*` fields from cached metadata before sending to clients.
+///
+/// The cached JSON contains `_nora_upstream_url`, `_nora_upstream_shasums_url`, and
+/// `_nora_upstream_shasums_sig_url` — needed internally by `resolve_upstream_download_url`
+/// but must NOT be exposed to clients (air-gap URL leak).
+fn strip_nora_internal_fields(data: &[u8]) -> Vec<u8> {
+    if let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(data) {
+        if let Some(obj) = json.as_object_mut() {
+            obj.retain(|k, _| !k.starts_with("_nora_"));
+        }
+        serde_json::to_vec(&json).unwrap_or_else(|_| data.to_vec())
+    } else {
+        tracing::warn!(
+            "strip_nora_internal_fields: failed to parse cached JSON, returning raw data"
+        );
+        data.to_vec()
+    }
+}
+
+/// Extract VCS prefix (`git::`, `hg::`) from a Terraform module source URL.
+///
+/// Returns `(prefix, inner_url)`. If no VCS prefix is present, prefix is empty.
+fn strip_vcs_prefix(url: &str) -> (&str, &str) {
+    for prefix in &["git::", "hg::"] {
+        if let Some(inner) = url.strip_prefix(prefix) {
+            return (prefix, inner);
+        }
+    }
+    ("", url)
 }
 
 /// Validate namespace/type/provider names
@@ -977,7 +1024,7 @@ mod tests {
     }
 
     #[test]
-    fn test_rewrite_module_source_url_git_passthrough() {
+    fn test_rewrite_module_source_url_git_rewrite() {
         let git_url = "git::https://example.com/module.git";
         let result = rewrite_module_source_url(
             git_url,
@@ -987,7 +1034,106 @@ mod tests {
             "aws",
             "0.1.0",
         );
-        assert_eq!(result, git_url, "git:: URLs should pass through unchanged");
+        assert_eq!(
+            result,
+            "http://nora:4000/terraform/v1/modules/download/hashicorp/consul/aws/0.1.0/source",
+            "git::https:// URLs must be rewritten through NORA (air-gap)"
+        );
+        assert!(
+            !result.contains("example.com"),
+            "upstream URL must not leak"
+        );
+        assert!(!result.contains("git::"), "VCS prefix must be stripped");
+    }
+
+    #[test]
+    fn test_rewrite_module_source_url_hg_rewrite() {
+        let hg_url = "hg::https://example.com/module.hg";
+        let result = rewrite_module_source_url(
+            hg_url,
+            "http://nora:4000",
+            "hashicorp",
+            "consul",
+            "aws",
+            "0.1.0",
+        );
+        assert_eq!(
+            result,
+            "http://nora:4000/terraform/v1/modules/download/hashicorp/consul/aws/0.1.0/source",
+            "hg::https:// URLs must be rewritten through NORA"
+        );
+    }
+
+    #[test]
+    fn test_rewrite_module_source_url_s3_passthrough() {
+        let s3_url = "s3::https://bucket.s3.amazonaws.com/module.zip";
+        let result = rewrite_module_source_url(
+            s3_url,
+            "http://nora:4000",
+            "hashicorp",
+            "consul",
+            "aws",
+            "0.1.0",
+        );
+        assert_eq!(result, s3_url, "s3:: URLs should pass through unchanged");
+    }
+
+    #[test]
+    fn test_strip_nora_internal_fields() {
+        let input = serde_json::json!({
+            "download_url": "http://nora:4000/terraform/providers/download/test.zip",
+            "_nora_upstream_url": "https://releases.hashicorp.com/test.zip",
+            "_nora_upstream_shasums_url": "https://releases.hashicorp.com/SHA256SUMS",
+            "_nora_upstream_shasums_sig_url": "https://releases.hashicorp.com/SHA256SUMS.sig",
+            "shasum": "abc123"
+        });
+        let stripped = strip_nora_internal_fields(input.to_string().as_bytes());
+        let json: serde_json::Value = serde_json::from_slice(&stripped).unwrap();
+        assert!(
+            json.get("download_url").is_some(),
+            "download_url must remain"
+        );
+        assert!(json.get("shasum").is_some(), "shasum must remain");
+        assert!(
+            json.get("_nora_upstream_url").is_none(),
+            "_nora_upstream_url must be stripped"
+        );
+        assert!(
+            json.get("_nora_upstream_shasums_url").is_none(),
+            "shasums must be stripped"
+        );
+        assert!(
+            json.get("_nora_upstream_shasums_sig_url").is_none(),
+            "sig must be stripped"
+        );
+    }
+
+    #[test]
+    fn test_strip_nora_internal_fields_invalid_json() {
+        let input = b"not json at all";
+        let result = strip_nora_internal_fields(input);
+        assert_eq!(result, input, "invalid JSON must pass through unchanged");
+    }
+
+    #[test]
+    fn test_strip_vcs_prefix() {
+        assert_eq!(
+            strip_vcs_prefix("git::https://example.com"),
+            ("git::", "https://example.com")
+        );
+        assert_eq!(
+            strip_vcs_prefix("hg::https://example.com"),
+            ("hg::", "https://example.com")
+        );
+        assert_eq!(
+            strip_vcs_prefix("https://example.com"),
+            ("", "https://example.com")
+        );
+        assert_eq!(strip_vcs_prefix("./local/path"), ("", "./local/path"));
+        assert_eq!(
+            strip_vcs_prefix("s3::https://bucket.s3.amazonaws.com/mod.zip"),
+            ("", "s3::https://bucket.s3.amazonaws.com/mod.zip")
+        );
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

- Strip `_nora_upstream_*` internal fields from Terraform provider download metadata responses on both TTL cache hit and fresh fetch paths
- Handle `git::` and `hg::` VCS-prefixed module source URLs by extracting the inner HTTP URL and rewriting through NORA
- Strip VCS prefix before caching module source URL so `module_source_download` can fetch via HTTP

Fixes #465 (A4b: `_nora_upstream_*` leak, A4e: `X-Terraform-Get` passes `git::https://` through)

## Test plan

- [ ] `cargo test` — 1096 pass, 0 fail
- [ ] `cargo clippy` — clean
- [ ] `airgap-url-audit.sh` — 37 pass / 0 fail (was 32/37)
- [ ] Verify cached JSON retains `_nora_upstream_*` for binary download resolution
- [ ] Verify TTL cache hit also strips internal fields
- [ ] Verify `X-Terraform-Get` header points to NORA for `git::https://` modules