### PR TITLE
fix(metrics): use body size_hint for leak detection guard (#517)

### DIFF
--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -291,8 +291,15 @@ fn log_outbound_proxy() {
 }
 
 /// Build HTTP client with optional custom CA certificate support.
-fn build_http_client(tls: &TlsConfig) -> reqwest::Client {
+///
+/// When `timeout` is `Some`, a default request timeout is set on the client
+/// (used by `nora mirror` for long-running downloads).
+fn build_http_client(tls: &TlsConfig, timeout: Option<std::time::Duration>) -> reqwest::Client {
     let mut builder = reqwest::ClientBuilder::new();
+
+    if let Some(t) = timeout {
+        builder = builder.timeout(t);
+    }
 
     if let Some(ref ca_path) = tls.ca_cert {
         match std::fs::read(ca_path) {
@@ -473,7 +480,9 @@ async fn main() {
             concurrency,
             json,
         }) => {
-            if let Err(e) = mirror::run_mirror(format, &registry, concurrency, json).await {
+            let client = build_http_client(&config.tls, Some(std::time::Duration::from_secs(300)));
+            if let Err(e) = mirror::run_mirror(format, &registry, concurrency, json, &client).await
+            {
                 error!("Mirror failed: {}", e);
                 std::process::exit(1);
             }
@@ -950,7 +959,7 @@ async fn run_server(mut config: Config, storage: Storage) {
     // Warn about plaintext credentials in config.toml
     config.warn_plaintext_credentials();
 
-    let http_client = build_http_client(&config.tls);
+    let http_client = build_http_client(&config.tls, None);
     log_outbound_proxy();
 
     // Initialize Docker auth with shared HTTP client (includes custom CA certs)

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -153,6 +153,16 @@ pub static CACHE_WRITE_ERRORS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("failed to create CACHE_WRITE_ERRORS metric at startup")
 });
 
+/// Leak detection scans skipped (#517)
+static LEAK_DETECTION_SKIPPED: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_leak_detection_skipped_total",
+        "Leak detection scans skipped (body too large or unknown size)",
+        &["reason"]
+    )
+    .expect("failed to create LEAK_DETECTION_SKIPPED metric at startup")
+});
+
 /// Maximum response body size to scan for upstream URL leaks (2 MB).
 const LEAK_SCAN_MAX_BYTES: usize = 2 * 1024 * 1024;
 
@@ -284,14 +294,34 @@ pub async fn leak_detection_middleware(
         return response;
     }
 
-    // Skip if Content-Length exceeds scan limit (avoid consuming body we can't restore)
+    // Determine body size BEFORE consuming it (#517).
+    // Primary: body.size_hint().exact() — works for handler-built responses (Full<Bytes>).
+    // Fallback: Content-Length header — works for proxy responses where upstream set it.
+    // If both are None (streaming/chunked without CL), skip scan to avoid body loss.
+    use axum::body::HttpBody as _;
+    let size_hint_exact = response.body().size_hint().exact().map(|s| s as usize);
     let content_length = response
         .headers()
         .get(axum::http::header::CONTENT_LENGTH)
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<usize>().ok());
-    if content_length.is_some_and(|len| len > LEAK_SCAN_MAX_BYTES) {
-        return response;
+    let known_size = size_hint_exact.or(content_length);
+
+    match known_size {
+        Some(size) if size > LEAK_SCAN_MAX_BYTES => {
+            LEAK_DETECTION_SKIPPED
+                .with_label_values(&["too_large"])
+                .inc();
+            return response;
+        }
+        None => {
+            // Unknown body size — cannot safely consume (body is one-shot stream).
+            LEAK_DETECTION_SKIPPED
+                .with_label_values(&["unknown_size"])
+                .inc();
+            return response;
+        }
+        Some(_) => {} // Size known and within limit — proceed to scan
     }
 
     let is_gzip = response
@@ -300,15 +330,30 @@ pub async fn leak_detection_middleware(
         .and_then(|v| v.to_str().ok())
         .is_some_and(|ce| ce.contains("gzip"));
 
-    // Collect response body
+    // CANCEL-SAFETY: to_bytes consumes the body stream (one-shot). If this future is
+    // dropped, the body is partially consumed and cannot be restored. The size pre-check
+    // above ensures we only reach here for known-size bodies within the limit, so
+    // cancellation would only occur from external timeout, not from exceeding the limit.
     let (parts, body) = response.into_parts();
     let body_bytes = match axum::body::to_bytes(body, LEAK_SCAN_MAX_BYTES).await {
         Ok(bytes) => bytes,
         Err(_) => {
-            // Body exceeded limit or read failed — can't restore original, return empty.
-            // In practice unreachable: Content-Length pre-check above catches oversized bodies.
-            tracing::debug!("leak_detection: body read exceeded limit, skipping scan");
-            return Response::from_parts(parts, Body::empty());
+            // Defense-in-depth: should be unreachable with correct size pre-check.
+            // Body is already consumed — cannot restore. Log and return empty.
+            LEAK_DETECTION_SKIPPED
+                .with_label_values(&["body_read_error"])
+                .inc();
+            tracing::warn!(
+                path = path.as_str(),
+                size_hint = ?size_hint_exact,
+                content_length = ?content_length,
+                "leak_detection: body read failed after size pre-check passed — returning empty body"
+            );
+            let mut error_parts = parts;
+            error_parts
+                .headers
+                .remove(axum::http::header::CONTENT_LENGTH);
+            return Response::from_parts(error_parts, Body::empty());
         }
     };
 
@@ -346,13 +391,30 @@ pub async fn leak_detection_middleware(
     Response::from_parts(parts, Body::from(body_bytes))
 }
 
-/// Decompress gzip bytes; returns None on failure (non-fatal).
+/// Decompress gzip bytes; returns None on failure or if decompressed size exceeds limit.
+///
+/// Capped at `LEAK_SCAN_MAX_BYTES` to prevent gzip bomb attacks (#517).
 fn decompress_gzip(data: &[u8]) -> Option<Vec<u8>> {
     use flate2::read::GzDecoder;
     use std::io::Read;
-    let mut decoder = GzDecoder::new(data);
+    let decoder = GzDecoder::new(data);
+    // Cap decompression to prevent gzip bombs (e.g. 42KB compressed → 4.5GB decompressed).
+    let mut limited = decoder.take(LEAK_SCAN_MAX_BYTES as u64);
     let mut buf = Vec::new();
-    decoder.read_to_end(&mut buf).ok()?;
+    limited.read_to_end(&mut buf).ok()?;
+    // Check if data was truncated (more bytes available beyond cap)
+    let mut probe = [0u8; 1];
+    if limited.into_inner().read(&mut probe).unwrap_or(0) > 0 {
+        LEAK_DETECTION_SKIPPED
+            .with_label_values(&["gzip_truncated"])
+            .inc();
+        tracing::debug!(
+            compressed_len = data.len(),
+            decompressed_cap = LEAK_SCAN_MAX_BYTES,
+            "leak_detection: gzip decompression truncated at scan limit"
+        );
+    }
+    debug_assert!(buf.len() <= LEAK_SCAN_MAX_BYTES);
     Some(buf)
 }
 
@@ -521,5 +583,41 @@ mod tests {
         let result = finders.scan(&decompressed);
         assert!(result.is_some());
         assert_eq!(result.unwrap().0, "nuget");
+    }
+
+    #[test]
+    fn test_decompress_gzip_capped_at_limit() {
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        // Create data larger than LEAK_SCAN_MAX_BYTES
+        let large_data = vec![b'A'; LEAK_SCAN_MAX_BYTES + 1024];
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(&large_data).expect("gzip encode");
+        let compressed = encoder.finish().expect("gzip finish");
+
+        // decompress_gzip must cap output at LEAK_SCAN_MAX_BYTES
+        let result = decompress_gzip(&compressed).expect("decompress");
+        assert!(result.len() <= LEAK_SCAN_MAX_BYTES);
+    }
+
+    #[test]
+    fn test_decompress_gzip_invalid_data_returns_none() {
+        // Random bytes are not valid gzip
+        assert!(decompress_gzip(b"not gzip data at all").is_none());
+        assert!(decompress_gzip(b"").is_none());
+    }
+
+    #[test]
+    fn test_decompress_gzip_normal_data_unchanged() {
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+        // Data well under the limit should decompress fully
+        let original = b"small payload for leak scanning test";
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(original).expect("gzip encode");
+        let compressed = encoder.finish().expect("gzip finish");
+
+        let result = decompress_gzip(&compressed).expect("decompress");
+        assert_eq!(result, original);
     }
 }

--- a/nora-registry/src/mirror/mod.rs
+++ b/nora-registry/src/mirror/mod.rs
@@ -92,15 +92,8 @@ pub async fn run_mirror(
     registry: &str,
     concurrency: usize,
     json_output: bool,
+    client: &reqwest::Client,
 ) -> Result<(), String> {
-    // SAFETY: mirror CLI connects to a local NORA server (not upstream registries),
-    // so custom CA certs from build_http_client() are not needed here.
-    // nosemgrep: reqwest-client-bypass
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(300))
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
-
     // Health check
     let health_url = format!("{}/health", registry.trim_end_matches('/'));
     match client.get(&health_url).send().await {
@@ -131,7 +124,7 @@ pub async fn run_mirror(
                 }
             }
             npm::run_npm_mirror(
-                &client,
+                client,
                 registry,
                 lockfile,
                 packages,
@@ -158,17 +151,17 @@ pub async fn run_mirror(
                     targets.len(),
                     registry
                 );
-                npm::mirror_npm_packages(&client, registry, &targets, concurrency).await?
+                npm::mirror_npm_packages(client, registry, &targets, concurrency).await?
             }
         }
         MirrorFormat::Pip { lockfile } => {
-            mirror_lockfile(&client, registry, "pip", &lockfile).await?
+            mirror_lockfile(client, registry, "pip", &lockfile).await?
         }
         MirrorFormat::Cargo { lockfile } => {
-            mirror_lockfile(&client, registry, "cargo", &lockfile).await?
+            mirror_lockfile(client, registry, "cargo", &lockfile).await?
         }
         MirrorFormat::Maven { lockfile } => {
-            mirror_lockfile(&client, registry, "maven", &lockfile).await?
+            mirror_lockfile(client, registry, "maven", &lockfile).await?
         }
         MirrorFormat::Docker {
             images,
@@ -191,7 +184,7 @@ pub async fn run_mirror(
                 image_refs.len(),
                 registry
             );
-            docker::run_docker_mirror(&client, registry, &image_refs, concurrency).await?
+            docker::run_docker_mirror(client, registry, &image_refs, concurrency).await?
         }
     };
 


