### PR TITLE
security: fix javascript: URI injection in metadata links (#522)

### DIFF
--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
-use super::components::{format_size, format_timestamp, html_escape};
+use super::components::{format_size, format_timestamp, html_escape, sanitize_href};
 use super::templates::encode_uri_component;
 use crate::activity_log::ActivityEntry;
 use crate::registry_type::RegistryType;
@@ -674,6 +674,7 @@ pub async fn get_npm_detail(
                 .get("homepage")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
+                .filter(|s| sanitize_href(s).is_some())
                 .map(|s| s.to_string());
             metadata.repository = meta_json
                 .get("repository")
@@ -687,7 +688,8 @@ pub async fn get_npm_detail(
                     s.trim_start_matches("git+")
                         .trim_end_matches(".git")
                         .to_string()
-                });
+                })
+                .filter(|s| sanitize_href(s).is_some());
             metadata.keywords = meta_json
                 .get("keywords")
                 .and_then(|v| v.as_array())
@@ -755,11 +757,13 @@ pub async fn get_cargo_detail(
                 .get("homepage")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
+                .filter(|s| sanitize_href(s).is_some())
                 .map(|s| s.to_string());
             metadata.repository = crate_obj
                 .get("repository")
                 .and_then(|v| v.as_str())
                 .filter(|s| !s.is_empty())
+                .filter(|s| sanitize_href(s).is_some())
                 .map(|s| s.to_string());
             // Cargo uses documentation field as well; use homepage fallback
             if metadata.homepage.is_none() {
@@ -767,6 +771,7 @@ pub async fn get_cargo_detail(
                     .get("documentation")
                     .and_then(|v| v.as_str())
                     .filter(|s| !s.is_empty())
+                    .filter(|s| sanitize_href(s).is_some())
                     .map(|s| s.to_string());
             }
             metadata.keywords = crate_obj

--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -730,6 +730,40 @@ pub fn html_escape(s: &str) -> String {
         .replace('\'', "&#39;")
 }
 
+/// Validate that a URL is safe to use in an `href` attribute.
+///
+/// Returns the trimmed URL if the scheme is `http` or `https` (case-insensitive),
+/// `None` otherwise. Strips leading ASCII control characters and whitespace
+/// to prevent bypass via `\x00javascript:` or `\tjavascript:` patterns.
+///
+/// # Security
+/// This prevents `javascript:`, `data:`, `vbscript:`, `blob:`, `file:` and
+/// other dangerous URI schemes from being rendered as clickable links.
+/// See: <https://github.com/nicholasgasior/nora/issues/522>
+pub fn sanitize_href(url: &str) -> Option<&str> {
+    // Strip leading ASCII control chars (0x00-0x1F, 0x7F) and whitespace
+    let trimmed = url.trim_start_matches(|c: char| c.is_ascii_control() || c.is_ascii_whitespace());
+
+    let bytes = trimmed.as_bytes();
+
+    // Check for https:// (8 bytes) or http:// (7 bytes) prefix, case-insensitive.
+    // All prefix chars are ASCII so byte comparison is safe and avoids char boundary issues.
+    let is_safe = (bytes.len() >= 8 && bytes[..8].eq_ignore_ascii_case(b"https://"))
+        || (bytes.len() >= 7 && bytes[..7].eq_ignore_ascii_case(b"http://"));
+    let result = if is_safe { Some(trimmed) } else { None };
+
+    // --- POSTCONDITION ---
+    debug_assert!(
+        result.is_none_or(|u| {
+            let lower = u.to_ascii_lowercase();
+            lower.starts_with("http://") || lower.starts_with("https://")
+        }),
+        "sanitize_href postcondition violated: result must start with http:// or https://"
+    );
+
+    result
+}
+
 /// Dynamic stats for the bragging footer (demo builds only).
 #[cfg(feature = "demo")]
 pub struct BraggingStats {
@@ -943,5 +977,155 @@ pub fn format_expiry(ts: u64) -> (String, bool) {
     } else {
         let days = diff / 86400;
         (format!("in {}d", days), false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn sanitize_href_allows_https() {
+        assert_eq!(
+            sanitize_href("https://example.com"),
+            Some("https://example.com")
+        );
+    }
+
+    #[test]
+    fn sanitize_href_allows_http() {
+        assert_eq!(
+            sanitize_href("http://example.com"),
+            Some("http://example.com")
+        );
+    }
+
+    #[test]
+    fn sanitize_href_allows_mixed_case_https() {
+        assert_eq!(
+            sanitize_href("HTTPS://example.com"),
+            Some("HTTPS://example.com")
+        );
+        assert_eq!(
+            sanitize_href("Https://example.com"),
+            Some("Https://example.com")
+        );
+    }
+
+    #[test]
+    fn sanitize_href_allows_mixed_case_http() {
+        assert_eq!(
+            sanitize_href("HTTP://example.com"),
+            Some("HTTP://example.com")
+        );
+        assert_eq!(
+            sanitize_href("Http://example.com"),
+            Some("Http://example.com")
+        );
+    }
+
+    #[test]
+    fn sanitize_href_blocks_javascript() {
+        assert_eq!(sanitize_href("javascript:alert(1)"), None);
+        assert_eq!(sanitize_href("JAVASCRIPT:alert(1)"), None);
+        assert_eq!(sanitize_href("JavaScript:alert(document.cookie)"), None);
+    }
+
+    #[test]
+    fn sanitize_href_blocks_data() {
+        assert_eq!(
+            sanitize_href("data:text/html,<script>alert(1)</script>"),
+            None
+        );
+    }
+
+    #[test]
+    fn sanitize_href_blocks_vbscript() {
+        assert_eq!(sanitize_href("vbscript:MsgBox(1)"), None);
+    }
+
+    #[test]
+    fn sanitize_href_blocks_blob() {
+        assert_eq!(sanitize_href("blob:http://evil.com/uuid"), None);
+    }
+
+    #[test]
+    fn sanitize_href_blocks_file() {
+        assert_eq!(sanitize_href("file:///etc/passwd"), None);
+    }
+
+    #[test]
+    fn sanitize_href_strips_leading_control_chars() {
+        assert_eq!(sanitize_href("\x00javascript:alert(1)"), None);
+        assert_eq!(sanitize_href("\tjavascript:alert(1)"), None);
+        assert_eq!(sanitize_href("\njavascript:alert(1)"), None);
+        assert_eq!(sanitize_href("\x01javascript:alert(1)"), None);
+        assert_eq!(sanitize_href("\x7Fjavascript:alert(1)"), None);
+    }
+
+    #[test]
+    fn sanitize_href_strips_leading_whitespace_for_valid() {
+        assert_eq!(
+            sanitize_href("  https://example.com"),
+            Some("https://example.com")
+        );
+        assert_eq!(
+            sanitize_href("\thttps://example.com"),
+            Some("https://example.com")
+        );
+    }
+
+    #[test]
+    fn sanitize_href_blocks_empty_and_short() {
+        assert_eq!(sanitize_href(""), None);
+        assert_eq!(sanitize_href("http"), None);
+        assert_eq!(sanitize_href("http:/"), None);
+        // "http://" (7 bytes) passes — it's a valid http scheme prefix, not dangerous
+        assert_eq!(sanitize_href("http://"), Some("http://"));
+    }
+
+    #[test]
+    fn sanitize_href_blocks_relative_paths() {
+        assert_eq!(sanitize_href("/path/to/page"), None);
+        assert_eq!(sanitize_href("../other"), None);
+    }
+
+    #[test]
+    fn sanitize_href_blocks_ftp_ssh() {
+        assert_eq!(sanitize_href("ftp://example.com"), None);
+        assert_eq!(sanitize_href("ssh://git@github.com"), None);
+        assert_eq!(sanitize_href("git://github.com/repo"), None);
+    }
+
+    proptest! {
+        #[test]
+        fn sanitize_href_never_returns_non_http(input in "\\PC{0,200}") {
+            if let Some(result) = sanitize_href(&input) {
+                let lower = result.to_ascii_lowercase();
+                prop_assert!(
+                    lower.starts_with("http://") || lower.starts_with("https://"),
+                    "sanitize_href returned non-http URL: {}", result
+                );
+            }
+        }
+
+        #[test]
+        fn sanitize_href_preserves_valid_http(suffix in "[a-zA-Z0-9./-]{1,100}") {
+            let url = format!("https://{}", suffix);
+            prop_assert_eq!(sanitize_href(&url), Some(url.as_str()));
+        }
+
+        #[test]
+        fn sanitize_href_rejects_arbitrary_scheme(
+            scheme in "[a-zA-Z]{1,20}",
+            body in "\\PC{0,100}"
+        ) {
+            let lower = scheme.to_ascii_lowercase();
+            if lower != "http" && lower != "https" {
+                let url = format!("{}://{}", scheme, body);
+                prop_assert_eq!(sanitize_href(&url), None, "should reject scheme: {}", scheme);
+            }
+        }
     }
 }

--- a/nora-registry/src/ui/templates.rs
+++ b/nora-registry/src/ui/templates.rs
@@ -1771,19 +1771,33 @@ fn render_metadata_panel(meta: &PackageMetadata) -> String {
     }
 
     if let Some(ref homepage) = meta.homepage {
-        info_items.push(format!(
-            r#"<span class="text-slate-500">Homepage:</span> <a href="{}" class="text-blue-400 hover:text-blue-300" target="_blank" rel="noopener">{}</a>"#,
-            html_escape(homepage),
-            html_escape(homepage)
-        ));
+        if let Some(safe_url) = sanitize_href(homepage) {
+            info_items.push(format!(
+                r#"<span class="text-slate-500">Homepage:</span> <a href="{}" class="text-blue-400 hover:text-blue-300" target="_blank" rel="noopener">{}</a>"#,
+                html_escape(safe_url),
+                html_escape(safe_url)
+            ));
+        } else {
+            info_items.push(format!(
+                r#"<span class="text-slate-500">Homepage:</span> <span class="text-slate-300">{}</span>"#,
+                html_escape(homepage)
+            ));
+        }
     }
 
     if let Some(ref repo) = meta.repository {
-        info_items.push(format!(
-            r#"<span class="text-slate-500">Repository:</span> <a href="{}" class="text-blue-400 hover:text-blue-300" target="_blank" rel="noopener">{}</a>"#,
-            html_escape(repo),
-            html_escape(repo)
-        ));
+        if let Some(safe_url) = sanitize_href(repo) {
+            info_items.push(format!(
+                r#"<span class="text-slate-500">Repository:</span> <a href="{}" class="text-blue-400 hover:text-blue-300" target="_blank" rel="noopener">{}</a>"#,
+                html_escape(safe_url),
+                html_escape(safe_url)
+            ));
+        } else {
+            info_items.push(format!(
+                r#"<span class="text-slate-500">Repository:</span> <span class="text-slate-300">{}</span>"#,
+                html_escape(repo)
+            ));
+        }
     }
 
     if !info_items.is_empty() {


### PR DESCRIPTION
## Summary

- Add `sanitize_href()` URL allowlist function (http/https only, case-insensitive, control-char stripping)
- Apply defense-in-depth: sanitize at both metadata extraction (api.rs) and rendering (templates.rs)
- Block `javascript:`, `data:`, `vbscript:`, `blob:`, `file:` and all non-http URI schemes
- Invalid URLs rendered as plain text instead of clickable links
- 14 unit tests + 3 proptest strategies covering bypass vectors

## Security

Closes #522 — upstream package metadata fields (`homepage`, `repository`) were rendered as `<a href="...">` using only `html_escape()`, which escapes HTML entities but does not prevent `javascript:` protocol URIs.

## Test plan

- [x] `cargo test` — 1142 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] semgrep — no new findings
- [x] proptest: arbitrary string → never returns non-http URL
- [x] proptest: `{scheme}://{body}` with non-http scheme → always rejected