### PR TITLE
fix(docker): deduplicate catalog repos across upstream namespaces

### DIFF
--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -456,6 +456,21 @@ async fn check() -> impl IntoResponse {
     )
 }
 
+/// Strip upstream namespace prefix from a Docker repository name.
+///
+/// Storage keys include the upstream namespace (e.g. `docker.io/library/nginx`),
+/// but catalog and UI should show the clean image name (`library/nginx`).
+/// Namespace segments are detected by containing a dot (hostnames like `docker.io`,
+/// `ghcr.io`), which is not valid in Docker org/user names.
+pub(crate) fn strip_docker_namespace(name: &str) -> &str {
+    if let Some((first, rest)) = name.split_once('/') {
+        if first.contains('.') && !rest.is_empty() {
+            return rest;
+        }
+    }
+    name
+}
+
 /// List all repositories in the registry
 async fn catalog(State(state): State<Arc<AppState>>) -> Json<Value> {
     let keys = state.storage.list("docker/").await;
@@ -476,7 +491,9 @@ async fn catalog(State(state): State<Arc<AppState>>) -> Json<Value> {
             if name.is_empty() {
                 return None;
             }
-            Some(name.to_string())
+            // Strip upstream namespace prefix (e.g. "docker.io/" or "ghcr.io/")
+            // so that images proxied through different upstreams are deduplicated.
+            Some(strip_docker_namespace(name).to_string())
         })
         .collect();
 
@@ -3073,5 +3090,89 @@ mod integration_tests {
             .circuit_breaker
             .check("docker:http://127.0.0.1:2")
             .is_ok());
