### PR TITLE
refactor(docker): unify name resolution into canonicalize() (#502)

### DIFF
--- a/nora-registry/src/docker_key_migration.rs
+++ b/nora-registry/src/docker_key_migration.rs
@@ -1,0 +1,489 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+
+//! Docker storage key migration — consolidate legacy flat keys into namespaced format.
+//!
+//! After introducing namespaced storage keys (`docker/{namespace}/{name}/...`),
+//! existing installations may have legacy keys (`docker/{name}/...`) alongside
+//! new namespaced keys for the same images. This module provides a CLI migration
+//! to consolidate them, eliminating double-counting in GC/retention and storage
+//! reporting.
+//!
+//! Algorithm:
+//! 1. List all keys under `docker/`
+//! 2. Classify each key as namespaced (first segment after `docker/` contains a dot)
+//!    or legacy (no dot — plain image name)
+//! 3. For legacy keys:
+//!    - If a namespaced equivalent already exists → delete legacy (dedup)
+//!    - If no namespaced equivalent → copy data to namespaced key, verify, delete legacy (migrate)
+//! 4. Already-namespaced keys are skipped
+
+use indicatif::{ProgressBar, ProgressStyle};
+use tracing::{info, warn};
+
+use crate::registry::docker::strip_docker_namespace;
+use crate::storage::Storage;
+
+/// Migration options
+#[derive(Default)]
+pub struct MigrateDockerKeysOptions {
+    /// If true, show what would be done without modifying storage
+    pub dry_run: bool,
+}
+
+/// Migration statistics
+#[derive(Debug, Default)]
+pub struct MigrateDockerKeysStats {
+    /// Total docker keys scanned
+    pub total_keys: usize,
+    /// Legacy keys copied to namespaced format and deleted
+    pub migrated: usize,
+    /// Legacy keys deleted because namespaced equivalent exists
+    pub deduped: usize,
+    /// Already-namespaced keys (no action needed)
+    pub skipped: usize,
+    /// Keys that failed to migrate
+    pub failed: usize,
+    /// Bytes freed by removing legacy duplicates
+    pub bytes_freed: u64,
+}
+
+/// Migrate legacy Docker storage keys to namespaced format.
+///
+/// `namespace` is the target namespace prefix (e.g., `"docker.io"`), typically
+/// derived from `DockerUpstream::resolved_namespace()`.
+pub async fn migrate_docker_keys(
+    storage: &Storage,
+    namespace: &str,
+    options: MigrateDockerKeysOptions,
+) -> Result<MigrateDockerKeysStats, String> {
+    println!("Docker key migration: legacy → namespaced (namespace: {namespace})");
+
+    if options.dry_run {
+        println!("DRY RUN — no data will be modified");
+    }
+
+    println!("Scanning docker storage keys...");
+    let all_keys = storage.list("docker/").await;
+
+    if all_keys.is_empty() {
+        println!("No docker keys found in storage.");
+        return Ok(MigrateDockerKeysStats::default());
+    }
+
+    println!("Found {} docker keys to analyze", all_keys.len());
+
+    let pb = ProgressBar::new(all_keys.len() as u64);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos}/{len} ({eta})",
+            )
+            .expect("Invalid progress bar template")
+            .progress_chars("#>-"),
+    );
+
+    let mut stats = MigrateDockerKeysStats {
+        total_keys: all_keys.len(),
+        ..Default::default()
+    };
+
+    for key in &all_keys {
+        let Some(rest) = key.strip_prefix("docker/") else {
+            stats.skipped += 1;
+            pb.inc(1);
+            continue;
+        };
+
+        // Extract repository name: everything before /manifests/ or /blobs/
+        let repo_name = if let Some(idx) = rest.find("/manifests/") {
+            &rest[..idx]
+        } else if let Some(idx) = rest.find("/blobs/") {
+            &rest[..idx]
+        } else {
+            // Not a manifest or blob key — skip (e.g., metadata or unknown)
+            stats.skipped += 1;
+            pb.inc(1);
+            continue;
+        };
+
+        if repo_name.is_empty() {
+            stats.skipped += 1;
+            pb.inc(1);
+            continue;
+        }
+
+        // Classify: if strip_docker_namespace changes the name, it's already namespaced
+        let canonical = strip_docker_namespace(repo_name);
+        if canonical != repo_name {
+            // Already namespaced — no action needed
+            stats.skipped += 1;
+            pb.inc(1);
+            continue;
+        }
+
+        // This is a legacy key (no namespace prefix).
+        // Build the target namespaced key by inserting {namespace}/ after "docker/".
+        let namespaced_key = format!("docker/{namespace}/{rest}");
+
+        // Check if the namespaced equivalent already exists
+        let ns_exists = storage.stat(&namespaced_key).await.is_some();
+
+        if ns_exists {
+            // Namespaced key exists — just remove the legacy duplicate
+            let freed = storage.stat(key).await.map_or(0, |m| m.size);
+
+            if options.dry_run {
+                info!(
+                    legacy_key = %key,
+                    namespaced_key = %namespaced_key,
+                    bytes = freed,
+                    action = "dedup",
+                    "would delete legacy duplicate"
+                );
+                stats.deduped += 1;
+                stats.bytes_freed += freed;
+            } else {
+                match storage.delete(key).await {
+                    Ok(()) => {
+                        info!(
+                            legacy_key = %key,
+                            namespaced_key = %namespaced_key,
+                            bytes = freed,
+                            action = "dedup",
+                            "deleted legacy duplicate"
+                        );
+                        stats.deduped += 1;
+                        stats.bytes_freed += freed;
+                    }
+                    Err(e) => {
+                        warn!(key = %key, error = %e, "failed to delete legacy key");
+                        stats.failed += 1;
+                    }
+                }
+            }
+        } else {
+            // No namespaced equivalent — copy data then delete legacy
+            if options.dry_run {
+                let size = storage.stat(key).await.map_or(0, |m| m.size);
+                info!(
+                    legacy_key = %key,
+                    namespaced_key = %namespaced_key,
+                    bytes = size,
+                    action = "migrate",
+                    "would copy to namespaced key and delete legacy"
+                );
+                stats.migrated += 1;
+            } else {
+                match storage.get(key).await {
+                    Ok(data) => {
+                        let data_len = data.len() as u64;
+
+                        // Write to namespaced location
+                        if let Err(e) = storage.put(&namespaced_key, &data).await {
+                            warn!(
+                                key = %namespaced_key,
+                                error = %e,
+                                "failed to write namespaced key"
+                            );
+                            stats.failed += 1;
+                            pb.inc(1);
+                            continue;
+                        }
+
+                        // Verify write: check size matches
+                        let written_size =
+                            storage.stat(&namespaced_key).await.map_or(0, |m| m.size);
+                        if written_size != data_len {
+                            warn!(
+                                key = %namespaced_key,
+                                expected = data_len,
+                                actual = written_size,
+                                "size mismatch after write — skipping delete"
+                            );
+                            stats.failed += 1;
+                            pb.inc(1);
+                            continue;
+                        }
+
+                        // Delete legacy key
+                        match storage.delete(key).await {
+                            Ok(()) => {
+                                info!(
+                                    legacy_key = %key,
+                                    namespaced_key = %namespaced_key,
+                                    bytes = data_len,
+                                    action = "migrate",
+                                    "migrated to namespaced key"
+                                );
+                                stats.migrated += 1;
+                                stats.bytes_freed += data_len;
+                            }
+                            Err(e) => {
+                                warn!(
+                                    key = %key,
+                                    error = %e,
+                                    "copied to namespaced but failed to delete legacy"
+                                );
+                                // Still counts as partial success — data is not lost
+                                stats.migrated += 1;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(key = %key, error = %e, "failed to read legacy key");
+                        stats.failed += 1;
+                    }
+                }
+            }
+        }
+
+        pb.inc(1);
+    }
+
+    pb.finish_with_message("Migration complete");
+
+    println!();
+    println!("Docker key migration summary:");
+    println!("  Total keys scanned:  {}", stats.total_keys);
+    println!("  Migrated (copy+del): {}", stats.migrated);
+    println!("  Deduped (del legacy): {}", stats.deduped);
+    println!("  Skipped (already ns): {}", stats.skipped);
+    println!("  Failed:              {}", stats.failed);
+    println!("  Bytes freed:         {} KB", stats.bytes_freed / 1024);
+
+    if stats.failed > 0 {
+        warn!("{} keys failed to migrate", stats.failed);
+    }
+
+    if options.dry_run {
+        info!("Dry run complete. Re-run without --dry-run to perform actual migration.");
+    }
+
+    Ok(stats)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn test_migrate_legacy_to_namespaced() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        // Legacy key (no namespace)
+        storage
+            .put(
+                "docker/library/nginx/manifests/latest.json",
+                b"manifest-data",
+            )
+            .await
+            .unwrap();
+
+        let stats = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.migrated, 1);
+        assert_eq!(stats.deduped, 0);
+        assert_eq!(stats.failed, 0);
+
+        // Legacy key should be gone
+        assert!(storage
+            .get("docker/library/nginx/manifests/latest.json")
+            .await
+            .is_err());
+        // Namespaced key should exist with same data
+        let data = storage
+            .get("docker/docker.io/library/nginx/manifests/latest.json")
+            .await
+            .unwrap();
+        assert_eq!(&*data, b"manifest-data");
+    }
+
+    #[tokio::test]
+    async fn test_dedup_when_both_exist() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        // Both formats exist
+        storage
+            .put("docker/library/nginx/manifests/latest.json", b"old-data")
+            .await
+            .unwrap();
+        storage
+            .put(
+                "docker/docker.io/library/nginx/manifests/latest.json",
+                b"new-data",
+            )
+            .await
+            .unwrap();
+
+        let stats = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.deduped, 1, "legacy duplicate should be deduped");
+        assert_eq!(stats.skipped, 1, "namespaced key should be skipped");
+        assert_eq!(stats.migrated, 0);
+
+        // Legacy gone, namespaced preserved with its own data
+        assert!(storage
+            .get("docker/library/nginx/manifests/latest.json")
+            .await
+            .is_err());
+        let data = storage
+            .get("docker/docker.io/library/nginx/manifests/latest.json")
+            .await
+            .unwrap();
+        assert_eq!(&*data, b"new-data");
+    }
+
+    #[tokio::test]
+    async fn test_skip_already_namespaced() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        // Only namespaced key
+        storage
+            .put(
+                "docker/docker.io/library/nginx/manifests/latest.json",
+                b"data",
+            )
+            .await
+            .unwrap();
+
+        let stats = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.skipped, 1);
+        assert_eq!(stats.migrated, 0);
+        assert_eq!(stats.deduped, 0);
+    }
+
+    #[tokio::test]
+    async fn test_dry_run_does_not_modify() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        storage
+            .put("docker/library/nginx/manifests/latest.json", b"data")
+            .await
+            .unwrap();
+
+        let stats = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: true },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.migrated, 1);
+
+        // Original key should still exist (dry run)
+        assert!(storage
+            .get("docker/library/nginx/manifests/latest.json")
+            .await
+            .is_ok());
+        // Namespaced key should NOT exist
+        assert!(storage
+            .get("docker/docker.io/library/nginx/manifests/latest.json")
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_empty_storage() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        let stats = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.total_keys, 0);
+        assert_eq!(stats.migrated, 0);
+    }
+
+    #[tokio::test]
+    async fn test_migrate_blobs() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        // Legacy blob key
+        storage
+            .put("docker/library/nginx/blobs/sha256:abc123", b"blob-data")
+            .await
+            .unwrap();
+
+        let stats = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(stats.migrated, 1);
+
+        // Should be at namespaced location
+        let data = storage
+            .get("docker/docker.io/library/nginx/blobs/sha256:abc123")
+            .await
+            .unwrap();
+        assert_eq!(&*data, b"blob-data");
+    }
+
+    #[tokio::test]
+    async fn test_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        storage
+            .put("docker/library/nginx/manifests/latest.json", b"data")
+            .await
+            .unwrap();
+
+        // First run: migrates
+        let stats1 = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+        assert_eq!(stats1.migrated, 1);
+
+        // Second run: nothing to do
+        let stats2 = migrate_docker_keys(
+            &storage,
+            "docker.io",
+            MigrateDockerKeysOptions { dry_run: false },
+        )
+        .await
+        .unwrap();
+        assert_eq!(stats2.migrated, 0);
+        assert_eq!(stats2.skipped, 1);
+    }
+}

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -13,6 +13,7 @@ mod config;
 mod curation;
 mod dashboard_metrics;
 mod digest_quarantine;
