### PR TITLE
refactor: make AppState Clone for FromRef decomposition

### DIFF
--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -26,7 +26,6 @@ use axum::{
 use base64::{engine::general_purpose::STANDARD, Engine};
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::Arc;
 use std::time::Instant;
 
 use crate::AppState;
@@ -167,7 +166,7 @@ fn extract_client_ip(
 
 /// Auth middleware - supports Basic auth, Bearer tokens, and OIDC JWT
 pub async fn auth_middleware(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     request: Request<Body>,
     next: Next,
 ) -> Response {
@@ -1135,7 +1134,7 @@ Jd74nq6dNCjpWG4drIsyhqX+
         let oidc_validator =
             OidcValidator::new(ctx.state.config.auth.oidc.clone(), reqwest::Client::new());
         // We need to rebuild the state with oidc set — use Arc::get_mut or rebuild
-        let state = Arc::new(crate::AppState {
+        let state = crate::AppState {
             storage: ctx.state.storage.clone(),
             config: ctx.state.config.clone(),
             enabled_registries: ctx.state.enabled_registries.clone(),
@@ -1143,33 +1142,33 @@ Jd74nq6dNCjpWG4drIsyhqX+
             startup_duration_ms: ctx.state.startup_duration_ms,
             auth: ctx.state.auth.clone(),
             tokens: ctx.state.tokens.clone(),
-            metrics: crate::dashboard_metrics::DashboardMetrics::new(),
-            activity: crate::activity_log::ActivityLog::new(50),
+            metrics: Arc::new(crate::dashboard_metrics::DashboardMetrics::new()),
+            activity: Arc::new(crate::activity_log::ActivityLog::new(50)),
             audit: ctx.state.audit.clone(),
-            docker_auth: crate::registry::DockerAuth::new(reqwest::Client::new(), 5),
-            repo_index: crate::repo_index::RepoIndex::new(),
+            docker_auth: Arc::new(crate::registry::DockerAuth::new(reqwest::Client::new(), 5)),
+            repo_index: Arc::new(crate::repo_index::RepoIndex::new()),
             http_client: reqwest::Client::new(),
             upload_sessions: Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new())),
-            publish_locks: parking_lot::Mutex::new(std::collections::HashMap::new()),
+            publish_locks: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
             reloadable: Arc::new(arc_swap::ArcSwap::from_pointee(crate::ReloadableConfig {
                 curation_engine: crate::curation::CurationEngine::new(
                     crate::config::CurationConfig::default(),
                 ),
                 bypass_token: None,
             })),
-            auth_failures: crate::auth::AuthFailureTracker::new(5, 900),
-            oidc: Some(oidc_validator),
-            circuit_breaker: crate::circuit_breaker::CircuitBreakerRegistry::new(
+            auth_failures: Arc::new(crate::auth::AuthFailureTracker::new(5, 900)),
+            oidc: Some(Arc::new(oidc_validator)),
+            circuit_breaker: Arc::new(crate::circuit_breaker::CircuitBreakerRegistry::new(
                 ctx.state.config.circuit_breaker.clone(),
-            ),
+            )),
             digest_store: ctx.state.digest_store.clone(),
             leak_finders: ctx.state.leak_finders.clone(),
-        });
+        };
 
         // Rebuild router with new state
         use axum::{extract::DefaultBodyLimit, middleware, Router};
         let mut registry_routes = Router::new();
-        for reg in &state.enabled_registries {
+        for reg in state.enabled_registries.iter() {
             match reg {
                 crate::registry_type::RegistryType::Raw => {
                     registry_routes = registry_routes.merge(crate::registry::raw_routes());

--- a/nora-registry/src/auth/token_routes.rs
+++ b/nora-registry/src/auth/token_routes.rs
@@ -12,7 +12,6 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::net::SocketAddr;
-use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::tokens::Role;
@@ -63,7 +62,7 @@ pub struct TokenListResponse {
 
 /// Create a new API token (requires Basic auth)
 async fn create_token(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(req): Json<CreateTokenRequest>,
@@ -129,7 +128,7 @@ async fn create_token(
 
 /// List tokens for authenticated user
 async fn list_tokens(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(req): Json<CreateTokenRequest>,
@@ -195,7 +194,7 @@ pub struct RevokeRequest {
 
 /// Revoke a token
 async fn revoke_token(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
     Json(req): Json<RevokeRequest>,
@@ -243,7 +242,7 @@ async fn revoke_token(
 }
 
 /// Token management routes
-pub fn token_routes() -> Router<Arc<AppState>> {
+pub fn token_routes() -> Router<AppState> {
     Router::new()
         .route("/api/tokens", post(create_token))
         .route("/api/tokens/list", post(list_tokens))

--- a/nora-registry/src/health.rs
+++ b/nora-registry/src/health.rs
@@ -4,7 +4,6 @@
 use axum::{extract::State, http::StatusCode, response::Json, routing::get, Router};
 use serde::Serialize;
 use std::collections::HashMap;
-use std::sync::Arc;
 use utoipa::ToSchema;
 
 use crate::AppState;
@@ -25,13 +24,13 @@ pub struct StorageHealth {
     pub total_size_bytes: u64,
 }
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/health", get(health_check))
         .route("/ready", get(readiness_check))
 }
 
-async fn health_check(State(state): State<Arc<AppState>>) -> (StatusCode, Json<HealthStatus>) {
+async fn health_check(State(state): State<AppState>) -> (StatusCode, Json<HealthStatus>) {
     let storage_reachable = check_storage_reachable(&state).await;
     let total_size = state.storage.total_size().await;
 
@@ -45,7 +44,7 @@ async fn health_check(State(state): State<Arc<AppState>>) -> (StatusCode, Json<H
 
     // Build registries map from enabled registries
     let mut registries = HashMap::new();
-    for reg in &state.enabled_registries {
+    for reg in state.enabled_registries.iter() {
         registries.insert(reg.as_str().to_string(), "ok".to_string());
     }
 
@@ -70,7 +69,7 @@ async fn health_check(State(state): State<Arc<AppState>>) -> (StatusCode, Json<H
     (status_code, Json(health))
 }
 
-async fn readiness_check(State(state): State<Arc<AppState>>) -> StatusCode {
+async fn readiness_check(State(state): State<AppState>) -> StatusCode {
     if check_storage_reachable(&state).await {
         StatusCode::OK
     } else {

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -156,31 +156,32 @@ pub struct ReloadableConfig {
     pub bypass_token: Option<String>,
 }
 
+#[derive(Clone)]
 pub struct AppState {
     pub storage: Storage,
-    pub config: Config,
-    pub enabled_registries: HashSet<RegistryType>,
+    pub config: Arc<Config>,
+    pub enabled_registries: Arc<HashSet<RegistryType>>,
     pub start_time: Instant,
     pub startup_duration_ms: u64,
-    pub auth: Option<HtpasswdAuth>,
+    pub auth: Option<Arc<HtpasswdAuth>>,
     pub tokens: Option<TokenStore>,
-    pub metrics: DashboardMetrics,
-    pub activity: ActivityLog,
+    pub metrics: Arc<DashboardMetrics>,
+    pub activity: Arc<ActivityLog>,
     pub audit: Arc<AuditLog>,
-    pub docker_auth: registry::DockerAuth,
-    pub repo_index: RepoIndex,
+    pub docker_auth: Arc<registry::DockerAuth>,
+    pub repo_index: Arc<RepoIndex>,
     pub http_client: reqwest::Client,
     pub upload_sessions: Arc<RwLock<HashMap<String, registry::docker::UploadSession>>>,
     /// Per-key publish locks for TOCTOU protection (immutable releases)
-    publish_locks: parking_lot::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    publish_locks: Arc<parking_lot::Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>,
     /// Hot-reloadable curation config (swapped atomically on SIGHUP).
     pub reloadable: Arc<ArcSwap<ReloadableConfig>>,
     /// Per-IP failed auth attempt tracker for brute-force protection
-    pub auth_failures: auth::AuthFailureTracker,
+    pub auth_failures: Arc<auth::AuthFailureTracker>,
     /// OIDC validator for workload identity (CI/CD)
-    pub oidc: Option<auth::OidcValidator>,
-    pub(crate) circuit_breaker: circuit_breaker::CircuitBreakerRegistry,
-    pub digest_store: std::sync::Arc<digest_quarantine::DigestStore>,
+    pub oidc: Option<Arc<auth::OidcValidator>>,
+    pub(crate) circuit_breaker: Arc<circuit_breaker::CircuitBreakerRegistry>,
+    pub digest_store: Arc<digest_quarantine::DigestStore>,
     /// Pre-compiled upstream hostname searchers for leak detection (#386)
     pub leak_finders: metrics::LeakFinders,
 }
@@ -210,12 +211,13 @@ impl AppState {
     /// Use for ALL proxy caching instead of manual `tokio::spawn` + `storage.put`.
     /// Guarantees that `repo_index.invalidate()` is called AFTER the write completes,
     /// avoiding the race condition where invalidation fires before the file lands on S3.
-    pub fn spawn_cache(self: &Arc<Self>, registry: &'static str, key: String, data: Bytes) {
-        let state = Arc::clone(self);
+    pub fn spawn_cache(&self, registry: &'static str, key: String, data: Bytes) {
+        let storage = self.storage.clone();
+        let repo_index = Arc::clone(&self.repo_index);
         tokio::spawn(
             std::panic::AssertUnwindSafe(async move {
-                if state.storage.put(&key, &data).await.is_ok() {
-                    state.repo_index.invalidate(registry);
+                if storage.put(&key, &data).await.is_ok() {
+                    repo_index.invalidate(registry);
                 }
             })
             .catch_unwind()
@@ -228,19 +230,13 @@ impl AppState {
     }
 
     /// Like [`spawn_cache`], but skips the write if the key already exists (immutable artifacts).
-    pub fn spawn_cache_immutable(
-        self: &Arc<Self>,
-        registry: &'static str,
-        key: String,
-        data: Bytes,
-    ) {
-        let state = Arc::clone(self);
+    pub fn spawn_cache_immutable(&self, registry: &'static str, key: String, data: Bytes) {
+        let storage = self.storage.clone();
+        let repo_index = Arc::clone(&self.repo_index);
         tokio::spawn(
             std::panic::AssertUnwindSafe(async move {
-                if state.storage.stat(&key).await.is_none()
-                    && state.storage.put(&key, &data).await.is_ok()
-                {
-                    state.repo_index.invalidate(registry);
+                if storage.stat(&key).await.is_none() && storage.put(&key, &data).await.is_ok() {
+                    repo_index.invalidate(registry);
                 }
             })
             .catch_unwind()
@@ -1098,29 +1094,30 @@ async fn run_server(mut config: Config, storage: Storage) {
 
     let leak_finders = metrics::LeakFinders::new(config.upstream_hostnames());
 
-    let state = Arc::new(AppState {
+    let enabled_registries = Arc::new(enabled_registries);
+    let state = AppState {
         storage,
-        config,
+        config: Arc::new(config),
         enabled_registries,
         start_time,
         startup_duration_ms,
-        auth,
+        auth: auth.map(Arc::new),
         tokens,
-        metrics: DashboardMetrics::with_persistence(&storage_path),
-        activity: ActivityLog::new(50),
+        metrics: Arc::new(DashboardMetrics::with_persistence(&storage_path)),
+        activity: Arc::new(ActivityLog::new(50)),
         audit: Arc::new(AuditLog::new(&storage_path, audit_mode)),
-        docker_auth,
-        repo_index: RepoIndex::new(),
+        docker_auth: Arc::new(docker_auth),
+        repo_index: Arc::new(RepoIndex::new()),
         http_client,
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
-        publish_locks: parking_lot::Mutex::new(HashMap::new()),
+        publish_locks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         reloadable,
-        auth_failures: auth::AuthFailureTracker::new(5, 900),
-        oidc: oidc_validator,
-        circuit_breaker: circuit_breaker::CircuitBreakerRegistry::new(cb_config),
+        auth_failures: Arc::new(auth::AuthFailureTracker::new(5, 900)),
+        oidc: oidc_validator.map(Arc::new),
+        circuit_breaker: Arc::new(circuit_breaker::CircuitBreakerRegistry::new(cb_config)),
         digest_store,
         leak_finders,
-    });
+    };
 
     // Initialize circuit breaker gauge to 0 (Closed) for all registries (#441)
     let registry_names: Vec<&str> = RegistryType::all().iter().map(|rt| rt.as_str()).collect();
@@ -1366,7 +1363,7 @@ async fn shutdown_signal() {
 /// Re-reads config.toml, rebuilds the CurationEngine with new filters,
 /// and atomically swaps the old config via ArcSwap.
 /// Storage, auth, port, and other settings are NOT reloaded — only curation.
-fn reload_curation(state: &Arc<AppState>) -> Result<(), String> {
+fn reload_curation(state: &AppState) -> Result<(), String> {
     let config = Config::try_load()?;
     let engine = build_curation_engine(&config);
 

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -207,7 +207,7 @@ impl LeakFinders {
 }
 
 /// Routes for metrics endpoint
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new().route("/metrics", get(metrics_handler))
 }
 
@@ -262,7 +262,7 @@ pub async fn metrics_middleware(
 /// Scans outgoing JSON responses for configured upstream hostnames.
 /// Detection only — never blocks responses. Increments counter and logs WARN.
 pub async fn leak_detection_middleware(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     request: Request<Body>,
     next: Next,
 ) -> Response {

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -8,7 +8,6 @@
 #![allow(dead_code)] // utoipa doc stubs — not called at runtime, used by derive macros
 
 use axum::Router;
-use std::sync::Arc;
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
@@ -1046,7 +1045,7 @@ pub async fn revoke_token() {}
 
 // ============ Routes ============
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .merge(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", ApiDoc::openapi()))
 }

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -34,7 +34,6 @@ use axum::{
     routing::get,
     Router,
 };
-use std::sync::Arc;
 use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://galaxy.ansible.com";
@@ -43,7 +42,7 @@ const UPSTREAM_DEFAULT: &str = "https://galaxy.ansible.com";
 pub const INDEX_PATTERN: (&str, &str) = ("ansible/", ".tar.gz");
 const API_PREFIX: &str = "/api/v3/plugin/ansible/content/published/collections/index";
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         // Galaxy API discovery (ansible-galaxy CLI hits this first)
         .route("/ansible/", get(api_discovery))
@@ -105,10 +104,7 @@ async fn api_discovery() -> Response {
 
 // ── Collection list ────────────────────────────────────────────────────
 
-async fn collection_list(
-    State(state): State<Arc<AppState>>,
-    RawQuery(raw_query): RawQuery,
-) -> Response {
+async fn collection_list(State(state): State<AppState>, RawQuery(raw_query): RawQuery) -> Response {
     let proxy_url = upstream_url(&state);
     let base = format!("{}{}/", proxy_url.trim_end_matches('/'), API_PREFIX);
     let url = append_query(&base, raw_query.as_deref());
@@ -124,7 +120,7 @@ async fn collection_list(
 // ── Collection detail ──────────────────────────────────────────────────
 
 async fn collection_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((ns, name)): Path<(String, String)>,
 ) -> Response {
     if !is_valid_name(&ns) || !is_valid_name(&name) {
@@ -147,7 +143,7 @@ async fn collection_detail(
 // ── Version listing ────────────────────────────────────────────────────
 
 async fn version_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((ns, name)): Path<(String, String)>,
     RawQuery(raw_query): RawQuery,
 ) -> Response {
@@ -185,7 +181,7 @@ async fn version_list(
 // ── Version detail ─────────────────────────────────────────────────────
 
 async fn version_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path((ns, name, ver)): Path<(String, String, String)>,
 ) -> Response {
@@ -229,7 +225,7 @@ async fn version_detail(
 // ── Tarball download (immutable) ───────────────────────────────────────
 
 async fn download_tarball(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(filename): Path<String>,
 ) -> Response {
@@ -347,12 +343,7 @@ async fn download_tarball(
 ///
 /// `cache_key` is the storage path for the cached response (e.g.
 /// `ansible/metadata/community/general.json`).
-async fn proxy_json(
-    state: &Arc<AppState>,
-    url: &str,
-    artifact_name: &str,
-    cache_key: &str,
-) -> Response {
+async fn proxy_json(state: &AppState, url: &str, artifact_name: &str, cache_key: &str) -> Response {
     let base_url = nora_base_url(state);
     let upstream = upstream_url(state);
 

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -27,10 +27,9 @@ use axum::{
     Router,
 };
 use sha2::Digest;
-use std::sync::Arc;
 use std::time::Duration;
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/cargo/index/config.json", get(index_config))
         .route("/cargo/index/{*path}", get(sparse_index))
@@ -50,7 +49,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 // ============================================================================
 
 /// GET /cargo/index/config.json — tells cargo where to download crates.
-async fn index_config(State(state): State<Arc<AppState>>) -> Response {
+async fn index_config(State(state): State<AppState>) -> Response {
     let base = nora_base_url(&state);
     let config = serde_json::json!({
         "dl": format!("{}/cargo/api/v1/crates", base),
@@ -83,7 +82,7 @@ async fn index_config(State(state): State<Arc<AppState>>) -> Response {
 ///
 /// Each entry is one JSON line per version (newline-delimited).
 async fn sparse_index(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: HeaderMap,
     Path(path): Path<String>,
 ) -> Response {
@@ -183,10 +182,7 @@ async fn sparse_index(
 // ============================================================================
 
 /// GET /cargo/api/v1/crates/{crate_name} — JSON metadata.
-async fn get_metadata(
-    State(state): State<Arc<AppState>>,
-    Path(crate_name): Path<String>,
-) -> Response {
+async fn get_metadata(State(state): State<AppState>, Path(crate_name): Path<String>) -> Response {
     if validate_storage_key(&crate_name).is_err() {
         return StatusCode::BAD_REQUEST.into_response();
     }
@@ -234,7 +230,7 @@ async fn get_metadata(
 
 /// GET /cargo/api/v1/crates/{name}/{version}/download — download .crate file.
 async fn download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path((crate_name, version)): Path<(String, String)>,
 ) -> Response {
@@ -380,7 +376,7 @@ async fn download(
 ///   N bytes:    metadata JSON
 ///   4 bytes LE: .crate tarball length
 ///   M bytes:    .crate tarball
-async fn publish(State(state): State<Arc<AppState>>, body: Bytes) -> Response {
+async fn publish(State(state): State<AppState>, body: Bytes) -> Response {
     if body.len() < 8 {
         return (StatusCode::BAD_REQUEST, "Payload too small").into_response();
     }

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -39,12 +39,11 @@ use axum::{
     Router,
 };
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://center2.conan.io";
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         // Ping — must come before the wildcard
         .route("/conan/v2/ping", get(ping))
@@ -109,7 +108,7 @@ async fn ping() -> Response {
 // ── Search ────────────────────────────────────────────────────────────
 
 async fn search(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(params): Query<HashMap<String, String>>,
 ) -> Response {
     let query = params.get("q").cloned().unwrap_or_default();
@@ -176,7 +175,7 @@ async fn search(
 // ── Recipe latest revision (TTL cached) ───────────────────────────────
 
 async fn recipe_latest(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, ver, user, chan)): Path<(String, String, String, String)>,
 ) -> Response {
     if !is_valid_ref(&name) || !is_valid_ref(&ver) || !is_valid_ref(&user) || !is_valid_ref(&chan) {
@@ -210,7 +209,7 @@ async fn recipe_latest(
 // ── Recipe revisions (TTL cached) ─────────────────────────────────────
 
 async fn recipe_revisions(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, ver, user, chan)): Path<(String, String, String, String)>,
 ) -> Response {
     if !is_valid_ref(&name) || !is_valid_ref(&ver) || !is_valid_ref(&user) || !is_valid_ref(&chan) {
@@ -243,7 +242,7 @@ async fn recipe_revisions(
 // ── Recipe file listing (immutable — scoped to revision) ──────────────
 
 async fn recipe_file_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, ver, user, chan, rrev)): Path<(String, String, String, String, String)>,
 ) -> Response {
     if !is_valid_ref(&name)
@@ -279,7 +278,7 @@ async fn recipe_file_list(
 // ── Recipe file download (immutable) ──────────────────────────────────
 
 async fn recipe_file_download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: HeaderMap,
     Path((name, ver, user, chan, rrev, filename)): Path<(
         String,
@@ -393,7 +392,7 @@ async fn recipe_file_download(
 // ── Package latest revision (TTL cached) ──────────────────────────────
 
 async fn package_latest(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, ver, user, chan, rrev, pkg_id)): Path<(
         String,
         String,
@@ -444,7 +443,7 @@ async fn package_latest(
 // ── Package revisions (TTL cached) ────────────────────────────────────
 
 async fn package_revisions(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, ver, user, chan, rrev, pkg_id)): Path<(
         String,
         String,
@@ -495,7 +494,7 @@ async fn package_revisions(
 // ── Package file listing (immutable — scoped to PREV) ─────────────────
 
 async fn package_file_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, ver, user, chan, rrev, pkg_id, prev)): Path<(
         String,
         String,
@@ -546,7 +545,7 @@ async fn package_file_list(
 // ── Package file download (immutable) ─────────────────────────────────
 
 async fn package_file_download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: HeaderMap,
     Path((name, ver, user, chan, rrev, pkg_id, prev, filename)): Path<(
         String,
@@ -670,7 +669,7 @@ async fn package_file_download(
 
 /// Fetch JSON from upstream, cache with TTL (mutable content).
 async fn fetch_and_cache_json(
-    state: &Arc<AppState>,
+    state: &AppState,
     url: &str,
     storage_key: &str,
     artifact: &str,
@@ -713,7 +712,7 @@ async fn fetch_and_cache_json(
 
 /// Fetch JSON from upstream, cache immutably (content scoped to revision, never changes).
 async fn fetch_and_cache_immutable_json(
-    state: &Arc<AppState>,
+    state: &AppState,
     url: &str,
     storage_key: &str,
     artifact: &str,

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -358,7 +358,7 @@ fn quarantine_forbidden(
 /// Docker v2 routes.
 /// Uses a `{*rest}` wildcard to support image names with arbitrary path depth
 /// (e.g., `library/astra/ubi18-cpp122`), per OCI Distribution spec.
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route(
             "/v2/",
@@ -372,7 +372,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 /// Parses the image name (arbitrary depth) and operation from the wildcard path,
 /// then delegates to the appropriate handler with correct method routing.
 async fn docker_v2_dispatch(
-    state: State<Arc<AppState>>,
+    state: State<AppState>,
     method: Method,
     Path(wildcard): Path<String>,
     uri: Uri,
@@ -535,7 +535,7 @@ pub(crate) fn strip_docker_namespace(name: &str) -> &str {
 }
 
 /// List all repositories in the registry
-async fn catalog(State(state): State<Arc<AppState>>) -> Json<Value> {
+async fn catalog(State(state): State<AppState>) -> Json<Value> {
     let keys = state.storage.list("docker/").await;
 
     // Extract unique repository names from paths like "docker/{name}/manifests/..."
@@ -567,7 +567,7 @@ async fn catalog(State(state): State<Arc<AppState>>) -> Json<Value> {
 }
 
 async fn check_blob(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
     let c = canonicalize(&name, &state.config.docker.upstreams);
@@ -596,7 +596,7 @@ async fn check_blob(
 }
 
 async fn download_blob(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
@@ -744,7 +744,7 @@ async fn download_blob(
     StatusCode::NOT_FOUND.into_response()
 }
 
-async fn start_upload(State(state): State<Arc<AppState>>, Path(name): Path<String>) -> Response {
+async fn start_upload(State(state): State<AppState>, Path(name): Path<String>) -> Response {
     let name = canonicalize(&name, &state.config.docker.upstreams).name;
     if let Err(e) = validate_docker_name(&name) {
         return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
@@ -793,7 +793,7 @@ async fn start_upload(State(state): State<Arc<AppState>>, Path(name): Path<Strin
 /// PATCH handler for chunked blob uploads
 /// Docker client sends data chunks via PATCH, then finalizes with PUT
 async fn patch_blob(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, uuid)): Path<(String, String)>,
     body: Bytes,
 ) -> Response {
@@ -919,7 +919,7 @@ async fn patch_blob(
 /// Handles both monolithic uploads (body contains all data) and
 /// chunked upload finalization (body may be empty, data in session)
 async fn upload_blob(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, uuid)): Path<(String, String)>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
     body: Bytes,
@@ -1110,7 +1110,7 @@ async fn upload_blob(
 /// Returns `Some(Response)` on first successful upstream (or quarantine block),
 /// `None` if all upstreams failed.
 async fn try_fetch_and_cache(
-    state: &Arc<AppState>,
+    state: &AppState,
     upstreams: &[&crate::config::DockerUpstream],
     upstream_name: &str,
     name: &str,
@@ -1168,7 +1168,7 @@ async fn try_fetch_and_cache(
                     {
                         let storage = state.storage.clone();
                         let key_clone = cache_key.to_string();
-                        let state_clone = Arc::clone(state);
+                        let repo_index = Arc::clone(&state.repo_index);
                         tokio::spawn(async move {
                             if let Err(e) = storage.put(&key_clone, &data).await {
                                 tracing::warn!(key = %key_clone, error = %e, "cache write failed (quarantine pre-cache)");
@@ -1176,7 +1176,7 @@ async fn try_fetch_and_cache(
                                     .with_label_values(&["docker", "manifest"])
                                     .inc();
                             }
-                            state_clone.repo_index.invalidate("docker");
+                            repo_index.invalidate("docker");
                         });
                         return Some(quarantine_forbidden(&digest, &q_status, q_secs));
                     }
@@ -1190,7 +1190,7 @@ async fn try_fetch_and_cache(
                 let name_clone = name.to_string();
                 let reference_clone = reference.to_string();
                 let digest_clone = digest.clone();
-                let state_clone = Arc::clone(state);
+                let repo_index = Arc::clone(&state.repo_index);
                 tokio::spawn(async move {
                     // Store manifest by tag and digest (namespaced)
                     if let Err(e) = storage.put(&key_clone, &data_clone).await {
@@ -1232,7 +1232,7 @@ async fn try_fetch_and_cache(
                                 .inc();
                         }
                     }
-                    state_clone.repo_index.invalidate("docker");
+                    repo_index.invalidate("docker");
                 });
 
                 return Some(manifest_response(data, content_type, digest));
@@ -1248,7 +1248,7 @@ async fn try_fetch_and_cache(
 }
 
 async fn get_manifest(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path((name, reference)): Path<(String, String)>,
 ) -> Response {
@@ -1358,7 +1358,7 @@ async fn get_manifest(
 
 /// Serve a manifest from local cache with all required headers and side-effects.
 fn serve_cached_manifest(
-    state: &Arc<AppState>,
+    state: &AppState,
     data: &[u8],
     name: &str,
     reference: &str,
@@ -1425,7 +1425,7 @@ fn serve_cached_manifest(
 }
 
 async fn put_manifest(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, reference)): Path<(String, String)>,
     body: Bytes,
 ) -> Response {
@@ -1507,7 +1507,7 @@ async fn put_manifest(
         .into_response()
 }
 
-async fn list_tags(State(state): State<Arc<AppState>>, Path(name): Path<String>) -> Response {
+async fn list_tags(State(state): State<AppState>, Path(name): Path<String>) -> Response {
     let c = canonicalize(&name, &state.config.docker.upstreams);
     let ns = c.namespace;
     let name = c.name;
@@ -1541,7 +1541,7 @@ async fn list_tags(State(state): State<Arc<AppState>>, Path(name): Path<String>)
 // ============================================================================
 
 async fn delete_manifest(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, reference)): Path<(String, String)>,
 ) -> Response {
     let c = canonicalize(&name, &state.config.docker.upstreams);
@@ -1661,7 +1661,7 @@ async fn delete_manifest(
 }
 
 async fn delete_blob(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((name, digest)): Path<(String, String)>,
 ) -> Response {
     let c = canonicalize(&name, &state.config.docker.upstreams);
@@ -2142,7 +2142,7 @@ async fn get_config_info(
 
 /// Update metadata when a manifest is pulled
 /// Increments download counter and updates last_pulled timestamp
-async fn update_metadata_on_pull(state: Arc<AppState>, storage: Storage, meta_key: String) {
+async fn update_metadata_on_pull(state: AppState, storage: Storage, meta_key: String) {
     // Lock to prevent lost counter increments from concurrent pulls
     let lock = state.publish_lock(&meta_key);
     let _guard = lock.lock().await;

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -27,12 +27,11 @@ use axum::{
     routing::get,
     Router,
 };
-use std::sync::Arc;
 use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://rubygems.org";
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         // Index files (mutable)
         .route("/gems/specs.4.8.gz", get(specs_index))
@@ -50,19 +49,19 @@ use crate::cache_ttl::is_within_ttl;
 
 // ── Index endpoints (mutable, TTL cached) ─────────────────────────────
 
-async fn specs_index(State(state): State<Arc<AppState>>) -> Response {
+async fn specs_index(State(state): State<AppState>) -> Response {
     fetch_index(&state, "specs.4.8.gz").await
 }
 
-async fn latest_specs_index(State(state): State<Arc<AppState>>) -> Response {
+async fn latest_specs_index(State(state): State<AppState>) -> Response {
     fetch_index(&state, "latest_specs.4.8.gz").await
 }
 
-async fn prerelease_specs_index(State(state): State<Arc<AppState>>) -> Response {
+async fn prerelease_specs_index(State(state): State<AppState>) -> Response {
     fetch_index(&state, "prerelease_specs.4.8.gz").await
 }
 
-async fn fetch_index(state: &Arc<AppState>, filename: &str) -> Response {
+async fn fetch_index(state: &AppState, filename: &str) -> Response {
     let storage_key = format!("gems/{}", filename);
 
     // Check TTL: if cached and fresh, serve from cache
@@ -125,7 +124,7 @@ async fn fetch_index(state: &Arc<AppState>, filename: &str) -> Response {
 // ── Compact index ──────────────────────────────────────────────────────
 
 async fn compact_index(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(name): Path<String>,
 ) -> Response {
@@ -207,7 +206,7 @@ async fn compact_index(
 // ── Gem download (immutable) ───────────────────────────────────────────
 
 async fn download_gem(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(filename): Path<String>,
 ) -> Response {
@@ -313,10 +312,7 @@ async fn download_gem(
 
 // ── Gemspec download (immutable) ───────────────────────────────────────
 
-async fn download_gemspec(
-    State(state): State<Arc<AppState>>,
-    Path(filename): Path<String>,
-) -> Response {
+async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<String>) -> Response {
     // filename = "name-version.gemspec.rz" — strip suffix and split
     let stem = match filename.strip_suffix(".gemspec.rz") {
         Some(s) => s,

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -25,16 +25,15 @@ use axum::{
     Router,
 };
 use percent_encoding::percent_decode;
-use std::sync::Arc;
 use std::time::Duration;
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new().route("/go/{*path}", get(handle))
 }
 
 /// Main handler — parses the wildcard path and dispatches to the right logic.
 async fn handle(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(path): Path<String>,
 ) -> Response {

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -24,10 +24,9 @@ use axum::{
 };
 use sha2::Digest;
 use std::collections::BTreeSet;
-use std::sync::Arc;
 use std::time::Duration;
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new().route(
         "/maven2/{*path}",
         get(download)
@@ -105,7 +104,7 @@ fn is_snapshot(version: &str) -> bool {
 // ============================================================================
 
 async fn download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(path): Path<String>,
 ) -> Response {
@@ -231,11 +230,7 @@ async fn download(
 // Upload
 // ============================================================================
 
-async fn upload(
-    State(state): State<Arc<AppState>>,
-    Path(path): Path<String>,
-    body: Bytes,
-) -> Response {
+async fn upload(State(state): State<AppState>, Path(path): Path<String>, body: Bytes) -> Response {
     if !path.is_ascii() || path.contains("..") || path.contains('\0') || path.starts_with('/') {
         return (StatusCode::BAD_REQUEST, "Invalid path").into_response();
     }

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -21,7 +21,7 @@ use sha2::Digest;
 use std::sync::Arc;
 use std::time::Duration;
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new().route(
         "/npm/{*path}",
         get(handle_request)
@@ -103,7 +103,7 @@ fn replace_upstream_bytes(data: &[u8], upstream_url: &str, nora_npm_base: &str) 
 }
 
 async fn handle_request(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(path): Path<String>,
 ) -> Response {
@@ -280,12 +280,12 @@ async fn handle_request(
                 let storage = state.storage.clone();
                 let key_clone = key.clone();
                 let invalidate_npm = is_tarball;
-                let state_clone = Arc::clone(&state);
+                let repo_index = Arc::clone(&state.repo_index);
                 tokio::spawn(async move {
                     if let Err(e) = storage.put(&key_clone, &data_to_cache).await {
                         tracing::warn!(key = %key_clone, error = ?e, "npm proxy: failed to cache artifact");
                     } else if invalidate_npm {
-                        state_clone.repo_index.invalidate("npm");
+                        repo_index.invalidate("npm");
                     }
                 });
 
@@ -304,7 +304,7 @@ async fn handle_request(
 
 /// Refetch metadata from upstream, rewrite URLs, update cache.
 /// Returns None if upstream is unavailable (caller serves stale cache).
-async fn refetch_metadata(state: &Arc<AppState>, path: &str, key: &str) -> Option<Vec<u8>> {
+async fn refetch_metadata(state: &AppState, path: &str, key: &str) -> Option<Vec<u8>> {
     let proxy_url = state.config.npm.proxy.as_ref()?;
     let url = format!("{}/{}", proxy_url.trim_end_matches('/'), path);
 
@@ -359,7 +359,7 @@ fn is_valid_attachment_name(name: &str) -> bool {
 }
 
 async fn handle_publish(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(path): Path<String>,
     body: Bytes,
 ) -> Response {

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -30,7 +30,6 @@ use axum::{
     Router,
 };
 use serde::Deserialize;
-use std::sync::Arc;
 use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://api.nuget.org";
@@ -163,7 +162,7 @@ pub async fn discover_search_endpoints(
     }
 }
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     routes_with_prefix("nuget")
 }
 
@@ -171,11 +170,11 @@ pub fn routes() -> Router<Arc<AppState>> {
 /// These serve the same NuGet V3 handlers under alternate path prefixes.
 /// The service index points back to /nuget/ paths, so clients follow those
 /// URLs after initial discovery — storage and caching stay unified.
-pub fn alias_routes() -> Router<Arc<AppState>> {
+pub fn alias_routes() -> Router<AppState> {
     routes_with_prefix("chocolatey").merge(routes_with_prefix("pwsh"))
 }
 
-fn routes_with_prefix(prefix: &str) -> Router<Arc<AppState>> {
+fn routes_with_prefix(prefix: &str) -> Router<AppState> {
     Router::new()
         .route(&format!("/{prefix}/v3/index.json"), get(service_index))
         .route(&format!("/{prefix}/v3/query"), get(search_query))
@@ -200,7 +199,7 @@ fn routes_with_prefix(prefix: &str) -> Router<Arc<AppState>> {
 
 // ── Service index ──────────────────────────────────────────────────────
 
-async fn service_index(State(state): State<Arc<AppState>>) -> Response {
+async fn service_index(State(state): State<AppState>) -> Response {
     let base_url = nora_base_url(&state);
     let index = generate_service_index(&base_url);
 
@@ -218,7 +217,7 @@ async fn service_index(State(state): State<Arc<AppState>>) -> Response {
 // ── Search query (proxy to upstream SearchQueryService, local fallback) ──
 
 async fn search_query(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     _headers: HeaderMap,
     Query(params): Query<SearchParams>,
     raw_query: axum::extract::RawQuery,
@@ -295,7 +294,7 @@ async fn search_query(
 // ── Autocomplete (proxy to upstream SearchAutocompleteService) ─────────
 
 async fn autocomplete_query(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(params): Query<SearchParams>,
     raw_query: axum::extract::RawQuery,
 ) -> Response {
@@ -370,7 +369,7 @@ async fn autocomplete_query(
 // ── Registration index ─────────────────────────────────────────────────
 
 async fn registration_index(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(id): Path<String>,
 ) -> Response {
@@ -461,7 +460,7 @@ async fn registration_index(
 // ── Registration page (paginated version ranges) ────────────────────────
 
 async fn registration_page(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((id, lower, upper_raw)): Path<(String, String, String)>,
 ) -> Response {
     let id_lower = id.to_lowercase();
@@ -545,7 +544,7 @@ async fn registration_page(
 // ── Flat container dispatcher ───────────────────────────────────────────
 
 async fn flatcontainer_handler(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(path): Path<String>,
 ) -> Response {
@@ -563,7 +562,7 @@ async fn flatcontainer_handler(
 
 // ── Version list ───────────────────────────────────────────────────────
 
-async fn version_list(state: Arc<AppState>, id: &str) -> Response {
+async fn version_list(state: AppState, id: &str) -> Response {
     let id = id.to_string();
     let id_lower = id.to_lowercase();
     if !is_valid_package_id(&id_lower) {
@@ -632,7 +631,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
 // ── Flatcontainer download (nupkg/nuspec, immutable) ───────────────────
 
 async fn flatcontainer_download(
-    state: Arc<AppState>,
+    state: AppState,
     headers: axum::http::HeaderMap,
     path: &str,
     id: &str,
@@ -761,7 +760,7 @@ async fn flatcontainer_download(
             // Best-effort: fetch flatcontainer index.json if missing (for local search)
             if ends_with_ci(filename, ".nupkg") {
                 let index_key = format!("nuget/flatcontainer/{}/index.json", id_lower);
-                let state2 = Arc::clone(&state);
+                let state2 = state.clone();
                 let proxy_url2 = proxy_url.clone();
                 let id2 = id_lower.clone();
                 tokio::spawn(async move {

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -33,7 +33,6 @@ use axum::{
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use serde_json::{Map, Value};
 use sha2::Digest;
-use std::sync::Arc;
 use std::time::Duration;
 
 /// Storage prefix and file suffix for repo index scanning.
@@ -59,7 +58,7 @@ const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
     .add(b'|')
     .add(b'}');
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/pub/api/packages", get(search_packages))
         .route(
@@ -77,10 +76,7 @@ pub fn routes() -> Router<Arc<AppState>> {
         )
 }
 
-async fn search_packages(
-    State(state): State<Arc<AppState>>,
-    RawQuery(raw_query): RawQuery,
-) -> Response {
+async fn search_packages(State(state): State<AppState>, RawQuery(raw_query): RawQuery) -> Response {
     let raw_query = raw_query.unwrap_or_default();
     let key = format!(
         "pub/search/{}.json",
@@ -126,7 +122,7 @@ async fn search_packages(
 }
 
 async fn package_listing(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(package): Path<String>,
 ) -> Response {
@@ -188,7 +184,7 @@ async fn package_listing(
 }
 
 async fn version_metadata(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((package, version)): Path<(String, String)>,
 ) -> Response {
     if !is_valid_pub_package_name(&package) || !is_valid_pub_version(&version) {
@@ -236,7 +232,7 @@ async fn version_metadata(
 }
 
 async fn package_advisories(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(package): Path<String>,
 ) -> Response {
     if !is_valid_pub_package_name(&package) {
@@ -281,7 +277,7 @@ async fn package_advisories(
 }
 
 async fn download_archive(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path((package, archive)): Path<(String, String)>,
 ) -> Response {
@@ -433,7 +429,7 @@ async fn fetch_pub_api(
     .await
 }
 
-async fn cache_bytes(state: &Arc<AppState>, key: String, data: Vec<u8>) {
+async fn cache_bytes(state: &AppState, key: String, data: Vec<u8>) {
     if let Err(e) = state.storage.put(&key, &data).await {
         tracing::warn!(key = %key, error = %e, "pub: failed to cache proxy data");
     }

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -33,7 +33,7 @@ use std::time::Duration;
 /// PEP 691 JSON content type
 const PEP691_JSON: &str = "application/vnd.pypi.simple.v1+json";
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         .route(
             "/simple/",
@@ -50,10 +50,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 // ============================================================================
 
 /// GET /simple/ — list all packages (PEP 503 HTML or PEP 691 JSON).
-async fn list_packages(
-    State(state): State<Arc<AppState>>,
-    headers: HeaderMap,
-) -> impl IntoResponse {
+async fn list_packages(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
     let keys = state.storage.list("pypi/").await;
     let mut packages = std::collections::HashSet::new();
 
@@ -121,7 +118,7 @@ async fn list_packages(
 /// (e.g. both cp310 and cp314) regardless of which were cached first.
 /// Falls back to local-only when upstream is unavailable.
 async fn package_versions(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     headers: HeaderMap,
 ) -> Response {
@@ -206,7 +203,7 @@ async fn package_versions(
 
 /// GET /simple/{name}/{filename} — download a specific file.
 async fn download_file(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: HeaderMap,
     Path((name, filename)): Path<(String, String)>,
 ) -> Response {
@@ -318,14 +315,14 @@ async fn download_file(
                             let storage = state.storage.clone();
                             let key_clone = key.clone();
                             let data_clone = data.clone();
-                            let state_clone = Arc::clone(&state);
+                            let repo_index = Arc::clone(&state.repo_index);
                             tokio::spawn(async move {
                                 if storage.put(&key_clone, &data_clone).await.is_ok() {
                                     let hash = hex::encode(sha2::Sha256::digest(&data_clone));
                                     let _ = storage
                                         .put(&format!("{}.sha256", key_clone), hash.as_bytes())
                                         .await;
-                                    state_clone.repo_index.invalidate("pypi");
+                                    repo_index.invalidate("pypi");
                                 }
                             });
 
@@ -369,7 +366,7 @@ async fn download_file(
 ///   content = the file bytes
 ///   sha256_digest = hex SHA-256 of file (optional)
 ///   metadata_version, summary, etc. (optional metadata)
-async fn upload(State(state): State<Arc<AppState>>, mut multipart: Multipart) -> Response {
+async fn upload(State(state): State<AppState>, mut multipart: Multipart) -> Response {
     let mut action = String::new();
     let mut name = String::new();
     let mut version = String::new();

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -13,9 +13,8 @@ use axum::{
     routing::{get, post},
     Router,
 };
-use std::sync::Arc;
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new().route("/raw/-/reindex", post(reindex)).route(
         "/raw/{*path}",
         get(download)
@@ -28,7 +27,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 /// Invalidate the raw index so it rebuilds on next read.
 /// Useful after uploading files directly to S3/storage bypassing the API.
-async fn reindex(State(state): State<Arc<AppState>>) -> Response {
+async fn reindex(State(state): State<AppState>) -> Response {
     if !state.config.raw.enabled {
         return StatusCode::NOT_FOUND.into_response();
     }
@@ -38,7 +37,7 @@ async fn reindex(State(state): State<Arc<AppState>>) -> Response {
 }
 
 async fn download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(path): Path<String>,
     headers: axum::http::HeaderMap,
 ) -> Response {
@@ -110,7 +109,7 @@ async fn download(
 }
 
 async fn upload(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(path): Path<String>,
     headers: axum::http::HeaderMap,
     body: Bytes,
@@ -243,7 +242,7 @@ async fn upload(
 }
 
 /// Overwrite an existing file (conditional PUT with `If-Match`).
-async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8]) -> Response {
+async fn do_overwrite(state: &AppState, key: &str, path: &str, body: &[u8]) -> Response {
     // Direct put() — both filesystem and S3 backends overwrite in-place,
     // avoiding the 404 window that delete-then-put created for concurrent readers.
     match state.storage.put(key, body).await {
@@ -268,7 +267,7 @@ async fn do_overwrite(state: &Arc<AppState>, key: &str, path: &str, body: &[u8])
     }
 }
 
-async fn delete_file(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
+async fn delete_file(State(state): State<AppState>, Path(path): Path<String>) -> Response {
     if !state.config.raw.enabled {
         return StatusCode::NOT_FOUND.into_response();
     }
@@ -290,7 +289,7 @@ async fn delete_file(State(state): State<Arc<AppState>>, Path(path): Path<String
     }
 }
 
-async fn check_exists(State(state): State<Arc<AppState>>, Path(path): Path<String>) -> Response {
+async fn check_exists(State(state): State<AppState>, Path(path): Path<String>) -> Response {
     if !state.config.raw.enabled {
         return StatusCode::NOT_FOUND.into_response();
     }

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -32,7 +32,6 @@ use axum::{
     routing::get,
     Router,
 };
-use std::sync::Arc;
 use std::time::Duration;
 
 const UPSTREAM_DEFAULT: &str = "https://registry.terraform.io";
@@ -40,7 +39,7 @@ const UPSTREAM_DEFAULT: &str = "https://registry.terraform.io";
 /// Storage prefix and file suffix for repo index scanning.
 pub const INDEX_PATTERN: (&str, &str) = ("terraform/", ".zip");
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         // Service discovery
         .route(
@@ -81,7 +80,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 // ── Service discovery ──────────────────────────────────────────────────
 
-async fn service_discovery(State(state): State<Arc<AppState>>) -> Response {
+async fn service_discovery(State(state): State<AppState>) -> Response {
     let base = nora_base_url(&state);
     let json = serde_json::json!({
         "providers.v1": format!("{}/terraform/v1/providers/", base),
@@ -107,7 +106,7 @@ async fn service_discovery(State(state): State<Arc<AppState>>) -> Response {
 // ── Provider versions (mutable, TTL cached) ────────────────────────────
 
 async fn provider_versions(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((ns, ptype)): Path<(String, String)>,
 ) -> Response {
     if !is_valid_name(&ns) || !is_valid_name(&ptype) {
@@ -174,7 +173,7 @@ async fn provider_versions(
 // ── Provider download metadata ─────────────────────────────────────────
 
 async fn provider_download_meta(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: HeaderMap,
     Path((ns, ptype, ver, os, arch)): Path<(String, String, String, String, String)>,
 ) -> Response {
@@ -275,7 +274,7 @@ async fn provider_download_meta(
 // ── Provider binary download (immutable) ───────────────────────────────
 
 async fn provider_download_binary(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(path): Path<String>,
 ) -> Response {
     if !is_safe_path(&path) {
@@ -349,7 +348,7 @@ async fn provider_download_binary(
 // ── Module versions ────────────────────────────────────────────────────
 
 async fn module_versions(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((ns, name, provider)): Path<(String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns) || !is_valid_name(&name) || !is_valid_name(&provider) {
@@ -420,7 +419,7 @@ async fn module_versions(
 // ── Module download ────────────────────────────────────────────────────
 
 async fn module_download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((ns, name, provider, ver)): Path<(String, String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns)
@@ -521,7 +520,7 @@ async fn module_download(
 // ── Module source download (cached, proxied) ─────────────────────────
 
 async fn module_source_download(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((ns, name, provider, ver)): Path<(String, String, String, String)>,
 ) -> Response {
     if !is_valid_name(&ns)

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -37,7 +37,7 @@ use parking_lot::RwLock;
 
 /// Everything a test needs: tempdir (must stay alive), shared state, and the router.
 pub struct TestContext {
-    pub state: Arc<AppState>,
+    pub state: AppState,
     pub app: Router,
     pub _tempdir: TempDir,
 }
@@ -226,36 +226,37 @@ fn build_context(
 
     let leak_finders = crate::metrics::LeakFinders::new(config.upstream_hostnames());
 
-    let state = Arc::new(AppState {
+    let enabled_registries = Arc::new(enabled_registries);
+    let state = AppState {
         storage,
-        config,
+        config: Arc::new(config),
         enabled_registries: enabled_registries.clone(),
         start_time: Instant::now(),
         startup_duration_ms: 0,
-        auth,
+        auth: auth.map(Arc::new),
         tokens,
-        metrics: DashboardMetrics::new(),
-        activity: ActivityLog::new(50),
+        metrics: Arc::new(DashboardMetrics::new()),
+        activity: Arc::new(ActivityLog::new(50)),
         audit: Arc::new(AuditLog::new(&storage_path, crate::audit::AuditMode::Off)),
-        docker_auth,
-        repo_index: RepoIndex::new(),
+        docker_auth: Arc::new(docker_auth),
+        repo_index: Arc::new(RepoIndex::new()),
         http_client: reqwest::Client::new(),
         upload_sessions: Arc::new(RwLock::new(HashMap::new())),
-        publish_locks: parking_lot::Mutex::new(HashMap::new()),
+        publish_locks: Arc::new(parking_lot::Mutex::new(HashMap::new())),
         reloadable,
-        auth_failures: crate::auth::AuthFailureTracker::new(5, 900),
+        auth_failures: Arc::new(crate::auth::AuthFailureTracker::new(5, 900)),
         oidc: None,
-        circuit_breaker: crate::circuit_breaker::CircuitBreakerRegistry::new(cb_config),
-        digest_store: std::sync::Arc::new(crate::digest_quarantine::DigestStore::empty(
-            &storage_path,
+        circuit_breaker: Arc::new(crate::circuit_breaker::CircuitBreakerRegistry::new(
+            cb_config,
         )),
+        digest_store: Arc::new(crate::digest_quarantine::DigestStore::empty(&storage_path)),
         leak_finders,
-    });
+    };
 
     // Build router identical to run_server() but without TcpListener / rate-limiting
     // Dynamic route merging based on enabled registries
     let mut registry_routes = Router::new();
-    for reg in &enabled_registries {
+    for reg in enabled_registries.iter() {
         match reg {
             crate::registry_type::RegistryType::Docker => {
                 registry_routes = registry_routes.merge(registry::docker_routes());

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -16,7 +16,6 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;
-use std::sync::Arc;
 use utoipa::ToSchema;
 
 #[derive(Serialize)]
@@ -152,9 +151,9 @@ pub struct MountPoint {
 
 // ============ API Handlers ============
 
-pub async fn api_stats(State(state): State<Arc<AppState>>) -> Json<RegistryStats> {
+pub async fn api_stats(State(state): State<AppState>) -> Json<RegistryStats> {
     // Trigger index rebuild if needed, then get counts
-    for reg in &state.enabled_registries {
+    for reg in state.enabled_registries.iter() {
         let _ = state.repo_index.get(reg.as_str(), &state.storage).await;
     }
 
@@ -177,7 +176,7 @@ pub async fn api_stats(State(state): State<Arc<AppState>>) -> Json<RegistryStats
     })
 }
 
-pub async fn api_dashboard(State(state): State<Arc<AppState>>) -> Json<DashboardResponse> {
+pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardResponse> {
     let mut total_storage: u64 = 0;
     let mut total_artifacts: usize = 0;
     let mut registry_card_stats = Vec::new();
@@ -261,7 +260,7 @@ pub async fn api_dashboard(State(state): State<Arc<AppState>>) -> Json<Dashboard
 }
 
 pub async fn api_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(registry_type): Path<String>,
 ) -> Json<Vec<RepoInfo>> {
     let repos = state.repo_index.get(&registry_type, &state.storage).await;
@@ -269,7 +268,7 @@ pub async fn api_list(
 }
 
 pub async fn api_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path((registry_type, name)): Path<(String, String)>,
 ) -> Json<serde_json::Value> {
     match registry_type.as_str() {
@@ -290,7 +289,7 @@ pub async fn api_detail(
 }
 
 pub async fn api_search(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(registry_type): Path<String>,
     Query(params): Query<SearchQuery>,
 ) -> axum::response::Html<String> {

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -18,7 +18,6 @@ use axum::{
     routing::{get, post},
     Form, Router,
 };
-use std::sync::Arc;
 
 use api::*;
 use i18n::Lang;
@@ -121,7 +120,7 @@ fn extract_basic_auth_user(headers: &axum::http::HeaderMap) -> Option<String> {
     Some(user.to_string())
 }
 
-pub fn routes() -> Router<Arc<AppState>> {
+pub fn routes() -> Router<AppState> {
     Router::new()
         // UI Pages
         .route("/", get(|| async { Redirect::to("/ui/") }))
@@ -176,7 +175,7 @@ pub fn routes() -> Router<Arc<AppState>> {
 
 // Dashboard page
 async fn dashboard(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -191,7 +190,7 @@ async fn dashboard(
 
 // Docker pages
 async fn docker_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -216,7 +215,7 @@ async fn docker_list(
 }
 
 async fn docker_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
@@ -239,7 +238,7 @@ async fn docker_detail(
 
 // Maven pages
 async fn maven_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -260,7 +259,7 @@ async fn maven_list(
 }
 
 async fn maven_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(path): Path<String>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
@@ -293,7 +292,7 @@ async fn maven_detail(
 
 // npm pages
 async fn npm_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -318,7 +317,7 @@ async fn npm_list(
 }
 
 async fn npm_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<DetailQuery>,
     headers: axum::http::HeaderMap,
@@ -349,7 +348,7 @@ async fn npm_detail(
 
 // Cargo pages
 async fn cargo_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -374,7 +373,7 @@ async fn cargo_list(
 }
 
 async fn cargo_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<DetailQuery>,
     headers: axum::http::HeaderMap,
@@ -405,7 +404,7 @@ async fn cargo_detail(
 
 // PyPI pages
 async fn pypi_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -430,7 +429,7 @@ async fn pypi_list(
 }
 
 async fn pypi_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<DetailQuery>,
     headers: axum::http::HeaderMap,
@@ -461,7 +460,7 @@ async fn pypi_detail(
 
 // Go pages
 async fn go_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -482,7 +481,7 @@ async fn go_list(
 }
 
 async fn go_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<DetailQuery>,
     headers: axum::http::HeaderMap,
@@ -530,7 +529,7 @@ async fn go_detail(
 
 // Raw pages
 async fn raw_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -555,7 +554,7 @@ async fn raw_list(
 }
 
 async fn raw_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
@@ -596,7 +595,7 @@ async fn raw_detail(
 
 // Generic registry list handler for new formats (v0.7)
 async fn generic_registry_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<ListQuery>,
     headers: axum::http::HeaderMap,
     uri: axum::http::Uri,
@@ -634,7 +633,7 @@ async fn generic_registry_list(
 }
 
 async fn generic_registry_detail(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(name): Path<String>,
     Query(query): Query<DetailQuery>,
     headers: axum::http::HeaderMap,
@@ -681,7 +680,7 @@ async fn generic_registry_detail(
 
 // Ansible Galaxy hierarchical browsing (namespace → collection → versions)
 async fn ansible_browse_root(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
@@ -704,7 +703,7 @@ async fn ansible_browse_root(
 }
 
 async fn ansible_browse(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(path): Path<String>,
     Query(query): Query<DetailQuery>,
     headers: axum::http::HeaderMap,
@@ -773,7 +772,7 @@ async fn ansible_browse(
 
 /// Token management page (GET /ui/tokens)
 async fn tokens_page(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let lang = extract_lang_from_headers(&headers);
@@ -795,7 +794,7 @@ struct CreateTokenForm {
 }
 
 async fn tokens_create(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Form(form): Form<CreateTokenForm>,
 ) -> impl IntoResponse {
@@ -862,7 +861,7 @@ async fn tokens_create(
 
 /// List tokens HTMX fragment (GET /api/ui/tokens/list)
 async fn tokens_list(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let lang = extract_lang_from_headers(&headers);
@@ -877,7 +876,7 @@ async fn tokens_list(
 
 /// Revoke token (POST /api/ui/tokens/{file_id}/revoke)
 async fn tokens_revoke(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
     Path(file_id): Path<String>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {


### PR DESCRIPTION
## Summary

- Make `AppState` implement `Clone` by wrapping all non-trivially-cloneable fields in `Arc`
- Change router state type from `State<Arc<AppState>>` to `State<AppState>` across all 22 files (104 handler signatures, 20 route functions)
- Refactor `spawn_cache`/`spawn_cache_immutable` from `self: &Arc<Self>` to `&self`, cloning only needed fields
- Decompose background cache spawns in docker/npm/pypi to clone only `repo_index` instead of full state

## Performance

Before: `State<Arc<AppState>>` = 1 atomic increment per request
After: `State<AppState>` = ~15 atomic increments per request (all fields Arc-wrapped or internally cheap)

Overhead: ~150-300ns per request — negligible vs I/O-bound registry operations.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 1115 passed
- [x] Pre-commit version check — PASS
- [x] Semgrep — no new findings
- [x] cargo-deny + cargo-audit — clean

Closes #483