### PR TITLE
fix(storage): add #[must_use] to integrity verification methods

### DIFF
--- a/nora-registry/src/digest_quarantine.rs
+++ b/nora-registry/src/digest_quarantine.rs
@@ -237,6 +237,7 @@ impl DigestStore {
     }
 
     /// Check quarantine status for a digest.
+    #[must_use = "ignoring quarantine status may serve blocked artifacts"]
     pub fn check(&self, registry: &str, digest: &str, quarantine_secs: i64) -> QuarantineStatus {
         let key = format!("{}:{}", registry, digest);
         let entries = self.entries.read();

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -94,6 +94,7 @@ impl HashPinStore {
     ///
     /// Returns `true` if the hash matches or no pin exists for this key.
     /// Returns `false` and logs a warning if tampering is detected.
+    #[must_use = "ignoring verification result may allow tampered data"]
     pub fn verify(&self, key: &str, data: &[u8]) -> bool {
         let pins = self.pins.read();
         if let Some(expected) = pins.get(key) {

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -121,7 +121,11 @@ impl Storage {
             Ok(data) => {
                 STORAGE_OPERATIONS.with_label_values(&["get", "ok"]).inc();
                 if let Some(ref pins) = self.pin_store {
-                    pins.verify(key, &data);
+                    if !pins.verify(key, &data) {
+                        STORAGE_OPERATIONS
+                            .with_label_values(&["get", "integrity_fail"])
+                            .inc();
+                    }
                 }
                 Ok(data)
             }


### PR DESCRIPTION
## Summary

- Add `#[must_use]` to `HashPinStore::verify()` and `DigestStore::check()` to prevent silently discarding security-critical results
- Fix existing bug in `Storage::get()` where `verify()` result was ignored — now increments `integrity_fail` metric on hash mismatch

## Test plan

- [x] clippy passes with `-D warnings` (annotation validated at compile time)
- [x] All 1086 existing tests pass
- [x] Existing callers already use return values correctly (only `Storage::get` was missing)

Closes #478