+mod docker_key_migration;
 mod gc;
 mod hash_pin_store;
 mod health;
@@ -126,6 +127,12 @@ enum Commands {
     Curation {
         #[command(subcommand)]
         action: CurationCommand,
+    },
+    /// Migrate legacy Docker storage keys to namespaced format
+    MigrateDockerKeys {
+        /// Dry run — show what would be migrated without modifying storage
+        #[arg(long, default_value = "false")]
+        dry_run: bool,
     },
 }
 
@@ -526,6 +533,41 @@ async fn main() {
                 run_curation_explain(&config, &package);
             }
         },
+        Some(Commands::MigrateDockerKeys { dry_run }) => {
+            let namespace = config
+                .docker
+                .upstreams
+                .first()
+                .map(|u| u.resolved_namespace())
+                .unwrap_or_else(|| "docker.io".to_string());
+
+            if config.docker.upstreams.len() > 1 {
+                warn!(
+                    namespace = %namespace,
+                    upstream_count = config.docker.upstreams.len(),
+                    "Multiple Docker upstreams configured; using first upstream namespace for migration"
+                );
+            }
+
+            match docker_key_migration::migrate_docker_keys(
+                &storage,
+                &namespace,
+                docker_key_migration::MigrateDockerKeysOptions { dry_run },
+            )
+            .await
+            {
+                Ok(stats) => {
+                    if stats.failed > 0 {
+                        error!("{} keys failed to migrate", stats.failed);
+                        std::process::exit(1);
+                    }
+                }
+                Err(e) => {
+                    error!("Docker key migration failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
     }
 }
 

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -107,6 +107,13 @@ lazy_static! {
         "Storage size in bytes by registry",
         &["registry"]
     ).expect("failed to create STORAGE_BYTES metric at startup");
+
+    /// Cache write errors by registry and operation (#500)
+    pub static ref CACHE_WRITE_ERRORS: IntCounterVec = register_int_counter_vec!(
+        "nora_cache_write_errors_total",
+        "Cache write failures in background cache tasks",
+        &["registry", "operation"]
+    ).expect("failed to create CACHE_WRITE_ERRORS metric at startup");
 }
 
 /// Maximum response body size to scan for upstream URL leaks (2 MB).

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1044,6 +1044,128 @@ async fn upload_blob(
     }
 }
 
