### PR TITLE
fix: pass shared HTTP client to DockerAuth and OidcValidator (#474)

### DIFF
--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -1132,7 +1132,8 @@ Jd74nq6dNCjpWG4drIsyhqX+
         });
 
         // Wire up the OidcValidator on the existing state
-        let oidc_validator = OidcValidator::new(ctx.state.config.auth.oidc.clone());
+        let oidc_validator =
+            OidcValidator::new(ctx.state.config.auth.oidc.clone(), reqwest::Client::new());
         // We need to rebuild the state with oidc set — use Arc::get_mut or rebuild
         let state = Arc::new(crate::AppState {
             storage: ctx.state.storage.clone(),
@@ -1145,7 +1146,7 @@ Jd74nq6dNCjpWG4drIsyhqX+
             metrics: crate::dashboard_metrics::DashboardMetrics::new(),
             activity: crate::activity_log::ActivityLog::new(50),
             audit: ctx.state.audit.clone(),
-            docker_auth: crate::registry::DockerAuth::new(5),
+            docker_auth: crate::registry::DockerAuth::new(reqwest::Client::new(), 5),
             repo_index: crate::repo_index::RepoIndex::new(),
             http_client: reqwest::Client::new(),
             upload_sessions: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),

--- a/nora-registry/src/auth/oidc.rs
+++ b/nora-registry/src/auth/oidc.rs
@@ -89,15 +89,15 @@ pub struct OidcValidator {
     jwks_cache: RwLock<HashMap<String, CachedJwks>>,
 }
 
+/// Per-request timeout for OIDC HTTP calls (discovery + JWKS fetch).
+const OIDC_REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl OidcValidator {
     /// Create a new validator from config.
-    pub fn new(config: OidcConfig) -> Self {
-        let http_client = Client::builder()
-            .timeout(Duration::from_secs(5))
-            .user_agent("nora-registry/0.8")
-            .build()
-            .unwrap_or_default();
-
+    ///
+    /// The client should be pre-configured with any required TLS settings
+    /// (e.g. custom CA certificates). Per-request timeouts are applied internally.
+    pub fn new(config: OidcConfig, http_client: Client) -> Self {
         Self {
             config,
             http_client,
@@ -280,7 +280,13 @@ impl OidcValidator {
             provider.issuer.trim_end_matches('/')
         );
 
-        if let Ok(resp) = self.http_client.get(&discovery_url).send().await {
+        if let Ok(resp) = self
+            .http_client
+            .get(&discovery_url)
+            .timeout(OIDC_REQUEST_TIMEOUT)
+            .send()
+            .await
+        {
             if resp.status().is_success() {
                 if let Ok(config) = resp.json::<OidcDiscoveryDoc>().await {
                     if !config.jwks_uri.is_empty() {
@@ -307,6 +313,7 @@ impl OidcValidator {
         let resp = self
             .http_client
             .get(url)
+            .timeout(OIDC_REQUEST_TIMEOUT)
             .send()
             .await
             .map_err(|e| format!("HTTP error: {}", e))?;
@@ -424,7 +431,7 @@ mod tests {
     #[test]
     fn test_match_role_first_wins() {
         let config = OidcConfig::default();
-        let validator = OidcValidator::new(config);
+        let validator = OidcValidator::new(config, Client::new());
 
         let provider = OidcProvider {
             name: "test".to_string(),

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -825,11 +825,11 @@ async fn run_server(mut config: Config, storage: Storage) {
     // Warn about plaintext credentials in config.toml
     config.warn_plaintext_credentials();
 
-    // Initialize Docker auth with proxy timeout
-    let docker_auth = registry::DockerAuth::new(config.docker.proxy_timeout);
-
     let http_client = build_http_client(&config.tls);
     log_outbound_proxy();
+
+    // Initialize Docker auth with shared HTTP client (includes custom CA certs)
+    let docker_auth = registry::DockerAuth::new(http_client.clone(), config.docker.proxy_timeout);
 
     // Discover NuGet search endpoints from upstream service index
     if config.nuget.enabled {
@@ -953,7 +953,10 @@ async fn run_server(mut config: Config, storage: Storage) {
     };
 
     let oidc_validator = if config.auth.oidc.enabled {
-        Some(auth::OidcValidator::new(config.auth.oidc.clone()))
+        Some(auth::OidcValidator::new(
+            config.auth.oidc.clone(),
+            http_client.clone(),
+        ))
     } else {
         None
     };

--- a/nora-registry/src/mirror/docker.rs
+++ b/nora-registry/src/mirror/docker.rs
@@ -105,7 +105,7 @@ pub async fn run_docker_mirror(
     images: &[ImageRef],
     concurrency: usize,
 ) -> Result<MirrorResult, String> {
-    let docker_auth = DockerAuth::new(DEFAULT_TIMEOUT);
+    let docker_auth = DockerAuth::new(client.clone(), DEFAULT_TIMEOUT);
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(concurrency));
 
     let pb = create_progress_bar(images.len() as u64);

--- a/nora-registry/src/registry/docker_auth.rs
+++ b/nora-registry/src/registry/docker_auth.rs
@@ -17,16 +17,19 @@ struct CachedToken {
 pub struct DockerAuth {
     tokens: RwLock<HashMap<String, CachedToken>>,
     client: reqwest::Client,
+    timeout: Duration,
 }
 
 impl DockerAuth {
-    pub fn new(timeout: u64) -> Self {
+    /// Create a new DockerAuth using the provided HTTP client.
+    ///
+    /// The client should be pre-configured with any required TLS settings
+    /// (e.g. custom CA certificates). The timeout is applied per-request.
+    pub fn new(client: reqwest::Client, timeout: u64) -> Self {
         Self {
             tokens: RwLock::new(HashMap::new()),
-            client: reqwest::Client::builder()
-                .timeout(Duration::from_secs(timeout))
-                .build()
-                .unwrap_or_default(),
+            client,
+            timeout: Duration::from_secs(timeout),
         }
     }
 
@@ -96,7 +99,7 @@ impl DockerAuth {
 
         tracing::debug!(url = %url, "Fetching auth token");
 
-        let mut request = self.client.get(&url);
+        let mut request = self.client.get(&url).timeout(self.timeout);
         if let Some(credentials) = basic_auth {
             request = request.header("Authorization", basic_auth_header(credentials));
             tracing::debug!("Using basic auth for token request");
@@ -121,7 +124,7 @@ impl DockerAuth {
 
 impl Default for DockerAuth {
     fn default() -> Self {
-        Self::new(60)
+        Self::new(reqwest::Client::new(), 60)
     }
 }
 
@@ -205,7 +208,7 @@ mod tests {
 
     #[test]
     fn test_docker_auth_new() {
-        let auth = DockerAuth::new(30);
+        let auth = DockerAuth::new(reqwest::Client::new(), 30);
         assert!(auth.tokens.read().is_empty());
     }
 
@@ -298,7 +301,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_fetch_token_invalid_url() {
-        let auth = DockerAuth::new(1);
+        let auth = DockerAuth::new(reqwest::Client::new(), 1);
         let result = auth
             .get_token(
                 "https://registry.example.com",

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -192,7 +192,8 @@ fn build_context(
         None
     };
 
-    let docker_auth = registry::DockerAuth::new(config.docker.proxy_timeout);
+    let docker_auth =
+        registry::DockerAuth::new(reqwest::Client::new(), config.docker.proxy_timeout);
 
     // Build curation engine before consuming config (mirroring main.rs)
     let mut curation_engine = CurationEngine::new(config.curation.clone());


### PR DESCRIPTION
## Summary

- DockerAuth and OidcValidator now receive the shared `http_client` (with custom CA from `NORA_TLS_CA_CERT`) instead of creating their own
- Per-request timeouts replace client-level timeouts

Fixes #474