+    }
+
+    #[test]
+    fn test_strip_docker_namespace() {
+        // Namespace prefix (hostname with dot) should be stripped
+        assert_eq!(
+            super::strip_docker_namespace("docker.io/library/nginx"),
+            "library/nginx"
+        );
+        assert_eq!(
+            super::strip_docker_namespace("ghcr.io/requarks/wiki"),
+            "requarks/wiki"
+        );
+        assert_eq!(
+            super::strip_docker_namespace("registry.example.com/myapp"),
+            "myapp"
+        );
+
+        // No namespace prefix — returned as-is
+        assert_eq!(
+            super::strip_docker_namespace("library/nginx"),
+            "library/nginx"
+        );
+        assert_eq!(super::strip_docker_namespace("alpine"), "alpine");
+
+        // Edge: empty or slash-only
+        assert_eq!(super::strip_docker_namespace(""), "");
+        assert_eq!(super::strip_docker_namespace("docker.io/"), "docker.io/");
+
+        // Org name with no dots — not a namespace
+        assert_eq!(
+            super::strip_docker_namespace("myorg/myimage"),
+            "myorg/myimage"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_catalog_dedup_across_namespaces() {
+        use crate::test_helpers::create_test_context;
+
+        let ctx = create_test_context();
+
+        // Simulate keys from two different upstream namespaces for the same image
+        ctx.state
+            .storage
+            .put(
+                "docker/docker.io/library/nginx/manifests/latest.json",
+                b"{}",
+            )
+            .await
+            .unwrap();
+        ctx.state
+            .storage
+            .put("docker/ghcr.io/library/nginx/manifests/v1.json", b"{}")
+            .await
+            .unwrap();
+        // And a non-namespaced (legacy) key for the same image
+        ctx.state
+            .storage
+            .put("docker/library/nginx/manifests/old.json", b"{}")
+            .await
+            .unwrap();
+
+        let keys = ctx.state.storage.list("docker/").await;
+        let mut repos: Vec<String> = keys
+            .iter()
+            .filter_map(|k| {
+                let rest = k.strip_prefix("docker/")?;
+                let name = if let Some(idx) = rest.find("/manifests/") {
+                    &rest[..idx]
+                } else {
+                    return None;
+                };
+                if name.is_empty() {
+                    return None;
+                }
+                Some(super::strip_docker_namespace(name).to_string())
+            })
+            .collect();
+        repos.sort();
+        repos.dedup();
+
+        // All three keys should resolve to a single repo: "library/nginx"
+        assert_eq!(repos, vec!["library/nginx"]);
     }
 }

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -192,7 +192,9 @@ async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
             let manifest_pos = parts.iter().position(|&p| p == "manifests");
             if let Some(pos) = manifest_pos {
                 if pos >= 1 && ends_with_ci(key, ".json") {
-                    let name = parts[..pos].join("/");
+                    let raw_name = parts[..pos].join("/");
+                    let name =
+                        crate::registry::docker::strip_docker_namespace(&raw_name).to_string();
                     let entry = repos.entry(name).or_insert((0, 0, 0));
                     entry.0 += 1;
 

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -349,8 +349,28 @@ pub async fn api_search(
 }
 
 pub async fn get_docker_detail(state: &AppState, name: &str) -> DockerDetail {
+    // Search for manifests under both the bare name and all namespace-prefixed variants.
+    // E.g. for "library/nginx", find keys in docker/library/nginx/manifests/
+    // AND docker/docker.io/library/nginx/manifests/, docker/ghcr.io/library/nginx/manifests/, etc.
     let prefix = format!("docker/{}/manifests/", name);
-    let keys = state.storage.list(&prefix).await;
+    let mut keys = state.storage.list(&prefix).await;
+
+    // Also collect namespaced keys by scanning all docker/ keys for this image name
+    let all_docker_keys = state.storage.list("docker/").await;
+    for key in &all_docker_keys {
+        if let Some(rest) = key.strip_prefix("docker/") {
+            if let Some(idx) = rest.find("/manifests/") {
+                let raw_name = &rest[..idx];
+                if crate::registry::docker::strip_docker_namespace(raw_name) == name
+                    && raw_name != name
+                {
+                    keys.push(key.clone());
+                }
+            }
+        }
+    }
+    keys.sort();
+    keys.dedup();
 
     // Build public URL for pull commands
     let registry_host =
@@ -365,10 +385,17 @@ pub async fn get_docker_detail(state: &AppState, name: &str) -> DockerDetail {
             continue;
         }
 
-        if let Some(tag_name) = key
+        // Extract tag name: find /manifests/{tag}.json regardless of namespace prefix
+        let tag_name = key
             .strip_prefix(&prefix)
-            .and_then(|s| s.strip_suffix(".json"))
-        {
+            .or_else(|| {
+                // For namespaced keys: docker/{ns}/{name}/manifests/{tag}.json
+                key.find("/manifests/")
+                    .map(|idx| &key[idx + "/manifests/".len()..])
+            })
+            .and_then(|s| s.strip_suffix(".json"));
+
+        if let Some(tag_name) = tag_name {
             // Load metadata from .meta.json file
             let meta_key = format!("{}.meta.json", key.trim_end_matches(".json"));
             let metadata = if let Ok(meta_data) = state.storage.get(&meta_key).await {


### PR DESCRIPTION
## Summary

Fixes #497 — Docker catalog and UI showed duplicate entries when the same image was cached through different upstream proxies.

- Add `strip_docker_namespace()` — detects hostname prefixes (segments with dots) in repo names and strips them for display
- Apply in `catalog()` (V2 API) and `build_docker_index()` (UI)
- Fix `get_docker_detail()` to search namespaced storage keys so detail pages work with stripped names

## Test plan

- [x] Unit test: `test_strip_docker_namespace` — covers hostname prefix, no-prefix, edge cases
- [x] Integration test: `test_catalog_dedup_across_namespaces` — verifies 3 keys from different namespaces resolve to 1 repo
- [x] Full test suite: 1088 tests pass
- [x] Clippy clean, fmt clean
- [x] Semgrep: 0 new findings
- [x] cargo-deny + cargo-audit: clean