### PR TITLE
fix: fail-fast on wildcard host, remove Host header injection (#510)

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1807,6 +1807,41 @@ impl Config {
             errors.push("server.port must not be 0".to_string());
         }
 
+        // 1b. Wildcard host requires public_url (non-routable address → broken client URLs)
+        {
+            let host = &self.server.host;
+            let is_wildcard = host == "0.0.0.0" || host == "::" || host == "0:0:0:0:0:0:0:0";
+
+            if is_wildcard && self.server.public_url.is_none() {
+                errors.push(format!(
+                    "NORA_PUBLIC_URL is required when host is '{}' (not routable). \
+                     Set: NORA_PUBLIC_URL=http://your-registry:{}",
+                    host, self.server.port
+                ));
+            }
+        }
+
+        // 1c. Validate public_url format if set
+        if let Some(ref url_str) = self.server.public_url {
+            match reqwest::Url::parse(url_str) {
+                Ok(parsed) => {
+                    let scheme = parsed.scheme();
+                    if scheme != "http" && scheme != "https" {
+                        errors.push(format!(
+                            "NORA_PUBLIC_URL must use http:// or https:// scheme, got: '{}'",
+                            scheme
+                        ));
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!(
+                        "NORA_PUBLIC_URL is not a valid URL: '{}' — {}",
+                        url_str, e
+                    ));
+                }
+            }
+        }
+
         // 2. Storage path must not be empty when mode = Local
         if self.storage.mode == StorageMode::Local && self.storage.path.trim().is_empty() {
             errors.push("storage.path must not be empty when storage mode is local".to_string());
@@ -4035,5 +4070,100 @@ mod tests {
             debug_output.contains("REDACTED"),
             "Debug output should show REDACTED for credential fields"
         );
+    }
+
+    // ========================================================================
+    // Wildcard host + public_url validation (#510)
+    // ========================================================================
+
+    #[test]
+    fn test_validate_wildcard_host_requires_public_url() {
+        for host in &["0.0.0.0", "::", "0:0:0:0:0:0:0:0"] {
+            let mut config = Config::default();
+            config.server.host = host.to_string();
+            config.server.public_url = None;
+            let (_, errors) = config.validate_with_config_path(None);
+            assert!(
+                errors.iter().any(|e| e.contains("NORA_PUBLIC_URL")),
+                "host='{}' without public_url should produce NORA_PUBLIC_URL error, got: {:?}",
+                host,
+                errors
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_wildcard_host_with_public_url_ok() {
+        let mut config = Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        config.server.public_url = Some("http://registry.example.com:4000".to_string());
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            !errors.iter().any(|e| e.contains("NORA_PUBLIC_URL")),
+            "0.0.0.0 with valid public_url should not error: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_validate_non_wildcard_host_no_public_url_ok() {
+        let mut config = Config::default();
+        config.server.host = "192.168.1.10".to_string();
+        config.server.public_url = None;
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors.is_empty(),
+            "non-wildcard host without public_url should have no errors: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_validate_public_url_rejects_bad_scheme() {
+        for scheme_url in &["ftp://registry.example.com", "javascript://alert(1)"] {
+            let mut config = Config::default();
+            config.server.public_url = Some(scheme_url.to_string());
+            let (_, errors) = config.validate_with_config_path(None);
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.contains("http://") || e.contains("https://")),
+                "public_url='{}' should be rejected for bad scheme: {:?}",
+                scheme_url,
+                errors
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_public_url_rejects_garbage() {
+        let mut config = Config::default();
+        config.server.public_url = Some("not-a-url".to_string());
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors.iter().any(|e| e.contains("not a valid URL")),
+            "garbage public_url should produce validation error: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_validate_public_url_accepts_valid() {
+        for url in &[
+            "http://registry:4000",
+            "https://nora.example.com",
+            "http://10.0.0.1:4000",
+            "https://nora.example.com:8443/",
+        ] {
+            let mut config = Config::default();
+            config.server.public_url = Some(url.to_string());
+            let (_, errors) = config.validate_with_config_path(None);
+            assert!(
+                !errors.iter().any(|e| e.contains("NORA_PUBLIC_URL")),
+                "valid public_url='{}' should not produce errors: {:?}",
+                url,
+                errors
+            );
+        }
     }
 }

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -51,8 +51,8 @@ pub fn routes() -> Router<Arc<AppState>> {
 async fn index_config(State(state): State<Arc<AppState>>) -> Response {
     let base = nora_base_url(&state);
     let config = serde_json::json!({
-        "dl": format!("{}/cargo/api/v1/crates", base.trim_end_matches('/')),
-        "api": format!("{}/cargo/api", base.trim_end_matches('/'))
+        "dl": format!("{}/cargo/api/v1/crates", base),
+        "api": format!("{}/cargo/api", base)
     });
     (
         StatusCode::OK,

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -104,7 +104,7 @@ async fn search_packages(
 
     match fetch_pub_api(&state, &url, &state.circuit_breaker).await {
         Ok(data) => {
-            let nora_base = nora_base_url(&state);
+            let nora_base = pub_base_url(&state);
             let rewritten = rewrite_search_response(&data, &nora_base, proxy_url).unwrap_or(data);
             cache_bytes(&state, key, rewritten.clone()).await;
             pub_json_response(rewritten)
@@ -161,7 +161,7 @@ async fn package_listing(
 
     match fetch_pub_api(&state, &url, &state.circuit_breaker).await {
         Ok(data) => {
-            let nora_base = nora_base_url(&state);
+            let nora_base = pub_base_url(&state);
             let rewritten = rewrite_package_response(&data, &nora_base, &package).unwrap_or(data);
             cache_bytes(&state, key, rewritten.clone()).await;
             state.repo_index.invalidate("pub");
@@ -206,7 +206,7 @@ async fn version_metadata(
 
     match fetch_pub_api(&state, &url, &state.circuit_breaker).await {
         Ok(data) => {
-            let nora_base = nora_base_url(&state);
+            let nora_base = pub_base_url(&state);
             let rewritten = rewrite_version_response(&data, &nora_base, &package).unwrap_or(data);
             cache_bytes(&state, key, rewritten.clone()).await;
             pub_json_response(rewritten)
@@ -597,7 +597,7 @@ fn nora_version_url(nora_base: &str, package: &str, version: &str) -> String {
 }
 
 /// Build NORA base URL with /pub prefix for URL rewriting.
-fn nora_base_url(state: &AppState) -> String {
+fn pub_base_url(state: &AppState) -> String {
     format!("{}/pub", nora_base_url_shared(state))
 }
 

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -19,7 +19,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry::{
+    circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
+};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -77,8 +79,8 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 // ── Service discovery ──────────────────────────────────────────────────
 
-async fn service_discovery(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
-    let base = extract_base_url(&state, &headers);
+async fn service_discovery(State(state): State<Arc<AppState>>) -> Response {
+    let base = nora_base_url(&state);
     let json = serde_json::json!({
         "providers.v1": format!("{}/terraform/v1/providers/", base),
         "modules.v1": format!("{}/terraform/v1/modules/", base)
@@ -171,7 +173,7 @@ async fn provider_versions(
 
 async fn provider_download_meta(
     State(state): State<Arc<AppState>>,
-    headers: axum::http::HeaderMap,
+    headers: HeaderMap,
     Path((ns, ptype, ver, os, arch)): Path<(String, String, String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns)
@@ -183,7 +185,7 @@ async fn provider_download_meta(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
-    let base_url = extract_base_url(&state, &headers);
+    let base_url = nora_base_url(&state);
     let artifact = format!("{}/{} v{} {}/{}", ns, ptype, ver, os, arch);
 
     // Extract publish date from cached metadata
@@ -417,7 +419,6 @@ async fn module_versions(
 
 async fn module_download(
     State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
     Path((ns, name, provider, ver)): Path<(String, String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns)
@@ -428,7 +429,7 @@ async fn module_download(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
-    let base_url = extract_base_url(&state, &headers);
+    let base_url = nora_base_url(&state);
 
     // If we have a cached source URL, return the rewritten header immediately
     let source_url_key = format!(
@@ -593,22 +594,6 @@ async fn module_source_download(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
-
-/// Extract base URL (scheme + host) from config or request headers.
-fn extract_base_url(state: &AppState, headers: &HeaderMap) -> String {
-    if let Some(public_url) = &state.config.server.public_url {
-        return public_url.trim_end_matches('/').to_string();
-    }
-    let scheme = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("http");
-    let host = headers
-        .get("host")
-        .and_then(|h| h.to_str().ok())
-        .unwrap_or("localhost:4000");
-    format!("{}://{}", scheme, host)
-}
 
 /// Extract publish date from cached Terraform provider versions metadata.
 ///


### PR DESCRIPTION
## Summary

- Startup validation rejects `NORA_HOST=0.0.0.0` / `::` without `NORA_PUBLIC_URL` — previously generated broken client URLs like `http://0.0.0.0:4000/cargo/api/v1/crates`
- `NORA_PUBLIC_URL` format validated at startup (must be valid http/https URL)
- Removed `extract_base_url()` from terraform.rs — had Host header fallback (injection vector), all handlers now use shared `nora_base_url()`
- Renamed pub_dart local `nora_base_url()` → `pub_base_url()` for grep-ability
- Removed redundant double `trim_end_matches('/')` from cargo `index_config()`

## Test plan

- [x] 1121 existing tests pass
- [x] 7 new validation tests (wildcard hosts, bad schemes, garbage URLs, valid URLs)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] semgrep, arch-predict, cargo-deny, cargo-audit — all pass

Closes #510