+/// Try to fetch a manifest from upstream(s) and cache it locally.
+///
+/// Iterates over `upstreams`, fetching `upstream_name` (which may differ from
+/// the user-facing `name` — e.g. `library/nginx` vs `nginx`). On success:
+/// records metrics/activity, runs quarantine, spawns a cache task that writes
+/// the manifest by tag, by digest, plus metadata sidecars.
+///
+/// Returns `Some(Response)` on first successful upstream (or quarantine block),
+/// `None` if all upstreams failed.
+async fn try_fetch_and_cache(
+    state: &Arc<AppState>,
+    upstreams: &[&crate::config::DockerUpstream],
+    upstream_name: &str,
+    name: &str,
+    reference: &str,
+    cache_key: &str,
+) -> Option<Response> {
+    for upstream in upstreams {
+        tracing::debug!(upstream_url = %upstream.url, upstream_name = %upstream_name, "Trying upstream");
+        match fetch_manifest_from_upstream(
+            &state.http_client,
+            &upstream.url,
+            upstream_name,
+            reference,
+            &state.docker_auth,
+            state.config.docker.proxy_timeout,
+            upstream.auth.as_deref(),
+            &state.circuit_breaker,
+        )
+        .await
+        {
+            Ok((data, content_type)) => {
+                state.metrics.record_download("docker");
+                state.metrics.record_cache_miss("docker");
+                state.activity.push(ActivityEntry::new(
+                    ActionType::ProxyFetch,
+                    format!("{}:{}", name, reference),
+                    "docker",
+                    "PROXY",
+                ));
+
+                // Calculate digest for Docker-Content-Digest header
+                use sha2::Digest;
+                let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&data)));
+
+                // Quarantine: record digest, check status
+                let (q_mode, q_secs) = resolve_quarantine(state);
+                if !matches!(q_mode, crate::digest_quarantine::QuarantineMode::Off) {
+                    state.digest_store.record("docker", &digest, &upstream.url);
+                    let q_status = state.digest_store.check("docker", &digest, q_secs);
+                    match &q_status {
+                        crate::digest_quarantine::QuarantineStatus::Mature => {}
+                        _ => {
+                            tracing::warn!(
+                                digest = %digest,
+                                upstream = %upstream.url,
+                                status = %q_status.header_value(),
+                                mode = ?q_mode,
+                                "Quarantine: proxy-fetched manifest"
+                            );
+                        }
+                    }
+                    // In enforce mode, still cache but block the client
+                    if matches!(q_mode, crate::digest_quarantine::QuarantineMode::Enforce)
+                        && !matches!(q_status, crate::digest_quarantine::QuarantineStatus::Mature)
+                    {
+                        let storage = state.storage.clone();
+                        let key_clone = cache_key.to_string();
+                        let state_clone = Arc::clone(state);
+                        tokio::spawn(async move {
+                            let _ = storage.put(&key_clone, &data).await;
+                            state_clone.repo_index.invalidate("docker");
+                        });
+                        return Some(quarantine_forbidden(&digest, &q_status, q_secs));
+                    }
+                }
+
+                // Cache manifest and create metadata (fire and forget)
+                let upstream_ns = Some(upstream.resolved_namespace());
+                let storage = state.storage.clone();
+                let key_clone = cache_key.to_string();
+                let data_clone = data.clone();
+                let name_clone = name.to_string();
+                let reference_clone = reference.to_string();
+                let digest_clone = digest.clone();
+                let state_clone = Arc::clone(state);
+                tokio::spawn(async move {
+                    // Store manifest by tag and digest (namespaced)
+                    let _ = storage.put(&key_clone, &data_clone).await;
+                    let digest_key =
+                        manifest_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
+                    let _ = storage.put(&digest_key, &data_clone).await;
+
+                    // Extract and save metadata
+                    let metadata = extract_metadata(&data_clone, &storage, &name_clone).await;
+                    if let Ok(meta_json) = serde_json::to_vec(&metadata) {
+                        let meta_key = manifest_meta_key(
+                            upstream_ns.as_deref(),
+                            &name_clone,
+                            &reference_clone,
+                        );
+                        let _ = storage.put(&meta_key, &meta_json).await;
+
+                        let digest_meta_key =
+                            manifest_meta_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
+                        let _ = storage.put(&digest_meta_key, &meta_json).await;
+                    }
+                    state_clone.repo_index.invalidate("docker");
+                });
+
+                return Some(manifest_response(data, content_type, digest));
+            }
+            Err(ProxyError::CircuitOpen(reg)) => return Some(circuit_open_response(&reg)),
+            Err(e) => {
+                tracing::debug!(error = ?e, upstream = %upstream.url, name = %upstream_name, reference = %reference, "Docker manifest proxy fetch failed, trying next");
+                continue;
+            }
+        }
+    }
+    None
+}
+
 async fn get_manifest(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,
@@ -1114,193 +1236,27 @@ async fn get_manifest(
         upstreams_count = upstreams_to_try.len(),
         "Trying upstream proxies"
     );
-    for upstream in &upstreams_to_try {
-        tracing::debug!(upstream_url = %upstream.url, "Trying upstream");
-        match fetch_manifest_from_upstream(
-            &state.http_client,
-            &upstream.url,
-            &name,
-            &reference,
-            &state.docker_auth,
-            state.config.docker.proxy_timeout,
-            upstream.auth.as_deref(),
-            &state.circuit_breaker,
-        )
-        .await
-        {
-            Ok((data, content_type)) => {
-                state.metrics.record_download("docker");
-                state.metrics.record_cache_miss("docker");
-                state.activity.push(ActivityEntry::new(
-                    ActionType::ProxyFetch,
-                    format!("{}:{}", name, reference),
-                    "docker",
-                    "PROXY",
-                ));
-
-                // Calculate digest for Docker-Content-Digest header
-                use sha2::Digest;
-                let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&data)));
-
-                // Quarantine: record digest, check status
-                let (q_mode, q_secs) = resolve_quarantine(&state);
-                if !matches!(q_mode, crate::digest_quarantine::QuarantineMode::Off) {
-                    state.digest_store.record("docker", &digest, &upstream.url);
-                    let q_status = state.digest_store.check("docker", &digest, q_secs);
-                    match &q_status {
-                        crate::digest_quarantine::QuarantineStatus::Mature => {}
-                        _ => {
-                            tracing::warn!(
-                                digest = %digest,
-                                upstream = %upstream.url,
-                                status = %q_status.header_value(),
-                                mode = ?q_mode,
-                                "Quarantine: proxy-fetched manifest"
-                            );
-                        }
-                    }
-                    // In enforce mode, still cache but block the client
-                    if matches!(q_mode, crate::digest_quarantine::QuarantineMode::Enforce)
-                        && !matches!(q_status, crate::digest_quarantine::QuarantineStatus::Mature)
-                    {
-                        // Cache manifest so it's ready after quarantine expires
-                        let storage = state.storage.clone();
-                        let key_clone = key.clone();
-                        let state_clone = Arc::clone(&state);
-                        tokio::spawn(async move {
-                            let _ = storage.put(&key_clone, &data).await;
-                            state_clone.repo_index.invalidate("docker");
-                        });
-                        return quarantine_forbidden(&digest, &q_status, q_secs);
-                    }
-                }
-
-                // Cache manifest and create metadata (fire and forget)
-                let upstream_ns = Some(upstream.resolved_namespace());
-                let storage = state.storage.clone();
-                let key_clone = key.clone();
-                let data_clone = data.clone();
-                let name_clone = name.clone();
-                let reference_clone = reference.clone();
-                let digest_clone = digest.clone();
-                let state_clone = Arc::clone(&state);
-                tokio::spawn(async move {
-                    // Store manifest by tag and digest (namespaced)
-                    let _ = storage.put(&key_clone, &data_clone).await;
-                    let digest_key =
-                        manifest_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
-                    let _ = storage.put(&digest_key, &data_clone).await;
-
-                    // Extract and save metadata
-                    let metadata = extract_metadata(&data_clone, &storage, &name_clone).await;
-                    if let Ok(meta_json) = serde_json::to_vec(&metadata) {
-                        let meta_key = manifest_meta_key(
-                            upstream_ns.as_deref(),
-                            &name_clone,
-                            &reference_clone,
-                        );
-                        let _ = storage.put(&meta_key, &meta_json).await;
-
-                        let digest_meta_key =
-                            manifest_meta_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
-                        let _ = storage.put(&digest_meta_key, &meta_json).await;
-                    }
-                    state_clone.repo_index.invalidate("docker");
-                });
-
-                return manifest_response(data, content_type, digest);
-            }
-            Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-            Err(e) => {
-                tracing::debug!(error = ?e, upstream = %upstream.url, name = %name, reference = %reference, "Docker manifest proxy fetch failed, trying next");
-                continue;
-            }
-        }
+    if let Some(response) =
+        try_fetch_and_cache(&state, &upstreams_to_try, &name, &name, &reference, &key).await
+    {
+        return response;
     }
 
     // Auto-prepend library/ for single-segment names (Docker Hub official images)
     // e.g., "nginx" -> "library/nginx", "alpine" -> "library/alpine"
     if !name.contains('/') {
         let library_name = format!("library/{}", name);
-        for upstream in &upstreams_to_try {
-            match fetch_manifest_from_upstream(
-                &state.http_client,
-                &upstream.url,
-                &library_name,
-                &reference,
-                &state.docker_auth,
-                state.config.docker.proxy_timeout,
-                upstream.auth.as_deref(),
-                &state.circuit_breaker,
-            )
-            .await
-            {
-                Ok((data, content_type)) => {
-                    state.metrics.record_download("docker");
-                    state.metrics.record_cache_miss("docker");
-                    state.activity.push(ActivityEntry::new(
-                        ActionType::ProxyFetch,
-                        format!("{}:{}", name, reference),
-                        "docker",
-                        "PROXY",
-                    ));
-
-                    use sha2::Digest;
-                    let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&data)));
-
-                    // Quarantine: record digest, check status
-                    let (q_mode, q_secs) = resolve_quarantine(&state);
-                    if !matches!(q_mode, crate::digest_quarantine::QuarantineMode::Off) {
-                        state.digest_store.record("docker", &digest, &upstream.url);
-                        let q_status = state.digest_store.check("docker", &digest, q_secs);
-                        match &q_status {
-                            crate::digest_quarantine::QuarantineStatus::Mature => {}
-                            _ => {
-                                tracing::warn!(
-                                    digest = %digest,
-                                    upstream = %upstream.url,
-                                    status = %q_status.header_value(),
-                                    mode = ?q_mode,
-                                    "Quarantine: proxy-fetched manifest (library/)"
-                                );
-                            }
-                        }
-                        if matches!(q_mode, crate::digest_quarantine::QuarantineMode::Enforce)
-                            && !matches!(
-                                q_status,
-                                crate::digest_quarantine::QuarantineStatus::Mature
-                            )
-                        {
-                            // Cache even though quarantined
-                            let storage = state.storage.clone();
-                            let key_clone = key.clone();
-                            tokio::spawn(async move {
-                                let _ = storage.put(&key_clone, &data).await;
-                            });
-                            return quarantine_forbidden(&digest, &q_status, q_secs);
-                        }
-                    }
-
-                    // Cache under original name for future local hits
-                    let storage = state.storage.clone();
-                    let key_clone = key.clone();
-                    let data_clone = data.clone();
-                    tokio::spawn(async move {
-                        if let Err(e) = storage.put(&key_clone, &data_clone).await {
-                            tracing::warn!(key = %key_clone, error = %e, "Failed to cache blob in storage");
-                        }
-                    });
-
-                    state.repo_index.invalidate("docker");
-
-                    return manifest_response(data, content_type, digest);
-                }
-                Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-                Err(e) => {
-                    tracing::debug!(error = ?e, upstream = %upstream.url, name = %library_name, reference = %reference, "Docker manifest proxy fetch failed, trying next");
-                    continue;
-                }
-            }
+        if let Some(response) = try_fetch_and_cache(
+            &state,
+            &upstreams_to_try,
+            &library_name,
+            &name,
+            &reference,
+            &key,
+        )
+        .await
+        {
+            return response;
         }
     }
 

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -67,24 +67,53 @@ fn manifest_prefix(namespace: Option<&str>, name: &str) -> String {
     }
 }
 
