### PR TITLE
chore: add LOCK-SAFE annotations to cache-through proxy functions

### DIFF
--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -96,6 +96,7 @@ fn replace_upstream_bytes(data: &[u8], upstream_url: &str, nora_npm_base: &str) 
     result
 }
 
+// LOCK-SAFE: cache-through proxy — get miss → fetch upstream → put; no RMW race
 async fn handle_request(
     State(state): State<Arc<AppState>>,
     headers: axum::http::HeaderMap,

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -628,7 +628,7 @@ async fn version_list(state: Arc<AppState>, id: &str) -> Response {
 }
 
 // ── Flatcontainer download (nupkg/nuspec, immutable) ───────────────────
-
+// LOCK-SAFE: cache-through proxy — get miss → fetch upstream → put; no RMW race
 async fn flatcontainer_download(
     state: Arc<AppState>,
     headers: axum::http::HeaderMap,

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -203,6 +203,7 @@ async fn package_versions(
 // ============================================================================
 
 /// GET /simple/{name}/{filename} — download a specific file.
+// LOCK-SAFE: cache-through proxy — get miss → fetch upstream → put; no RMW race
 async fn download_file(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,


### PR DESCRIPTION
## Summary
- Add `// LOCK-SAFE: cache-through proxy` annotations to 3 download handlers that use a get-miss→fetch-upstream→put pattern
- Documents that these functions are safe without `publish_lock` (no read-modify-write race)
- Affected: `npm.rs:handle_request`, `nuget.rs:flatcontainer_download`, `pypi.rs:download_file`

## Test plan
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy` — PASS
- [x] `opsec-check` — PASS (no leaks)
- [x] `lock-audit.sh` — PASS (0 false positives with annotations)
- [x] `coherence-check.sh` — PASS

Closes #518