### PR DESCRIPTION
## Summary

- **Root cause**: `leak_detection_middleware` checked `Content-Length` header to decide whether to scan response bodies. But axum does not set `Content-Length` in the Response header map — it is computed by hyper from `Body::size_hint()` at wire serialization. So the header was always `None` for handler-built responses, causing `to_bytes()` to consume the body stream for ALL JSON responses. When the body exceeded the 2MB limit, the middleware returned `Body::empty()` — silent data loss.
- **Fix**: Check `body.size_hint().exact()` first (works for `Full<Bytes>` bodies from handlers), fall back to `Content-Length` header (for proxy responses where upstream set it). Skip scan when size is unknown.
- **Bonus**: Cap `decompress_gzip` with `Read::take()` to prevent decompression bombs. Add truncation detection with metric + log.
- **Bonus**: Fix pre-existing `reqwest-client-bypass` in mirror module — use shared `build_http_client()` with custom CA cert support (#474).

## Test plan

- [x] 3 new unit tests for `decompress_gzip` (capped, invalid, normal)
- [x] 1118 unit tests + 38 integration tests pass
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Semgrep: 0 errors, 1045 warnings (matches baseline)
- [x] OPSEC check passed
- [ ] Manual test: `curl --head localhost:4000/cargo/index/we/b-/web-sys` returns non-zero Content-Length

Closes #517