### PR TITLE
fix: close 6 bugs — base URL, npm diagnostics, pub TTL, GC coverage

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1807,6 +1807,41 @@ impl Config {
             errors.push("server.port must not be 0".to_string());
         }
 
+        // 1b. Wildcard host requires public_url (non-routable address → broken client URLs)
+        {
+            let host = &self.server.host;
+            let is_wildcard = host == "0.0.0.0" || host == "::" || host == "0:0:0:0:0:0:0:0";
+
+            if is_wildcard && self.server.public_url.is_none() {
+                errors.push(format!(
+                    "NORA_PUBLIC_URL is required when host is '{}' (not routable). \
+                     Set: NORA_PUBLIC_URL=http://your-registry:{}",
+                    host, self.server.port
+                ));
+            }
+        }
+
+        // 1c. Validate public_url format if set
+        if let Some(ref url_str) = self.server.public_url {
+            match reqwest::Url::parse(url_str) {
+                Ok(parsed) => {
+                    let scheme = parsed.scheme();
+                    if scheme != "http" && scheme != "https" {
+                        errors.push(format!(
+                            "NORA_PUBLIC_URL must use http:// or https:// scheme, got: '{}'",
+                            scheme
+                        ));
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!(
+                        "NORA_PUBLIC_URL is not a valid URL: '{}' — {}",
+                        url_str, e
+                    ));
+                }
+            }
+        }
+
         // 2. Storage path must not be empty when mode = Local
         if self.storage.mode == StorageMode::Local && self.storage.path.trim().is_empty() {
             errors.push("storage.path must not be empty when storage mode is local".to_string());
@@ -4035,5 +4070,100 @@ mod tests {
             debug_output.contains("REDACTED"),
             "Debug output should show REDACTED for credential fields"
         );
+    }
+
+    // ========================================================================
+    // Wildcard host + public_url validation (#510)
+    // ========================================================================
+
+    #[test]
+    fn test_validate_wildcard_host_requires_public_url() {
+        for host in &["0.0.0.0", "::", "0:0:0:0:0:0:0:0"] {
+            let mut config = Config::default();
+            config.server.host = host.to_string();
+            config.server.public_url = None;
+            let (_, errors) = config.validate_with_config_path(None);
+            assert!(
+                errors.iter().any(|e| e.contains("NORA_PUBLIC_URL")),
+                "host='{}' without public_url should produce NORA_PUBLIC_URL error, got: {:?}",
+                host,
+                errors
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_wildcard_host_with_public_url_ok() {
+        let mut config = Config::default();
+        config.server.host = "0.0.0.0".to_string();
+        config.server.public_url = Some("http://registry.example.com:4000".to_string());
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            !errors.iter().any(|e| e.contains("NORA_PUBLIC_URL")),
+            "0.0.0.0 with valid public_url should not error: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_validate_non_wildcard_host_no_public_url_ok() {
+        let mut config = Config::default();
+        config.server.host = "192.168.1.10".to_string();
+        config.server.public_url = None;
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors.is_empty(),
+            "non-wildcard host without public_url should have no errors: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_validate_public_url_rejects_bad_scheme() {
+        for scheme_url in &["ftp://registry.example.com", "javascript://alert(1)"] {
+            let mut config = Config::default();
+            config.server.public_url = Some(scheme_url.to_string());
+            let (_, errors) = config.validate_with_config_path(None);
+            assert!(
+                errors
+                    .iter()
+                    .any(|e| e.contains("http://") || e.contains("https://")),
+                "public_url='{}' should be rejected for bad scheme: {:?}",
+                scheme_url,
+                errors
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_public_url_rejects_garbage() {
+        let mut config = Config::default();
+        config.server.public_url = Some("not-a-url".to_string());
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors.iter().any(|e| e.contains("not a valid URL")),
+            "garbage public_url should produce validation error: {:?}",
+            errors
+        );
+    }
+
+    #[test]
+    fn test_validate_public_url_accepts_valid() {
+        for url in &[
+            "http://registry:4000",
+            "https://nora.example.com",
+            "http://10.0.0.1:4000",
+            "https://nora.example.com:8443/",
+        ] {
+            let mut config = Config::default();
+            config.server.public_url = Some(url.to_string());
+            let (_, errors) = config.validate_with_config_path(None);
+            assert!(
+                !errors.iter().any(|e| e.contains("NORA_PUBLIC_URL")),
+                "valid public_url='{}' should not produce errors: {:?}",
+                url,
+                errors
+            );
+        }
     }
 }

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -583,6 +583,10 @@ pub struct PubDartConfig {
     pub proxy_auth: Option<String>,
     #[serde(default = "default_timeout")]
     pub proxy_timeout: u64,
+    /// Metadata cache TTL in seconds (default: 300 = 5 min).
+    /// -1 = cache forever, 0 = always refetch, >0 = seconds.
+    #[serde(default = "default_metadata_ttl")]
+    pub metadata_ttl: i64,
 }
 
 fn default_pub_proxy() -> Option<String> {
@@ -596,6 +600,7 @@ impl Default for PubDartConfig {
             proxy: default_pub_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
+            metadata_ttl: 300,
         }
     }
 }
@@ -2474,6 +2479,11 @@ impl Config {
         if let Ok(val) = env::var("NORA_PUB_PROXY_TIMEOUT") {
             if let Ok(timeout) = val.parse() {
                 self.pub_dart.proxy_timeout = timeout;
+            }
+        }
+        if let Ok(val) = env::var("NORA_PUB_METADATA_TTL") {
+            if let Ok(ttl) = val.parse() {
+                self.pub_dart.metadata_ttl = ttl;
             }
         }
 

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -162,10 +162,23 @@ pub async fn run_gc(storage: &Storage, dry_run: bool) -> GcResult {
 
     // Detect registries with data but no GC coverage
     // Raw has no version model and no reference graph — nothing to GC by design
+    // Terraform/Pub/Ansible/NuGet store only cached metadata — no orphan graph,
+    // but we track them so the GC report shows data exists outside coverage
     let mut uncovered = Vec::new();
-    let count = storage.list("raw/").await.len();
-    if count > 0 {
-        uncovered.push(("raw".to_string(), count));
+    for prefix in [
+        "raw/",
+        "terraform/",
+        "pub/",
+        "ansible/",
+        "nuget/",
+        "gems/",
+        "conan/",
+    ] {
+        let count = storage.list(prefix).await.len();
+        if count > 0 {
+            let name = prefix.trim_end_matches('/').to_string();
+            uncovered.push((name, count));
+        }
     }
 
     let duration = start.elapsed().as_secs_f64();

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -51,8 +51,8 @@ pub fn routes() -> Router<Arc<AppState>> {
 async fn index_config(State(state): State<Arc<AppState>>) -> Response {
     let base = nora_base_url(&state);
     let config = serde_json::json!({
-        "dl": format!("{}/cargo/api/v1/crates", base.trim_end_matches('/')),
-        "api": format!("{}/cargo/api", base.trim_end_matches('/'))
+        "dl": format!("{}/cargo/api/v1/crates", base),
+        "api": format!("{}/cargo/api", base)
     });
     (
         StatusCode::OK,

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -37,7 +37,9 @@ pub fn routes() -> Router<Arc<AppState>> {
 /// 1. Targeted: parse JSON, rewrite `versions.*.dist.tarball`
 /// 2. Safety net: byte-level replace of upstream URL prefix in serialized output
 fn rewrite_tarball_urls(data: &[u8], nora_base: &str, upstream_url: &str) -> Result<Vec<u8>, ()> {
-    let mut json: serde_json::Value = serde_json::from_slice(data).map_err(|_| ())?;
+    let mut json: serde_json::Value = serde_json::from_slice(data).map_err(|e| {
+        tracing::debug!(error = %e, "npm: JSON parse failed in rewrite_tarball_urls");
+    })?;
 
     let upstream_trimmed = upstream_url.trim_end_matches('/');
     let nora_npm_base = format!("{}/npm", nora_base.trim_end_matches('/'));
@@ -58,7 +60,9 @@ fn rewrite_tarball_urls(data: &[u8], nora_base: &str, upstream_url: &str) -> Res
         }
     }
 
-    let output = serde_json::to_vec(&json).map_err(|_| ())?;
+    let output = serde_json::to_vec(&json).map_err(|e| {
+        tracing::debug!(error = %e, "npm: JSON serialize failed in rewrite_tarball_urls");
+    })?;
 
     // Safety net: byte-level replace of any remaining upstream URL prefix (#439).
     // Catches edge cases where targeted rewrite missed (e.g. new npm metadata fields).

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -104,7 +104,7 @@ async fn search_packages(
 
     match fetch_pub_api(&state, &url, &state.circuit_breaker).await {
         Ok(data) => {
-            let nora_base = nora_base_url(&state);
+            let nora_base = pub_base_url(&state);
             let rewritten = rewrite_search_response(&data, &nora_base, proxy_url).unwrap_or(data);
             cache_bytes(&state, key, rewritten.clone()).await;
             pub_json_response(rewritten)
@@ -161,7 +161,7 @@ async fn package_listing(
 
     match fetch_pub_api(&state, &url, &state.circuit_breaker).await {
         Ok(data) => {
-            let nora_base = nora_base_url(&state);
+            let nora_base = pub_base_url(&state);
             let rewritten = rewrite_package_response(&data, &nora_base, &package).unwrap_or(data);
             cache_bytes(&state, key, rewritten.clone()).await;
             state.repo_index.invalidate("pub");
@@ -206,7 +206,7 @@ async fn version_metadata(
 
     match fetch_pub_api(&state, &url, &state.circuit_breaker).await {
         Ok(data) => {
-            let nora_base = nora_base_url(&state);
+            let nora_base = pub_base_url(&state);
             let rewritten = rewrite_version_response(&data, &nora_base, &package).unwrap_or(data);
             cache_bytes(&state, key, rewritten.clone()).await;
             pub_json_response(rewritten)
@@ -597,7 +597,7 @@ fn nora_version_url(nora_base: &str, package: &str, version: &str) -> String {
 }
 
 /// Build NORA base URL with /pub prefix for URL rewriting.
-fn nora_base_url(state: &AppState) -> String {
+fn pub_base_url(state: &AppState) -> String {
     format!("{}/pub", nora_base_url_shared(state))
 }
 

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -16,6 +16,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::cache_ttl::is_within_ttl;
 use crate::registry::{
     circuit_open_response, nora_base_url as nora_base_url_shared, proxy_fetch, ProxyError,
 };
@@ -85,7 +86,11 @@ async fn search_packages(
     );
 
     if let Ok(data) = state.storage.get(&key).await {
-        return pub_json_response(data.to_vec());
+        if let Some(meta) = state.storage.stat(&key).await {
+            if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
+                return pub_json_response(data.to_vec());
+            }
+        }
     }
 
     let Some(proxy_url) = &state.config.pub_dart.proxy else {
@@ -146,7 +151,11 @@ async fn package_listing(
 
     let key = format!("pub/api/packages/{}.json", package);
     if let Ok(data) = state.storage.get(&key).await {
-        return pub_json_response(data.to_vec());
+        if let Some(meta) = state.storage.stat(&key).await {
+            if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
+                return pub_json_response(data.to_vec());
+            }
+        }
     }
 
     let Some(proxy_url) = &state.config.pub_dart.proxy else {
@@ -190,7 +199,11 @@ async fn version_metadata(
 
     let key = format!("pub/api/packages/{}/versions/{}.json", package, version);
     if let Ok(data) = state.storage.get(&key).await {
-        return pub_json_response(data.to_vec());
+        if let Some(meta) = state.storage.stat(&key).await {
+            if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
+                return pub_json_response(data.to_vec());
+            }
+        }
     }
 
     let Some(proxy_url) = &state.config.pub_dart.proxy else {

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -567,7 +567,14 @@ fn rewrite_next_url(next_url: &str, nora_base: &str, proxy_url: &str) -> String 
     next_url
         .strip_prefix(&upstream_prefix)
         .map(|suffix| format!("{}{}", nora_prefix, suffix))
-        .unwrap_or_else(|| next_url.to_string())
+        .unwrap_or_else(|| {
+            tracing::warn!(
+                next_url,
+                expected_prefix = %upstream_prefix,
+                "pub: next_url does not match expected upstream prefix, returning as-is"
+            );
+            next_url.to_string()
+        })
 }
 
 fn nora_archive_url(nora_base: &str, package: &str, version: &str) -> String {

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -247,7 +247,11 @@ async fn package_advisories(
 
     let key = format!("pub/api/packages/{}/advisories.json", package);
     if let Ok(data) = state.storage.get(&key).await {
-        return pub_json_response(data.to_vec());
+        if let Some(meta) = state.storage.stat(&key).await {
+            if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
+                return pub_json_response(data.to_vec());
+            }
+        }
     }
 
     let Some(proxy_url) = &state.config.pub_dart.proxy else {

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -19,7 +19,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry::{
+    circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
+};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -77,8 +79,8 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 // ── Service discovery ──────────────────────────────────────────────────
 
-async fn service_discovery(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
-    let base = extract_base_url(&state, &headers);
+async fn service_discovery(State(state): State<Arc<AppState>>) -> Response {
+    let base = nora_base_url(&state);
     let json = serde_json::json!({
         "providers.v1": format!("{}/terraform/v1/providers/", base),
         "modules.v1": format!("{}/terraform/v1/modules/", base)
@@ -171,7 +173,7 @@ async fn provider_versions(
 
 async fn provider_download_meta(
     State(state): State<Arc<AppState>>,
-    headers: axum::http::HeaderMap,
+    headers: HeaderMap,
     Path((ns, ptype, ver, os, arch)): Path<(String, String, String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns)
@@ -183,7 +185,7 @@ async fn provider_download_meta(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
-    let base_url = extract_base_url(&state, &headers);
+    let base_url = nora_base_url(&state);
     let artifact = format!("{}/{} v{} {}/{}", ns, ptype, ver, os, arch);
 
     // Extract publish date from cached metadata
@@ -417,7 +419,6 @@ async fn module_versions(
 
 async fn module_download(
     State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
     Path((ns, name, provider, ver)): Path<(String, String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns)
@@ -428,7 +429,7 @@ async fn module_download(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
-    let base_url = extract_base_url(&state, &headers);
+    let base_url = nora_base_url(&state);
 
     // If we have a cached source URL, return the rewritten header immediately
     let source_url_key = format!(
@@ -593,22 +594,6 @@ async fn module_source_download(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
-
-/// Extract base URL (scheme + host) from config or request headers.
-fn extract_base_url(state: &AppState, headers: &HeaderMap) -> String {
-    if let Some(public_url) = &state.config.server.public_url {
-        return public_url.trim_end_matches('/').to_string();
-    }
-    let scheme = headers
-        .get("x-forwarded-proto")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("http");
-    let host = headers
-        .get("host")
-        .and_then(|h| h.to_str().ok())
-        .unwrap_or("localhost:4000");
-    format!("{}://{}", scheme, host)
-}
 
 /// Extract publish date from cached Terraform provider versions metadata.
 ///


### PR DESCRIPTION
## Summary

Closes 6 open bugs in a single branch with clean per-issue commits:

- **#510** — `0.0.0.0` URL in cargo `config.json`: fail-fast validation when wildcard host has no `public_url`
- **#471** — Cache poisoning via Host header: unify base URL resolution, remove `extract_base_url` from headers
- **#481** — npm `rewrite_tarball_urls` discards errors: add `tracing::debug` for JSON parse/serialize failures
- **#472** — Pub `next_url` silent fallback: add `tracing::warn` when `strip_prefix` fails
- **#469** — Pub search/metadata cache has no TTL: add `metadata_ttl` (default 300s) to `PubDartConfig`, wire TTL checks into all 4 cache-read paths (search, listing, version, advisories)
- **#470** — GC doesn't scan Terraform metadata: expand uncovered registries list to all 7 metadata-only formats (raw, terraform, pub, ansible, nuget, gems, conan)

## Commits

| Commit | Bug | Scope |
|--------|-----|-------|
| `fix(config)` | #510 | config.rs — wildcard host validation |
| `refactor(registry)` | #471 | 3 files — unified `nora_base_url()` |
| `fix(npm)` | #481 | npm.rs — error logging |
| `fix(pub)` | #472 | pub_dart.rs — warn on prefix mismatch |
| `fix(pub)` | #469 | config.rs + pub_dart.rs — metadata TTL |
| `fix(gc,pub)` | #470+#469 | gc.rs + pub_dart.rs — GC coverage + advisory TTL |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib --bin nora` — 1121 passed
- [x] `scripts/pre-commit-check.sh` — version check OK
- [x] semgrep — no new findings in diff
- [x] arch-predict — 0 ADR violations
- [x] rust-analyzers (cargo-deny + cargo-audit) — clean
- [ ] Smoke test with `NORA_PUBLIC_URL` set on wildcard host
- [ ] Verify pub metadata refreshes after TTL expires

Closes #510, #471, #481, #472, #469, #470