### PR TITLE
fix(storage): return Result from StorageBackend::list() (#528)

### DIFF
--- a/nora-registry/src/backup.rs
+++ b/nora-registry/src/backup.rs
@@ -49,7 +49,10 @@ pub async fn create_backup(storage: &Storage, output: &Path) -> Result<BackupSta
 
     // List all keys
     println!("Scanning storage...");
-    let keys = storage.list("").await;
+    let keys = storage
+        .list("")
+        .await
+        .map_err(|e| format!("storage list failed: {}", e))?;
 
     if keys.is_empty() {
         println!("No artifacts found in storage. Creating empty backup.");

--- a/nora-registry/src/docker_key_migration.rs
+++ b/nora-registry/src/docker_key_migration.rs
@@ -64,7 +64,10 @@ pub async fn migrate_docker_keys(
     }
 
     println!("Scanning docker storage keys...");
-    let all_keys = storage.list("docker/").await;
+    let all_keys = storage
+        .list("docker/")
+        .await
+        .map_err(|e| format!("Failed to list docker keys: {}", e))?;
 
     if all_keys.is_empty() {
         println!("No docker keys found in storage.");

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -184,7 +184,11 @@ pub async fn run_gc(storage: &Storage, dry_run: bool) -> GcResult {
         "gems/",
         "conan/",
     ] {
-        let count = storage.list(prefix).await.len();
+        let keys = storage.list(prefix).await.unwrap_or_else(|e| {
+            tracing::error!("GC: storage.list({}) failed: {}", prefix, e);
+            Vec::new()
+        });
+        let count = keys.len();
         if count > 0 {
             let name = prefix.trim_end_matches('/').to_string();
             uncovered.push((name, count));
@@ -222,7 +226,10 @@ struct DetectionResult {
 }
 
 async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
-    let keys = storage.list("docker/").await;
+    let keys = storage.list("docker/").await.unwrap_or_else(|e| {
+        tracing::error!("GC: storage.list(docker/) failed: {}", e);
+        Vec::new()
+    });
 
     let mut blobs: Vec<String> = Vec::new();
     let mut referenced = HashSet::new();
@@ -310,7 +317,10 @@ async fn detect_checksum_orphans(storage: &Storage) -> DetectionResult {
 
     // Scan Maven, npm, PyPI prefixes for checksum sidecar files
     for prefix in &["maven/", "npm/", "pypi/"] {
-        let keys = storage.list(prefix).await;
+        let keys = storage.list(prefix).await.unwrap_or_else(|e| {
+            tracing::error!("GC: storage.list({}) failed: {}", prefix, e);
+            Vec::new()
+        });
         for key in keys {
             if is_checksum_sidecar(&key) {
                 checksums.push(key);
@@ -340,7 +350,10 @@ async fn detect_checksum_orphans(storage: &Storage) -> DetectionResult {
 /// Go modules store 3 files per version: .info, .mod, .zip
 /// If any file is missing, the remaining files are orphaned (partial upload or failed delete).
 async fn detect_go_incomplete_versions(storage: &Storage) -> DetectionResult {
-    let keys = storage.list("go/").await;
+    let keys = storage.list("go/").await.unwrap_or_else(|e| {
+        tracing::error!("GC: storage.list(go/) failed: {}", e);
+        Vec::new()
+    });
     let mut versions: HashMap<String, Vec<String>> = HashMap::new();
 
     for key in &keys {
@@ -384,7 +397,10 @@ async fn detect_go_incomplete_versions(storage: &Storage) -> DetectionResult {
 /// Cargo stores .crate files and index entries separately.
 /// Orphan = index entry without .crate file, or .crate without index entry.
 async fn detect_cargo_orphans(storage: &Storage) -> DetectionResult {
-    let keys = storage.list("cargo/").await;
+    let keys = storage.list("cargo/").await.unwrap_or_else(|e| {
+        tracing::error!("GC: storage.list(cargo/) failed: {}", e);
+        Vec::new()
+    });
     let mut crate_files: HashSet<String> = HashSet::new(); // "name/version"
     let mut index_entries: HashSet<String> = HashSet::new(); // "name"
     let mut crate_keys: Vec<String> = Vec::new();
@@ -461,7 +477,10 @@ async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) ->
     let mut total_removed = 0usize;
 
     // npm metadata cleanup
-    let npm_keys = storage.list("npm/").await;
+    let npm_keys = storage.list("npm/").await.unwrap_or_else(|e| {
+        tracing::error!("GC: storage.list(npm/) failed: {}", e);
+        Vec::new()
+    });
     let mut npm_meta_keys: Vec<String> = Vec::new();
     let mut npm_tarball_keys: HashSet<String> = HashSet::new();
 
@@ -482,7 +501,10 @@ async fn detect_and_clean_metadata_phantoms(storage: &Storage, dry_run: bool) ->
     }
 
     // PyPI metadata cleanup
-    let pypi_keys = storage.list("pypi/").await;
+    let pypi_keys = storage.list("pypi/").await.unwrap_or_else(|e| {
+        tracing::error!("GC: storage.list(pypi/) failed: {}", e);
+        Vec::new()
+    });
     let mut pypi_meta_keys: Vec<String> = Vec::new();
     let mut pypi_file_keys: HashSet<String> = HashSet::new();
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1460,7 +1460,11 @@ async fn print_retention_coverage(storage: &Storage, rules: &[config::RetentionR
     let mut uncovered = Vec::new();
     for name in &all_registries {
         if !covered.contains(name) {
-            let count = storage.list(&format!("{}/", name)).await.len();
+            let count = storage
+                .list(&format!("{}/", name))
+                .await
+                .unwrap_or_default()
+                .len();
             if count > 0 {
                 uncovered.push(format!("{} ({} files)", name, count));
             }

--- a/nora-registry/src/migrate.rs
+++ b/nora-registry/src/migrate.rs
@@ -50,7 +50,10 @@ pub async fn migrate(
 
     // List all keys from source
     println!("Scanning source storage...");
-    let keys = from.list("").await;
+    let keys = from
+        .list("")
+        .await
+        .map_err(|e| format!("failed to list source: {e}"))?;
 
     if keys.is_empty() {
         println!("No artifacts found in source storage.");

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -535,8 +535,14 @@ pub(crate) fn strip_docker_namespace(name: &str) -> &str {
 }
 
 /// List all repositories in the registry
-async fn catalog(State(state): State<AppState>) -> Json<Value> {
-    let keys = state.storage.list("docker/").await;
+async fn catalog(State(state): State<AppState>) -> Response {
+    let keys = match state.storage.list("docker/").await {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = ?e, "docker: failed to list storage for catalog");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
 
     // Extract unique repository names from paths like "docker/{name}/manifests/..."
     let mut repos: Vec<String> = keys
@@ -563,7 +569,7 @@ async fn catalog(State(state): State<AppState>) -> Json<Value> {
     repos.sort();
     repos.dedup();
 
-    Json(json!({ "repositories": repos }))
+    Json(json!({ "repositories": repos })).into_response()
 }
 
 async fn check_blob(
@@ -1518,12 +1524,25 @@ async fn list_tags(State(state): State<AppState>, Path(name): Path<String>) -> R
     }
     let prefix = manifest_prefix(ns.as_deref(), &name);
     let legacy_prefix = manifest_prefix(None, &name);
-    let mut keys = state.storage.list(&prefix).await;
+    let mut keys = match state.storage.list(&prefix).await {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = ?e, "docker: failed to list manifests for tags");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     // Also include legacy non-namespaced keys during migration
     if prefix != legacy_prefix {
-        keys.extend(state.storage.list(&legacy_prefix).await);
-        keys.sort();
-        keys.dedup();
+        match state.storage.list(&legacy_prefix).await {
+            Ok(legacy_keys) => {
+                keys.extend(legacy_keys);
+                keys.sort();
+                keys.dedup();
+            }
+            Err(e) => {
+                tracing::warn!(error = ?e, "docker: failed to list legacy manifests, continuing with namespaced only");
+            }
+        }
     }
     let tags: Vec<String> = keys
         .iter()
@@ -3205,7 +3224,7 @@ mod integration_tests {
             .await
             .unwrap();
 
-        let keys = ctx.state.storage.list("docker/").await;
+        let keys = ctx.state.storage.list("docker/").await.unwrap();
         let mut repos: Vec<String> = keys
             .iter()
             .filter_map(|k| {

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -393,7 +393,13 @@ async fn compute_and_store_checksums(storage: &crate::storage::Storage, key: &st
 
 async fn update_artifact_metadata(state: &AppState, group_path: &str, artifact_id: &str) {
     let prefix = format!("maven/{}/{}/", group_path, artifact_id);
-    let keys = state.storage.list(&prefix).await;
+    let keys = match state.storage.list(&prefix).await {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::warn!(error = ?e, prefix, "maven: failed to list storage for metadata generation");
+            return;
+        }
+    };
 
     let mut versions = BTreeSet::new();
     for key in &keys {

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -52,7 +52,13 @@ pub fn routes() -> Router<AppState> {
 
 /// GET /simple/ — list all packages (PEP 503 HTML or PEP 691 JSON).
 async fn list_packages(State(state): State<AppState>, headers: HeaderMap) -> impl IntoResponse {
-    let keys = state.storage.list("pypi/").await;
+    let keys = match state.storage.list("pypi/").await {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = ?e, "pypi: failed to list storage for packages");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     let mut packages = std::collections::HashSet::new();
 
     for key in keys {
@@ -128,7 +134,13 @@ async fn package_versions(
     let base_url = nora_base_url(&state);
 
     // Collect local files with their hashes
-    let keys = state.storage.list(&prefix).await;
+    let keys = match state.storage.list(&prefix).await {
+        Ok(k) => k,
+        Err(e) => {
+            tracing::error!(error = ?e, "pypi: failed to list storage for package versions");
+            return StatusCode::SERVICE_UNAVAILABLE.into_response();
+        }
+    };
     let mut local_files: Vec<FileEntry> = Vec::new();
     for key in &keys {
         if let Some(filename) = key.strip_prefix(&prefix) {

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -673,7 +673,7 @@ async fn resolve_upstream_download_url(
         // For shasums/sig files, scan any cached metadata for this provider version
         // (shasums URLs are the same regardless of os/arch)
         let prefix = format!("terraform/providers/{}/{}/{}/", ns, ptype, ver);
-        let keys = state.storage.list(&prefix).await;
+        let keys = state.storage.list(&prefix).await.unwrap_or_default();
         for key in keys {
             if key.ends_with(".json") {
                 if let Ok(data) = state.storage.get(&key).await {

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -176,7 +176,7 @@ impl Default for RepoIndex {
 // ============================================================================
 
 async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("docker/").await;
+    let keys = storage.list("docker/").await.unwrap_or_default();
     let mut repos: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -232,7 +232,7 @@ async fn build_docker_index(storage: &Storage) -> Vec<RepoInfo> {
 }
 
 async fn build_maven_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("maven/").await;
+    let keys = storage.list("maven/").await.unwrap_or_default();
     let mut repos: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -257,7 +257,7 @@ async fn build_maven_index(storage: &Storage) -> Vec<RepoInfo> {
 }
 
 async fn build_npm_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("npm/").await;
+    let keys = storage.list("npm/").await.unwrap_or_default();
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     // Count tarballs instead of parsing metadata.json (faster than parsing JSON)
@@ -292,7 +292,7 @@ async fn build_npm_index(storage: &Storage) -> Vec<RepoInfo> {
 }
 
 async fn build_cargo_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("cargo/").await;
+    let keys = storage.list("cargo/").await.unwrap_or_default();
     let mut crates: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -319,7 +319,7 @@ async fn build_cargo_index(storage: &Storage) -> Vec<RepoInfo> {
 }
 
 async fn build_pypi_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("pypi/").await;
+    let keys = storage.list("pypi/").await.unwrap_or_default();
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -344,7 +344,7 @@ async fn build_pypi_index(storage: &Storage) -> Vec<RepoInfo> {
 }
 
 async fn build_go_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("go/").await;
+    let keys = storage.list("go/").await.unwrap_or_default();
     let mut modules: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -373,7 +373,7 @@ async fn build_go_index(storage: &Storage) -> Vec<RepoInfo> {
 }
 
 async fn build_raw_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("raw/").await;
+    let keys = storage.list("raw/").await.unwrap_or_default();
     // (count, size, modified, is_file)
     let mut groups: HashMap<String, (usize, u64, u64, bool)> = HashMap::new();
 
@@ -415,7 +415,7 @@ async fn build_raw_index(storage: &Storage) -> Vec<RepoInfo> {
 /// Generic index builder: groups files under `prefix` by first path segment.
 /// Only counts files matching `suffix` (e.g. ".gem", ".nupkg", ".tar.gz").
 async fn build_generic_index(storage: &Storage, prefix: &str, suffix: &str) -> Vec<RepoInfo> {
-    let keys = storage.list(prefix).await;
+    let keys = storage.list(prefix).await.unwrap_or_default();
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -444,7 +444,7 @@ async fn build_generic_index(storage: &Storage, prefix: &str, suffix: &str) -> V
 /// Gems index: keys like gems/gems/{name}-{version}.gem
 /// Uses split_gem_filename to extract package name from flat file layout.
 async fn build_gems_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("gems/gems/").await;
+    let keys = storage.list("gems/gems/").await.unwrap_or_default();
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {
@@ -476,7 +476,7 @@ async fn build_gems_index(storage: &Storage) -> Vec<RepoInfo> {
 
 /// Conan index: keys like conan/{name}/{ver}/{user}/{chan}/revisions/{rev}/files/{file}
 async fn build_conan_index(storage: &Storage) -> Vec<RepoInfo> {
-    let keys = storage.list("conan/").await;
+    let keys = storage.list("conan/").await.unwrap_or_default();
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     for key in &keys {

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -193,7 +193,10 @@ fn glob_match_inner(p: &[char], t: &[char]) -> bool {
 
 /// Collect Maven versions for a given group/artifact.
 async fn collect_maven_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntry>)> {
-    let all_keys = storage.list("maven/").await;
+    let all_keys = storage.list("maven/").await.unwrap_or_else(|e| {
+        tracing::error!("Failed to list maven/ keys: {}", e);
+        Vec::new()
+    });
     let mut artifacts: std::collections::HashMap<
         String,
         std::collections::HashMap<String, Vec<String>>,
@@ -243,7 +246,10 @@ async fn collect_maven_versions(storage: &Storage) -> Vec<(String, Vec<VersionEn
 
 /// Collect Docker tags for each repository.
 async fn collect_docker_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntry>)> {
-    let all_keys = storage.list("docker/").await;
+    let all_keys = storage.list("docker/").await.unwrap_or_else(|e| {
+        tracing::error!("Failed to list docker/ keys: {}", e);
+        Vec::new()
+    });
     let mut repos: std::collections::HashMap<String, Vec<(String, String)>> =
         std::collections::HashMap::new();
 
@@ -287,7 +293,10 @@ async fn collect_docker_versions(storage: &Storage) -> Vec<(String, Vec<VersionE
 
 /// Collect npm package versions.
 async fn collect_npm_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntry>)> {
-    let all_keys = storage.list("npm/").await;
+    let all_keys = storage.list("npm/").await.unwrap_or_else(|e| {
+        tracing::error!("Failed to list npm/ keys: {}", e);
+        Vec::new()
+    });
     let mut packages: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
 
@@ -332,7 +341,10 @@ async fn collect_npm_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntr
 
 /// Collect PyPI package files.
 async fn collect_pypi_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntry>)> {
-    let all_keys = storage.list("pypi/").await;
+    let all_keys = storage.list("pypi/").await.unwrap_or_else(|e| {
+        tracing::error!("Failed to list pypi/ keys: {}", e);
+        Vec::new()
+    });
     let mut packages: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
 
@@ -375,7 +387,10 @@ async fn collect_pypi_versions(storage: &Storage) -> Vec<(String, Vec<VersionEnt
 
 /// Collect Cargo crate versions.
 async fn collect_cargo_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntry>)> {
-    let all_keys = storage.list("cargo/").await;
+    let all_keys = storage.list("cargo/").await.unwrap_or_else(|e| {
+        tracing::error!("Failed to list cargo/ keys: {}", e);
+        Vec::new()
+    });
     let mut crates: std::collections::HashMap<
         String,
         std::collections::HashMap<String, Vec<String>>,
@@ -422,7 +437,10 @@ async fn collect_cargo_versions(storage: &Storage) -> Vec<(String, Vec<VersionEn
 }
 
 async fn collect_go_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntry>)> {
-    let all_keys = storage.list("go/").await;
+    let all_keys = storage.list("go/").await.unwrap_or_else(|e| {
+        tracing::error!("Failed to list go/ keys: {}", e);
+        Vec::new()
+    });
     let mut modules: std::collections::HashMap<
         String,
         std::collections::HashMap<String, Vec<String>>,

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -98,7 +98,7 @@ impl StorageBackend for LocalStorage {
         Ok(())
     }
 
-    async fn list(&self, prefix: &str) -> Vec<String> {
+    async fn list(&self, prefix: &str) -> Result<Vec<String>> {
         let base = self.base_path.clone();
         let prefix = prefix.to_string();
 
@@ -112,7 +112,7 @@ impl StorageBackend for LocalStorage {
             results
         })
         .await
-        .unwrap_or_default()
+        .map_err(|e| StorageError::Io(format!("list task panicked: {e}")))
     }
 
     async fn stat(&self, key: &str) -> Option<FileMeta> {
@@ -255,11 +255,11 @@ mod tests {
         storage.put("docker/image/blob2", b"data2").await.unwrap();
         storage.put("maven/artifact", b"data3").await.unwrap();
 
-        let docker_keys = storage.list("docker/").await;
+        let docker_keys = storage.list("docker/").await.unwrap();
         assert_eq!(docker_keys.len(), 2);
         assert!(docker_keys.iter().all(|k| k.starts_with("docker/")));
 
-        let all_keys = storage.list("").await;
+        let all_keys = storage.list("").await.unwrap();
         assert_eq!(all_keys.len(), 3);
     }
 

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -46,7 +46,7 @@ pub trait StorageBackend: Send + Sync {
     async fn put(&self, key: &str, data: &[u8]) -> Result<()>;
     async fn get(&self, key: &str) -> Result<Bytes>;
     async fn delete(&self, key: &str) -> Result<()>;
-    async fn list(&self, prefix: &str) -> Vec<String>;
+    async fn list(&self, prefix: &str) -> Result<Vec<String>>;
     async fn stat(&self, key: &str) -> Option<FileMeta>;
     async fn health_check(&self) -> bool;
     /// Total size of all stored artifacts in bytes
@@ -159,17 +159,16 @@ impl Storage {
         }
     }
 
-    pub async fn list(&self, prefix: &str) -> Vec<String> {
+    pub async fn list(&self, prefix: &str) -> Result<Vec<String>> {
         // Empty prefix is valid for listing all
-        if !prefix.is_empty() && validate_storage_key(prefix).is_err() {
-            return Vec::new();
+        if !prefix.is_empty() {
+            validate_storage_key(prefix)?;
         }
-        self.inner
-            .list(prefix)
-            .await
+        let keys = self.inner.list(prefix).await?;
+        Ok(keys
             .into_iter()
             .filter(|k| !k.starts_with(".nora-"))
-            .collect()
+            .collect())
     }
 
     pub async fn stat(&self, key: &str) -> Option<FileMeta> {

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -104,7 +104,7 @@ impl StorageBackend for S3Storage {
         Ok(())
     }
 
-    async fn list(&self, prefix: &str) -> Vec<String> {
+    async fn list(&self, prefix: &str) -> Result<Vec<String>> {
         let encoded = encode_s3_key(prefix);
         let prefix_path = Path::from(encoded);
         let list_prefix = if prefix.is_empty() {
@@ -114,16 +114,17 @@ impl StorageBackend for S3Storage {
         };
 
         // Collect all objects from the listing stream.
-        let result: std::result::Result<Vec<_>, _> =
-            self.store.list(list_prefix).try_collect().await;
+        let objects: Vec<_> = self
+            .store
+            .list(list_prefix)
+            .try_collect()
+            .await
+            .map_err(|e| StorageError::Network(e.to_string()))?;
 
-        match result {
-            Ok(objects) => objects
-                .into_iter()
-                .map(|meta| decode_s3_key(meta.location.as_ref()))
-                .collect(),
-            Err(_) => Vec::new(),
-        }
+        Ok(objects
+            .into_iter()
+            .map(|meta| decode_s3_key(meta.location.as_ref()))
+            .collect())
     }
 
     async fn stat(&self, key: &str) -> Option<FileMeta> {

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -352,10 +352,10 @@ pub async fn get_docker_detail(state: &AppState, name: &str) -> DockerDetail {
     // E.g. for "library/nginx", find keys in docker/library/nginx/manifests/
     // AND docker/docker.io/library/nginx/manifests/, docker/ghcr.io/library/nginx/manifests/, etc.
     let prefix = format!("docker/{}/manifests/", name);
-    let mut keys = state.storage.list(&prefix).await;
+    let mut keys = state.storage.list(&prefix).await.unwrap_or_default();
 
     // Also collect namespaced keys by scanning all docker/ keys for this image name
-    let all_docker_keys = state.storage.list("docker/").await;
+    let all_docker_keys = state.storage.list("docker/").await.unwrap_or_default();
     for key in &all_docker_keys {
         if let Some(rest) = key.strip_prefix("docker/") {
             if let Some(idx) = rest.find("/manifests/") {
@@ -489,7 +489,7 @@ pub async fn get_maven_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoIn
     } else {
         format!("maven/{}/", path)
     };
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     if keys.is_empty() {
         return (vec![], false);
@@ -540,7 +540,7 @@ pub async fn get_maven_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoIn
 
 pub async fn get_maven_detail(storage: &Storage, path: &str) -> MavenDetail {
     let prefix = format!("maven/{}/", path);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     let mut artifacts = Vec::new();
     for key in &keys {
@@ -717,7 +717,7 @@ pub async fn get_cargo_detail(
     show_all: bool,
 ) -> PackageDetail {
     let prefix = format!("cargo/{}/", name);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     let mut versions = Vec::new();
     for key in keys.iter().filter(|k| ends_with_ci(k, ".crate")) {
@@ -811,7 +811,7 @@ pub async fn get_pypi_detail(
     show_all: bool,
 ) -> PackageDetail {
     let prefix = format!("pypi/{}/", name);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     let mut versions = Vec::new();
     for key in &keys {
@@ -851,7 +851,7 @@ pub async fn get_go_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoInfo>
     } else {
         format!("go/{}/", path)
     };
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     if keys.is_empty() {
         return (vec![], false);
@@ -915,7 +915,7 @@ pub async fn get_go_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoInfo>
 /// Namespace and name are `[a-z0-9_]+`, so the first `-` is an unambiguous separator.
 /// Does NOT call `storage.stat` — avoids latency on large collection counts.
 pub async fn get_ansible_namespace_listing(storage: &Storage, path: &str) -> Vec<RepoInfo> {
-    let keys = storage.list("ansible/download/").await;
+    let keys = storage.list("ansible/download/").await.unwrap_or_default();
 
     if keys.is_empty() {
         return vec![];
@@ -1006,7 +1006,7 @@ pub async fn get_go_detail(
     }
 
     // Also scan for .zip files that might exist without being in the list
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
     for key in keys.iter().filter(|k| ends_with_ci(k, ".zip")) {
         if let Some(rest) = key.strip_prefix(&prefix) {
             if let Some(version) = rest.strip_suffix(".zip") {
@@ -1274,7 +1274,7 @@ async fn get_conan_detail(
     // Conan: conan/{name}/{version}/_/_/revisions.json (metadata)
     // Actual files: conan/{name}/{version}/_/_/{rrev}/export/* or /packages/*/
     let prefix = format!("conan/{}/", name);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
     let mut version_data: HashMap<String, (u64, u64, bool)> = HashMap::new(); // (size, mtime, has_content)
 
     for key in &keys {
@@ -1384,7 +1384,7 @@ async fn get_pub_detail(
 ) -> PackageDetail {
     // Pub: pub/packages/{name}/versions/{version}.tar.gz
     let prefix = format!("pub/packages/{}/versions/", name);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
     let mut versions = Vec::new();
 
     for key in &keys {
@@ -1440,7 +1440,7 @@ async fn get_ansible_detail(
         }
     };
 
-    let keys = storage.list("ansible/download/").await;
+    let keys = storage.list("ansible/download/").await.unwrap_or_default();
     let prefix = format!("{}-{}-", ns, col);
     let mut versions = Vec::new();
 
@@ -1487,7 +1487,7 @@ async fn get_storage_scan_detail(
     show_all: bool,
 ) -> PackageDetail {
     let prefix = format!("{}/{}/", registry, name);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
     let mut versions = Vec::new();
     for key in &keys {
         if let Some(rest) = key.strip_prefix(&prefix) {
@@ -1624,7 +1624,7 @@ fn extract_pypi_version(name: &str, filename: &str) -> Option<String> {
 
 pub async fn get_raw_detail(storage: &Storage, group: &str) -> PackageDetail {
     let prefix = format!("raw/{}/", group);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     let mut versions = Vec::new();
 
@@ -1675,7 +1675,7 @@ pub async fn get_raw_detail(storage: &Storage, group: &str) -> PackageDetail {
 /// Returns (entries, is_directory). If the path is a single file, returns empty vec + false.
 pub async fn get_raw_dir_listing(storage: &Storage, path: &str) -> (Vec<RepoInfo>, bool) {
     let prefix = format!("raw/{}/", path);
-    let keys = storage.list(&prefix).await;
+    let keys = storage.list(&prefix).await.unwrap_or_default();
 
     if keys.is_empty() {
         // Check if it's a direct file


### PR DESCRIPTION
## Summary

- Change `StorageBackend::list()` trait return type from `Vec<String>` to `Result<Vec<String>>`
- S3 backend was silently returning empty Vec on any ListObjects error, causing backup to produce empty archives, GC/retention to skip all work, and registry endpoints to return 200 OK with empty results during outages
- Critical callers (backup, migrate, docker_key_migration) now fail-fast with `?`
- Registry handlers (docker, pypi) return 503 Service Unavailable on storage errors
- GC/retention log errors and degrade safely (both candidate and keep sets derive from same call)
- UI/repo_index use `unwrap_or_default()` for graceful degradation

Closes #528

## Test plan

- [x] `cargo fmt` — PASS
- [x] `cargo clippy -p nora-registry --all-targets -- -D warnings` — PASS
- [x] `cargo test -p nora-registry` — 1162 passed, 0 failed
- [x] semgrep — 0 errors (1074 pre-existing warnings)
- [x] arch-predict — 0 errors
- [x] rust-analyzers (deny + audit) — PASS
- [x] typos — PASS