### PR TITLE
refactor(registry): replace stringly-typed proxy_fetch parameters with newtypes (#482)

### DIFF
--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -24,6 +24,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
 };
+use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -34,6 +35,7 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://galaxy.ansible.com";
 
@@ -307,10 +309,10 @@ async fn download_tarball(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.ansible.proxy_timeout,
+        Duration::from_secs(state.config.ansible.proxy_timeout),
         state.config.ansible.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "ansible",
+        RegistryType::Ansible,
     )
     .await
     {
@@ -374,11 +376,11 @@ async fn proxy_json(
     match proxy_fetch_text(
         &state.http_client,
         url,
-        state.config.ansible.proxy_timeout,
+        Duration::from_secs(state.config.ansible.proxy_timeout),
         state.config.ansible.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "ansible",
+        RegistryType::Ansible,
     )
     .await
     {

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -15,6 +15,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
 };
+use crate::registry_type::RegistryType;
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -27,6 +28,7 @@ use axum::{
 };
 use sha2::Digest;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
@@ -138,10 +140,10 @@ async fn sparse_index(
     match proxy_fetch(
         &state.http_client,
         &upstream_index_url,
-        state.config.cargo.proxy_timeout,
+        Duration::from_secs(state.config.cargo.proxy_timeout),
         state.config.cargo.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "cargo",
+        RegistryType::Cargo,
     )
     .await
     {
@@ -210,10 +212,10 @@ async fn get_metadata(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.cargo.proxy_timeout,
+        Duration::from_secs(state.config.cargo.proxy_timeout),
         state.config.cargo.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "cargo",
+        RegistryType::Cargo,
     )
     .await
     {
@@ -322,10 +324,10 @@ async fn download(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.cargo.proxy_timeout,
+        Duration::from_secs(state.config.cargo.proxy_timeout),
         state.config.cargo.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "cargo",
+        RegistryType::Cargo,
     )
     .await
     {

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -28,6 +28,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -39,6 +40,7 @@ use axum::{
 };
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://center2.conan.io";
 
@@ -144,11 +146,11 @@ async fn search(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.conan.proxy_timeout,
+        Duration::from_secs(state.config.conan.proxy_timeout),
         state.config.conan.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "conan",
+        RegistryType::Conan,
     )
     .await
     {
@@ -355,10 +357,10 @@ async fn recipe_file_download(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.conan.proxy_timeout,
+        Duration::from_secs(state.config.conan.proxy_timeout),
         state.config.conan.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "conan",
+        RegistryType::Conan,
     )
     .await
     {
@@ -631,10 +633,10 @@ async fn package_file_download(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.conan.proxy_timeout_dl,
+        Duration::from_secs(state.config.conan.proxy_timeout_dl),
         state.config.conan.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "conan",
+        RegistryType::Conan,
     )
     .await
     {
@@ -676,11 +678,11 @@ async fn fetch_and_cache_json(
     match proxy_fetch_text(
         &state.http_client,
         url,
-        state.config.conan.proxy_timeout,
+        Duration::from_secs(state.config.conan.proxy_timeout),
         state.config.conan.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "conan",
+        RegistryType::Conan,
     )
     .await
     {
@@ -719,11 +721,11 @@ async fn fetch_and_cache_immutable_json(
     match proxy_fetch_text(
         &state.http_client,
         url,
-        state.config.conan.proxy_timeout,
+        Duration::from_secs(state.config.conan.proxy_timeout),
         state.config.conan.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "conan",
+        RegistryType::Conan,
     )
     .await
     {

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -17,6 +17,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -27,6 +28,7 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://rubygems.org";
 
@@ -87,10 +89,10 @@ async fn fetch_index(state: &Arc<AppState>, filename: &str) -> Response {
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.gems.proxy_timeout,
+        Duration::from_secs(state.config.gems.proxy_timeout),
         state.config.gems.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "gems",
+        RegistryType::Gems,
     )
     .await
     {
@@ -169,11 +171,11 @@ async fn compact_index(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.gems.proxy_timeout,
+        Duration::from_secs(state.config.gems.proxy_timeout),
         state.config.gems.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "gems",
+        RegistryType::Gems,
     )
     .await
     {
@@ -276,10 +278,10 @@ async fn download_gem(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.gems.proxy_timeout,
+        Duration::from_secs(state.config.gems.proxy_timeout),
         state.config.gems.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "gems",
+        RegistryType::Gems,
     )
     .await
     {
@@ -354,10 +356,10 @@ async fn download_gemspec(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.gems.proxy_timeout,
+        Duration::from_secs(state.config.gems.proxy_timeout),
         state.config.gems.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "gems",
+        RegistryType::Gems,
     )
     .await
     {

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -13,6 +13,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, proxy_fetch, proxy_fetch_text, ProxyError};
+use crate::registry_type::RegistryType;
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::body::Bytes;
@@ -25,6 +26,7 @@ use axum::{
 };
 use percent_encoding::percent_decode;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new().route("/go/{*path}", get(handle))
@@ -147,11 +149,11 @@ async fn handle(
     );
 
     // Use longer timeout for .zip files
-    let timeout = if ends_with_ci(&file, ".zip") {
+    let timeout = Duration::from_secs(if ends_with_ci(&file, ".zip") {
         state.config.go.proxy_timeout_zip
     } else {
         state.config.go.proxy_timeout
-    };
+    });
 
     // Fetch: binary for .zip, text for everything else
     let data = if ends_with_ci(&file, ".zip") {
@@ -161,7 +163,7 @@ async fn handle(
             timeout,
             state.config.go.proxy_auth.as_deref(),
             &state.circuit_breaker,
-            "go",
+            RegistryType::Go,
         )
         .await
     } else {
@@ -172,7 +174,7 @@ async fn handle(
             state.config.go.proxy_auth.as_deref(),
             None,
             &state.circuit_breaker,
-            "go",
+            RegistryType::Go,
         )
         .await
         .map(|s| s.into_bytes())

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -11,6 +11,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, method_not_allowed, proxy_fetch, ProxyError};
+use crate::registry_type::RegistryType;
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
@@ -24,6 +25,7 @@ use axum::{
 use sha2::Digest;
 use std::collections::BTreeSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new().route(
@@ -187,10 +189,10 @@ async fn download(
         match proxy_fetch(
             &state.http_client,
             &url,
-            state.config.maven.proxy_timeout,
+            Duration::from_secs(state.config.maven.proxy_timeout),
             proxy.auth(),
             &state.circuit_breaker,
-            "maven",
+            RegistryType::Maven,
         )
         .await
         {

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -35,6 +35,7 @@ pub use terraform::routes as terraform_routes;
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
 use crate::metrics::UPSTREAM_REQUEST_DURATION;
+use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
@@ -88,21 +89,22 @@ pub(crate) fn circuit_open_response(registry: &str) -> Response {
 async fn proxy_fetch_core<T, F, Fut>(
     client: &reqwest::Client,
     url: &str,
-    timeout_secs: u64,
+    timeout: Duration,
     auth: Option<&str>,
     extra_headers: Option<(&str, &str)>,
     extract: F,
     cb: &CircuitBreakerRegistry,
-    registry: &str,
+    registry: RegistryType,
 ) -> Result<T, ProxyError>
 where
     F: Fn(reqwest::Response) -> Fut + Copy,
     Fut: std::future::Future<Output = Result<T, reqwest::Error>>,
 {
-    cb.check(registry)?;
+    let registry_str = registry.as_str();
+    cb.check(registry_str)?;
 
     for attempt in 0..2 {
-        let mut request = client.get(url).timeout(Duration::from_secs(timeout_secs));
+        let mut request = client.get(url).timeout(timeout);
         if let Some(credentials) = auth {
             request = request.header("Authorization", basic_auth_header(credentials));
         }
@@ -116,54 +118,54 @@ where
                 let elapsed = upstream_start.elapsed().as_secs_f64();
                 if response.status().is_success() {
                     UPSTREAM_REQUEST_DURATION
-                        .with_label_values(&[registry, "2xx"])
+                        .with_label_values(&[registry_str, "2xx"])
                         .observe(elapsed);
                     let result = extract(response)
                         .await
                         .map_err(|e| ProxyError::Network(e.to_string()));
                     if result.is_ok() {
-                        cb.record_success(registry);
+                        cb.record_success(registry_str);
                     }
                     return result;
                 }
                 let status = response.status().as_u16();
                 if (400..500).contains(&status) {
                     UPSTREAM_REQUEST_DURATION
-                        .with_label_values(&[registry, "4xx"])
+                        .with_label_values(&[registry_str, "4xx"])
                         .observe(elapsed);
                     return Err(ProxyError::NotFound);
                 }
                 if attempt == 0 {
                     UPSTREAM_REQUEST_DURATION
-                        .with_label_values(&[registry, "5xx"])
+                        .with_label_values(&[registry_str, "5xx"])
                         .observe(elapsed);
                     tracing::debug!(url, status, "upstream 5xx, retrying in 1s");
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     continue;
                 }
                 UPSTREAM_REQUEST_DURATION
-                    .with_label_values(&[registry, "5xx"])
+                    .with_label_values(&[registry_str, "5xx"])
                     .observe(elapsed);
-                cb.record_failure(registry);
+                cb.record_failure(registry_str);
                 return Err(ProxyError::Upstream(status));
             }
             Err(e) => {
                 let elapsed = upstream_start.elapsed().as_secs_f64();
                 let status_label = if e.is_timeout() { "timeout" } else { "error" };
                 UPSTREAM_REQUEST_DURATION
-                    .with_label_values(&[registry, status_label])
+                    .with_label_values(&[registry_str, status_label])
                     .observe(elapsed);
                 if attempt == 0 {
                     tracing::debug!(url, error = %e, "upstream error, retrying in 1s");
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     continue;
                 }
-                cb.record_failure(registry);
+                cb.record_failure(registry_str);
                 return Err(ProxyError::Network(e.to_string()));
             }
         }
     }
-    cb.record_failure(registry);
+    cb.record_failure(registry_str);
     Err(ProxyError::Network("max retries exceeded".into()))
 }
 
@@ -171,15 +173,15 @@ where
 pub(crate) async fn proxy_fetch(
     client: &reqwest::Client,
     url: &str,
-    timeout_secs: u64,
+    timeout: Duration,
     auth: Option<&str>,
     cb: &CircuitBreakerRegistry,
-    registry: &str,
+    registry: RegistryType,
 ) -> Result<Vec<u8>, ProxyError> {
     proxy_fetch_core(
         client,
         url,
-        timeout_secs,
+        timeout,
         auth,
         None,
         |r| async { r.bytes().await.map(|b| b.to_vec()) },
@@ -193,16 +195,16 @@ pub(crate) async fn proxy_fetch(
 pub(crate) async fn proxy_fetch_text(
     client: &reqwest::Client,
     url: &str,
-    timeout_secs: u64,
+    timeout: Duration,
     auth: Option<&str>,
     extra_headers: Option<(&str, &str)>,
     cb: &CircuitBreakerRegistry,
-    registry: &str,
+    registry: RegistryType,
 ) -> Result<String, ProxyError> {
     proxy_fetch_core(
         client,
         url,
-        timeout_secs,
+        timeout,
         auth,
         extra_headers,
         |r| r.text(),
@@ -225,10 +227,10 @@ mod tests {
         let result = proxy_fetch(
             &client,
             "http://127.0.0.1:1/nonexistent",
-            2,
+            Duration::from_secs(2),
             None,
             &cb,
-            "test",
+            RegistryType::Docker, // arbitrary variant, testing proxy logic not registry type
         )
         .await;
         assert!(matches!(result, Err(ProxyError::Network(_))));

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -6,6 +6,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
 };
+use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -18,6 +19,7 @@ use axum::{
 use base64::Engine;
 use sha2::Digest;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new().route(
@@ -220,10 +222,10 @@ async fn handle_request(
         match proxy_fetch(
             &state.http_client,
             &url,
-            state.config.npm.proxy_timeout,
+            Duration::from_secs(state.config.npm.proxy_timeout),
             state.config.npm.proxy_auth.as_deref(),
             &state.circuit_breaker,
-            "npm",
+            RegistryType::Npm,
         )
         .await
         {
@@ -309,10 +311,10 @@ async fn refetch_metadata(state: &Arc<AppState>, path: &str, key: &str) -> Optio
     let data = proxy_fetch(
         &state.http_client,
         &url,
-        state.config.npm.proxy_timeout,
+        Duration::from_secs(state.config.npm.proxy_timeout),
         state.config.npm.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "npm",
+        RegistryType::Npm,
     )
     .await
     .ok()?;

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -18,6 +18,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
 };
+use crate::registry_type::RegistryType;
 use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
@@ -30,6 +31,7 @@ use axum::{
 };
 use serde::Deserialize;
 use std::sync::Arc;
+use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://api.nuget.org";
 const SEARCH_TIMEOUT_SECS: u64 = 5;
@@ -248,11 +250,11 @@ async fn search_query(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        SEARCH_TIMEOUT_SECS,
+        Duration::from_secs(SEARCH_TIMEOUT_SECS),
         None, // search endpoint is public
         None,
         &state.circuit_breaker,
-        "nuget",
+        RegistryType::Nuget,
     )
     .await
     {
@@ -323,11 +325,11 @@ async fn autocomplete_query(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        SEARCH_TIMEOUT_SECS,
+        Duration::from_secs(SEARCH_TIMEOUT_SECS),
         None, // autocomplete endpoint is public
         None,
         &state.circuit_breaker,
-        "nuget",
+        RegistryType::Nuget,
     )
     .await
     {
@@ -420,11 +422,11 @@ async fn registration_index(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.nuget.metadata_proxy_timeout,
+        Duration::from_secs(state.config.nuget.metadata_proxy_timeout),
         state.config.nuget.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "nuget",
+        RegistryType::Nuget,
     )
     .await
     {
@@ -508,11 +510,11 @@ async fn registration_page(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.nuget.metadata_proxy_timeout,
+        Duration::from_secs(state.config.nuget.metadata_proxy_timeout),
         state.config.nuget.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "nuget",
+        RegistryType::Nuget,
     )
     .await
     {
@@ -594,11 +596,11 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.nuget.metadata_proxy_timeout,
+        Duration::from_secs(state.config.nuget.metadata_proxy_timeout),
         state.config.nuget.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "nuget",
+        RegistryType::Nuget,
     )
     .await
     {
@@ -734,10 +736,10 @@ async fn flatcontainer_download(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.nuget.proxy_timeout,
+        Duration::from_secs(state.config.nuget.proxy_timeout),
         state.config.nuget.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "nuget",
+        RegistryType::Nuget,
     )
     .await
     {
@@ -772,11 +774,11 @@ async fn flatcontainer_download(
                         if let Ok(text) = proxy_fetch_text(
                             &state2.http_client,
                             &url,
-                            state2.config.nuget.proxy_timeout,
+                            Duration::from_secs(state2.config.nuget.proxy_timeout),
                             state2.config.nuget.proxy_auth.as_deref(),
                             None,
                             &state2.circuit_breaker,
-                            "nuget",
+                            RegistryType::Nuget,
                         )
                         .await
                         {

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -20,6 +20,7 @@ use crate::cache_ttl::is_within_ttl;
 use crate::registry::{
     circuit_open_response, nora_base_url as nora_base_url_shared, proxy_fetch, ProxyError,
 };
+use crate::registry_type::RegistryType;
 use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
@@ -33,6 +34,7 @@ use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use serde_json::{Map, Value};
 use sha2::Digest;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// Storage prefix and file suffix for repo index scanning.
 pub const INDEX_PATTERN: (&str, &str) = ("pub/", ".tar.gz");
@@ -377,10 +379,10 @@ async fn download_archive(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.pub_dart.proxy_timeout,
+        Duration::from_secs(state.config.pub_dart.proxy_timeout),
         state.config.pub_dart.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "pub",
+        RegistryType::PubDart,
     )
     .await
     {
@@ -421,12 +423,12 @@ async fn fetch_pub_api(
     super::proxy_fetch_core(
         &state.http_client,
         url,
-        state.config.pub_dart.proxy_timeout,
+        Duration::from_secs(state.config.pub_dart.proxy_timeout),
         state.config.pub_dart.proxy_auth.as_deref(),
         Some(("Accept", PUB_CONTENT_TYPE)),
         |response| async { response.bytes().await.map(|b| b.to_vec()) },
         cb,
-        "pub",
+        RegistryType::PubDart,
     )
     .await
 }

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -14,6 +14,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_text,
 };
+use crate::registry_type::RegistryType;
 use crate::ui::components::html_escape;
 use crate::validation::ends_with_ci;
 use crate::AppState;
@@ -27,6 +28,7 @@ use axum::{
 use sha2::Digest;
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::Duration;
 
 /// PEP 691 JSON content type
 const PEP691_JSON: &str = "application/vnd.pypi.simple.v1+json";
@@ -156,11 +158,11 @@ async fn package_versions(
         match proxy_fetch_text(
             &state.http_client,
             &url,
-            state.config.pypi.proxy_timeout,
+            Duration::from_secs(state.config.pypi.proxy_timeout),
             state.config.pypi.proxy_auth.as_deref(),
             Some(("Accept", "text/html")),
             &state.circuit_breaker,
-            "pypi",
+            RegistryType::PyPI,
         )
         .await
         {
@@ -279,11 +281,11 @@ async fn download_file(
         match proxy_fetch_text(
             &state.http_client,
             &page_url,
-            state.config.pypi.proxy_timeout,
+            Duration::from_secs(state.config.pypi.proxy_timeout),
             state.config.pypi.proxy_auth.as_deref(),
             Some(("Accept", "text/html")),
             &state.circuit_breaker,
-            "pypi",
+            RegistryType::PyPI,
         )
         .await
         {
@@ -292,10 +294,10 @@ async fn download_file(
                     match proxy_fetch(
                         &state.http_client,
                         &file_url,
-                        state.config.pypi.proxy_timeout,
+                        Duration::from_secs(state.config.pypi.proxy_timeout),
                         state.config.pypi.proxy_auth.as_deref(),
                         &state.circuit_breaker,
-                        "pypi",
+                        RegistryType::PyPI,
                     )
                     .await
                     {

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -22,6 +22,7 @@ use crate::audit::AuditEntry;
 use crate::registry::{
     circuit_open_response, nora_base_url, proxy_fetch, proxy_fetch_text, ProxyError,
 };
+use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -32,6 +33,7 @@ use axum::{
     Router,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://registry.terraform.io";
 
@@ -136,11 +138,11 @@ async fn provider_versions(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.terraform.proxy_timeout,
+        Duration::from_secs(state.config.terraform.proxy_timeout),
         state.config.terraform.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "terraform",
+        RegistryType::Terraform,
     )
     .await
     {
@@ -234,11 +236,11 @@ async fn provider_download_meta(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.terraform.proxy_timeout,
+        Duration::from_secs(state.config.terraform.proxy_timeout),
         state.config.terraform.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "terraform",
+        RegistryType::Terraform,
     )
     .await
     {
@@ -311,10 +313,10 @@ async fn provider_download_binary(
     match proxy_fetch(
         &state.http_client,
         &url,
-        state.config.terraform.proxy_timeout_dl,
+        Duration::from_secs(state.config.terraform.proxy_timeout_dl),
         state.config.terraform.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "terraform",
+        RegistryType::Terraform,
     )
     .await
     {
@@ -382,11 +384,11 @@ async fn module_versions(
     match proxy_fetch_text(
         &state.http_client,
         &url,
-        state.config.terraform.proxy_timeout,
+        Duration::from_secs(state.config.terraform.proxy_timeout),
         state.config.terraform.proxy_auth.as_deref(),
         None,
         &state.circuit_breaker,
-        "terraform",
+        RegistryType::Terraform,
     )
     .await
     {
@@ -563,10 +565,10 @@ async fn module_source_download(
     match proxy_fetch(
         &state.http_client,
         &upstream_url,
-        state.config.terraform.proxy_timeout_dl,
+        Duration::from_secs(state.config.terraform.proxy_timeout_dl),
         state.config.terraform.proxy_auth.as_deref(),
         &state.circuit_breaker,
-        "terraform",
+        RegistryType::Terraform,
     )
     .await
     {


### PR DESCRIPTION
## Summary

- `proxy_fetch_core`, `proxy_fetch`, `proxy_fetch_text`: replace `timeout_secs: u64` with `Duration` and `registry: &str` with `RegistryType`
- All 11 handler call sites updated — each now passes `Duration::from_secs(config.proxy_timeout)` and `RegistryType::Variant`
- CircuitBreaker API intentionally kept on `&str` — Docker uses composite CB keys (`"docker:https://registry-1.docker.io"`)

## Changes

| File | Change |
|------|--------|
| `registry/mod.rs` | Core signatures + internal bridge `registry.as_str()` for CB/metrics |
| `registry/ansible.rs` | 2 call sites: Duration + RegistryType::Ansible |
| `registry/cargo_registry.rs` | 3 call sites: Duration + RegistryType::Cargo |
| `registry/conan.rs` | 5 call sites: Duration + RegistryType::Conan |
| `registry/gems.rs` | 4 call sites: Duration + RegistryType::Gems |
| `registry/go.rs` | 2 call sites: Duration + RegistryType::Go (conditional zip timeout) |
| `registry/maven.rs` | 1 call site: Duration + RegistryType::Maven |
| `registry/npm.rs` | 2 call sites: Duration + RegistryType::Npm |
| `registry/nuget.rs` | 7 call sites: Duration + RegistryType::Nuget (incl. SEARCH_TIMEOUT_SECS) |
| `registry/pub_dart.rs` | 2 call sites: Duration + RegistryType::PubDart (incl. direct proxy_fetch_core) |
| `registry/pypi.rs` | 3 call sites: Duration + RegistryType::PyPI |
| `registry/terraform.rs` | 5 call sites: Duration + RegistryType::Terraform |

## Design decisions

- **CB stays on `&str`**: Docker's `fetch_blob_from_upstream`/`fetch_manifest_from_upstream` use composite keys like `"docker:https://..."` — cannot change CB to accept `RegistryType` without breaking Docker
- **Conversion at call site**: `Duration::from_secs()` wraps config `u64` at each handler — config stays `u64` (TOML user-facing)
- **`as_str()` bridge**: inside `proxy_fetch_core`, `let registry_str = registry.as_str()` feeds CB and metrics — zero label drift, centralized mapping

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 1115 passed, 0 failed
- [x] `scripts/pre-commit-check.sh` — version check OK
- [x] semgrep — no new findings in diff
- [x] rust-analyzers (cargo-deny + cargo-audit) — clean
- [x] OPSEC check — clean

Closes #482