-/// Resolve upstream and namespace for a Docker image name.
+/// Result of Docker image name canonicalization.
 ///
-/// Returns `(matched_upstream, stripped_name, namespace)`:
-/// - If `raw_name` starts with a configured prefix (e.g. `docker-hub/library/nginx`),
-///   returns the matching upstream, the name with prefix stripped (`library/nginx`),
-///   and that upstream's namespace.
-/// - Otherwise falls back to the first upstream (existing behavior).
-fn resolve_upstream<'c, 'n>(
-    config: &'c crate::config::DockerConfig,
-    raw_name: &'n str,
-) -> (
-    Option<&'c crate::config::DockerUpstream>,
-    &'n str,
-    Option<String>,
-) {
-    // Check for prefix-based routing: first path segment matches an upstream prefix
+/// Unifies both config-aware prefix routing and hostname-based namespace
+/// detection into a single entry point, eliminating the asymmetry between
+/// write-path (former `resolve_upstream`) and read-path (`strip_docker_namespace`).
+pub(crate) struct Canonical {
+    /// Cleaned image name (prefix/hostname stripped).
+    pub name: String,
+    /// Namespace for storage key construction (e.g. `"docker.io"`).
+    pub namespace: Option<String>,
+    /// Index of the prefix-matched upstream in the config, if any.
+    matched_upstream_idx: Option<usize>,
+}
+
+impl Canonical {
+    /// Get the list of upstreams to try for fetching this image.
+    ///
+    /// If a specific upstream was matched by prefix, returns only that one.
+    /// Otherwise returns all configured upstreams (fallback chain).
+    pub fn upstreams_to_try<'a>(
+        &self,
+        upstreams: &'a [crate::config::DockerUpstream],
+    ) -> Vec<&'a crate::config::DockerUpstream> {
+        match self.matched_upstream_idx {
+            Some(idx) => vec![&upstreams[idx]],
+            None => upstreams.iter().collect(),
+        }
+    }
+}
+
+/// Canonicalize a Docker image name: resolve upstream, strip prefix/hostname,
+/// and determine the storage namespace.
+///
+/// This is the single entry point for Docker name resolution. Use instead of
+/// the heuristic `strip_docker_namespace()` whenever upstream config is available.
+///
+/// Resolution order (early-return):
+/// 1. Prefix match — first path segment matches a configured upstream prefix
+/// 2. Hostname detection — first segment contains a dot (FQDN like `docker.io`)
+/// 3. Fallback — use the first configured upstream, keep name as-is
+pub(crate) fn canonicalize(
+    raw_name: &str,
+    upstreams: &[crate::config::DockerUpstream],
+) -> Canonical {
+    // Step 1: Check for prefix-based routing
     if let Some((first_segment, rest)) = raw_name.split_once('/') {
-        for upstream in &config.upstreams {
+        for (idx, upstream) in upstreams.iter().enumerate() {
             if let Some(ref prefix) = upstream.prefix {
                 if first_segment == prefix {
                     tracing::debug!(
@@ -94,15 +123,45 @@ fn resolve_upstream<'c, 'n>(
                         routing = "prefix",
                         "Docker path-based upstream routing"
                     );
-                    return (Some(upstream), rest, Some(upstream.resolved_namespace()));
+                    return Canonical {
+                        name: rest.to_string(),
+                        namespace: Some(upstream.resolved_namespace()),
+                        matched_upstream_idx: Some(idx),
+                    };
                 }
             }
         }
+
+        // Step 2: Hostname detection (dot in first segment = FQDN)
+        if first_segment.contains('.') && !rest.is_empty() {
+            // Check if it matches a known upstream's namespace
+            for (idx, upstream) in upstreams.iter().enumerate() {
+                let ns = upstream.resolved_namespace();
+                if first_segment == ns {
+                    return Canonical {
+                        name: rest.to_string(),
+                        namespace: Some(ns),
+                        matched_upstream_idx: Some(idx),
+                    };
+                }
+            }
+            // Unknown hostname — strip it but use default upstream
+            let ns = upstreams.first().map(|u| u.resolved_namespace());
+            return Canonical {
+                name: rest.to_string(),
+                namespace: ns,
+                matched_upstream_idx: None,
+            };
+        }
     }
 
-    // Fallback: first upstream (existing behavior for single-upstream setups)
-    let ns = config.upstreams.first().map(|u| u.resolved_namespace());
-    (None, raw_name, ns)
+    // Step 3: Fallback — first upstream, name unchanged
+    let ns = upstreams.first().map(|u| u.resolved_namespace());
+    Canonical {
+        name: raw_name.to_string(),
+        namespace: ns,
+        matched_upstream_idx: None,
+    }
 }
 
 /// Try to get content from namespaced key, falling back to legacy (non-namespaced) key.
@@ -458,12 +517,14 @@ async fn check() -> impl IntoResponse {
     )
 }
 
-/// Strip upstream namespace prefix from a Docker repository name.
+/// Strip hostname prefix from a Docker repository name (config-free heuristic).
 ///
-/// Storage keys include the upstream namespace (e.g. `docker.io/library/nginx`),
-/// but catalog and UI should show the clean image name (`library/nginx`).
-/// Namespace segments are detected by containing a dot (hostnames like `docker.io`,
-/// `ghcr.io`), which is not valid in Docker org/user names.
+/// Detects hostnames by checking for a dot in the first path segment
+/// (e.g. `docker.io/library/nginx` → `library/nginx`).
+///
+/// **When to use:** Only in config-free contexts like storage key classification
+/// (e.g., `docker_key_migration`). For request-time routing, use [`canonicalize()`]
+/// which is config-aware and handles prefix-based upstream matching.
 pub(crate) fn strip_docker_namespace(name: &str) -> &str {
     if let Some((first, rest)) = name.split_once('/') {
         if first.contains('.') && !rest.is_empty() {
@@ -493,9 +554,9 @@ async fn catalog(State(state): State<Arc<AppState>>) -> Json<Value> {
             if name.is_empty() {
                 return None;
             }
-            // Strip upstream namespace prefix (e.g. "docker.io/" or "ghcr.io/")
+            // Canonicalize to strip upstream namespace prefix (e.g. "docker.io/")
             // so that images proxied through different upstreams are deduplicated.
-            Some(strip_docker_namespace(name).to_string())
+            Some(canonicalize(name, &state.config.docker.upstreams).name)
         })
         .collect();
 
@@ -509,8 +570,8 @@ async fn check_blob(
     State(state): State<Arc<AppState>>,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
-    let (_matched, name, ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let c = canonicalize(&name, &state.config.docker.upstreams);
+    let name = c.name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -518,7 +579,7 @@ async fn check_blob(
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    let key = blob_key(ns.as_deref(), &name, &digest);
+    let key = blob_key(c.namespace.as_deref(), &name, &digest);
     let legacy_key = blob_key(None, &name, &digest);
     match storage_get_with_fallback(&state.storage, &key, &legacy_key).await {
         Ok(data) => (
@@ -539,8 +600,10 @@ async fn download_blob(
     headers: axum::http::HeaderMap,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
-    let (matched_upstream, name, ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let c = canonicalize(&name, &state.config.docker.upstreams);
+    let upstreams_to_try = c.upstreams_to_try(&state.config.docker.upstreams);
+    let ns = c.namespace;
+    let name = c.name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -596,13 +659,7 @@ async fn download_blob(
             .into_response();
     }
 
-    // Select upstreams: prefix-matched → single upstream, otherwise → fallback chain
-    let upstreams_to_try: Vec<&crate::config::DockerUpstream> = match matched_upstream {
-        Some(u) => vec![u],
-        None => state.config.docker.upstreams.iter().collect(),
-    };
-
-    // Try upstream proxies
+    // Try upstream proxies (prefix-matched → single upstream, otherwise → fallback chain)
     for upstream in &upstreams_to_try {
         match fetch_blob_from_upstream(
             &state.http_client,
@@ -688,8 +745,7 @@ async fn download_blob(
 }
 
 async fn start_upload(State(state): State<Arc<AppState>>, Path(name): Path<String>) -> Response {
-    let (_matched, name, _ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let name = canonicalize(&name, &state.config.docker.upstreams).name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -741,8 +797,7 @@ async fn patch_blob(
     Path((name, uuid)): Path<(String, String)>,
     body: Bytes,
 ) -> Response {
-    let (_matched, name, _ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let name = canonicalize(&name, &state.config.docker.upstreams).name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -869,8 +924,7 @@ async fn upload_blob(
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: Bytes,
 ) -> Response {
-    let (_matched, name, _ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let name = canonicalize(&name, &state.config.docker.upstreams).name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -1198,8 +1252,10 @@ async fn get_manifest(
     headers: axum::http::HeaderMap,
     Path((name, reference)): Path<(String, String)>,
 ) -> Response {
-    let (matched_upstream, name, ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let c = canonicalize(&name, &state.config.docker.upstreams);
+    let upstreams_to_try = c.upstreams_to_try(&state.config.docker.upstreams);
+    let ns = c.namespace;
+    let name = c.name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -1251,12 +1307,6 @@ async fn get_manifest(
             return serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
         }
     }
-
-    // Select upstreams: prefix-matched → single upstream, otherwise → fallback chain
-    let upstreams_to_try: Vec<&crate::config::DockerUpstream> = match matched_upstream {
-        Some(u) => vec![u],
-        None => state.config.docker.upstreams.iter().collect(),
-    };
 
     // Try upstream proxies (always if no cache, or if cache is stale)
     tracing::debug!(
@@ -1379,8 +1429,7 @@ async fn put_manifest(
     Path((name, reference)): Path<(String, String)>,
     body: Bytes,
 ) -> Response {
-    let (_matched, name, _ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let name = canonicalize(&name, &state.config.docker.upstreams).name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -1459,8 +1508,9 @@ async fn put_manifest(
 }
 
 async fn list_tags(State(state): State<Arc<AppState>>, Path(name): Path<String>) -> Response {
-    let (_matched, name, ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let c = canonicalize(&name, &state.config.docker.upstreams);
+    let ns = c.namespace;
+    let name = c.name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -1494,8 +1544,9 @@ async fn delete_manifest(
     State(state): State<Arc<AppState>>,
     Path((name, reference)): Path<(String, String)>,
 ) -> Response {
-    let (_matched, name, ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let c = canonicalize(&name, &state.config.docker.upstreams);
+    let ns = c.namespace;
+    let name = c.name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -1613,8 +1664,9 @@ async fn delete_blob(
     State(state): State<Arc<AppState>>,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
-    let (_matched, name, ns) = resolve_upstream(&state.config.docker, &name);
-    let name = name.to_string();
+    let c = canonicalize(&name, &state.config.docker.upstreams);
+    let ns = c.namespace;
+    let name = c.name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
@@ -3172,5 +3224,105 @@ mod integration_tests {
 
         // All three keys should resolve to a single repo: "library/nginx"
         assert_eq!(repos, vec!["library/nginx"]);
+    }
+
+    #[test]
+    fn test_canonicalize_prefix_routing() {
+        let upstreams = vec![crate::config::DockerUpstream {
+            url: "https://registry-1.docker.io".to_string(),
+            auth: None,
+            namespace: Some("docker.io".to_string()),
+            prefix: Some("docker-hub".to_string()),
+        }];
+
+        let c = super::canonicalize("docker-hub/library/nginx", &upstreams);
+        assert_eq!(c.name, "library/nginx");
+        assert_eq!(c.namespace.as_deref(), Some("docker.io"));
+        assert_eq!(c.upstreams_to_try(&upstreams).len(), 1);
+    }
+
+    #[test]
+    fn test_canonicalize_hostname_detection() {
+        let upstreams = vec![crate::config::DockerUpstream {
+            url: "https://registry-1.docker.io".to_string(),
+            auth: None,
+            namespace: Some("docker.io".to_string()),
+            prefix: None,
+        }];
+
+        let c = super::canonicalize("docker.io/library/nginx", &upstreams);
+        assert_eq!(c.name, "library/nginx");
+        assert_eq!(c.namespace.as_deref(), Some("docker.io"));
+        // Known namespace matches specific upstream
+        assert_eq!(c.upstreams_to_try(&upstreams).len(), 1);
+
+        // Unknown hostname → strip but use default upstream
+        let c2 = super::canonicalize("ghcr.io/requarks/wiki", &upstreams);
+        assert_eq!(c2.name, "requarks/wiki");
+        assert_eq!(c2.namespace.as_deref(), Some("docker.io"));
+        // No specific match → all upstreams
+        assert_eq!(c2.upstreams_to_try(&upstreams).len(), 1); // only 1 configured
+    }
+
+    #[test]
+    fn test_canonicalize_fallback() {
+        let upstreams = vec![crate::config::DockerUpstream {
+            url: "https://registry-1.docker.io".to_string(),
+            auth: None,
+            namespace: Some("docker.io".to_string()),
+            prefix: None,
+        }];
+
+        // No prefix, no dot in first segment → fallback
+        let c = super::canonicalize("library/nginx", &upstreams);
+        assert_eq!(c.name, "library/nginx");
+        assert_eq!(c.namespace.as_deref(), Some("docker.io"));
+        assert_eq!(c.upstreams_to_try(&upstreams).len(), 1);
+
+        // Single segment
+        let c2 = super::canonicalize("alpine", &upstreams);
+        assert_eq!(c2.name, "alpine");
+        assert_eq!(c2.namespace.as_deref(), Some("docker.io"));
+    }
+
+    #[test]
+    fn test_canonicalize_empty_upstreams() {
+        let upstreams: Vec<crate::config::DockerUpstream> = vec![];
+
+        let c = super::canonicalize("library/nginx", &upstreams);
+        assert_eq!(c.name, "library/nginx");
+        assert!(c.namespace.is_none());
+        assert!(c.upstreams_to_try(&upstreams).is_empty());
+    }
+
+    #[test]
+    fn test_canonicalize_multi_upstream() {
+        let upstreams = vec![
+            crate::config::DockerUpstream {
+                url: "https://registry-1.docker.io".to_string(),
+                auth: None,
+                namespace: Some("docker.io".to_string()),
+                prefix: Some("docker-hub".to_string()),
+            },
+            crate::config::DockerUpstream {
+                url: "https://ghcr.io".to_string(),
+                auth: None,
+                namespace: Some("ghcr.io".to_string()),
+                prefix: Some("ghcr".to_string()),
+            },
+        ];
+
+        // Prefix routes to specific upstream
+        let c1 = super::canonicalize("ghcr/requarks/wiki", &upstreams);
+        assert_eq!(c1.name, "requarks/wiki");
+        assert_eq!(c1.namespace.as_deref(), Some("ghcr.io"));
+        let targets = c1.upstreams_to_try(&upstreams);
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].url, "https://ghcr.io");
+
+        // No prefix match → all upstreams
+        let c2 = super::canonicalize("library/nginx", &upstreams);
+        assert_eq!(c2.name, "library/nginx");
+        assert_eq!(c2.upstreams_to_try(&upstreams).len(), 2);
     }
 }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -218,7 +218,9 @@ pub fn cleanup_expired_sessions(sessions: &RwLock<HashMap<String, UploadSession>
 /// Get the temp directory for Docker uploads, creating it if needed.
 fn upload_temp_dir(data_dir: &str) -> std::path::PathBuf {
     let dir = std::path::PathBuf::from(data_dir).join("tmp/docker-uploads");
-    let _ = std::fs::create_dir_all(&dir);
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::error!(path = %dir.display(), error = %e, "failed to create upload temp directory");
+    }
     dir
 }
 
@@ -1114,7 +1116,12 @@ async fn try_fetch_and_cache(
                         let key_clone = cache_key.to_string();
                         let state_clone = Arc::clone(state);
                         tokio::spawn(async move {
-                            let _ = storage.put(&key_clone, &data).await;
+                            if let Err(e) = storage.put(&key_clone, &data).await {
+                                tracing::warn!(key = %key_clone, error = %e, "cache write failed (quarantine pre-cache)");
+                                crate::metrics::CACHE_WRITE_ERRORS
+                                    .with_label_values(&["docker", "manifest"])
+                                    .inc();
+                            }
                             state_clone.repo_index.invalidate("docker");
                         });
                         return Some(quarantine_forbidden(&digest, &q_status, q_secs));
@@ -1132,10 +1139,20 @@ async fn try_fetch_and_cache(
                 let state_clone = Arc::clone(state);
                 tokio::spawn(async move {
                     // Store manifest by tag and digest (namespaced)
-                    let _ = storage.put(&key_clone, &data_clone).await;
+                    if let Err(e) = storage.put(&key_clone, &data_clone).await {
+                        tracing::warn!(key = %key_clone, error = %e, "cache write failed (manifest by tag)");
+                        crate::metrics::CACHE_WRITE_ERRORS
+                            .with_label_values(&["docker", "manifest"])
+                            .inc();
+                    }
                     let digest_key =
                         manifest_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
-                    let _ = storage.put(&digest_key, &data_clone).await;
+                    if let Err(e) = storage.put(&digest_key, &data_clone).await {
+                        tracing::warn!(key = %digest_key, error = %e, "cache write failed (manifest by digest)");
+                        crate::metrics::CACHE_WRITE_ERRORS
+                            .with_label_values(&["docker", "manifest"])
+                            .inc();
+                    }
 
                     // Extract and save metadata
                     let metadata = extract_metadata(&data_clone, &storage, &name_clone).await;
@@ -1145,11 +1162,21 @@ async fn try_fetch_and_cache(
                             &name_clone,
                             &reference_clone,
                         );
-                        let _ = storage.put(&meta_key, &meta_json).await;
+                        if let Err(e) = storage.put(&meta_key, &meta_json).await {
+                            tracing::warn!(key = %meta_key, error = %e, "cache write failed (metadata by tag)");
+                            crate::metrics::CACHE_WRITE_ERRORS
+                                .with_label_values(&["docker", "metadata"])
+                                .inc();
+                        }
 
                         let digest_meta_key =
                             manifest_meta_key(upstream_ns.as_deref(), &name_clone, &digest_clone);
-                        let _ = storage.put(&digest_meta_key, &meta_json).await;
+                        if let Err(e) = storage.put(&digest_meta_key, &meta_json).await {
+                            tracing::warn!(key = %digest_meta_key, error = %e, "cache write failed (metadata by digest)");
+                            crate::metrics::CACHE_WRITE_ERRORS
+                                .with_label_values(&["docker", "metadata"])
+                                .inc();
+                        }
                     }
                     state_clone.repo_index.invalidate("docker");
                 });
@@ -1387,11 +1414,21 @@ async fn put_manifest(
     let metadata = extract_metadata(&body, &state.storage, &name).await;
     let meta_key = format!("docker/{}/manifests/{}.meta.json", name, reference);
     if let Ok(meta_json) = serde_json::to_vec(&metadata) {
-        let _ = state.storage.put(&meta_key, &meta_json).await;
+        if let Err(e) = state.storage.put(&meta_key, &meta_json).await {
+            tracing::warn!(key = %meta_key, error = %e, "cache write failed (push metadata by tag)");
+            crate::metrics::CACHE_WRITE_ERRORS
+                .with_label_values(&["docker", "metadata"])
+                .inc();
+        }
 
         // Also save metadata by digest
         let digest_meta_key = format!("docker/{}/manifests/{}.meta.json", name, digest);
-        let _ = state.storage.put(&digest_meta_key, &meta_json).await;
+        if let Err(e) = state.storage.put(&digest_meta_key, &meta_json).await {
+            tracing::warn!(key = %digest_meta_key, error = %e, "cache write failed (push metadata by digest)");
+            crate::metrics::CACHE_WRITE_ERRORS
+                .with_label_values(&["docker", "metadata"])
+                .inc();
+        }
     }
 
     state.metrics.record_upload("docker");
@@ -2076,7 +2113,12 @@ async fn update_metadata_on_pull(state: Arc<AppState>, storage: Storage, meta_ke
 
     // Save back
     if let Ok(json) = serde_json::to_vec(&metadata) {
-        let _ = storage.put(&meta_key, &json).await;
+        if let Err(e) = storage.put(&meta_key, &json).await {
+            tracing::warn!(key = %meta_key, error = %e, "cache write failed (pull stats update)");
+            crate::metrics::CACHE_WRITE_ERRORS
+                .with_label_values(&["docker", "metadata"])
+                .inc();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace asymmetric `resolve_upstream()` / `strip_docker_namespace()` dual-function pattern with single `canonicalize()` entry point
- New `Canonical` struct encapsulates cleaned name, namespace, and matched upstream index
- Add hostname detection (Step 2) to resolution chain alongside existing prefix-based routing
- Update all 11 call sites in docker.rs; keep `strip_docker_namespace` for config-free contexts
- 5 new unit tests for canonicalize (prefix routing, hostname detection, fallback, empty upstreams, multi-upstream)

Closes #502

## Test plan

- [x] All 1114 tests pass (1109 existing + 5 new canonicalize tests)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Semgrep: no new findings
- [x] Architecture prediction: 0 errors
- [x] Rust analyzers: PASS (cargo-deny + cargo-audit)