### PR TITLE
chore: pin Rust toolchain to 1.96.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "stable"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- Pin `rust-toolchain.toml` from floating `stable` to `1.96.0`
- Prevents CI/local clippy divergence when new Rust releases ship new lints (e.g. `unnecessary_map_or` and `collapsible_if` in 1.96 broke PR #554 while local 1.95 passed)
- Future bumps: `sed -i 's/1.96.0/1.97.0/' rust-toolchain.toml`

## Test plan

- [x] `cargo clippy -p nora-registry -- -D warnings` passes with 1.96.0
- [x] `cargo test -p nora-registry` passes