### PR TITLE
fix(terraform): serve stale cached metadata on upstream failure

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -429,6 +429,9 @@ pub struct TerraformConfig {
     /// -1 = cache forever, 0 = always refetch, >0 = seconds.
     #[serde(default = "default_metadata_ttl")]
     pub metadata_ttl: i64,
+    /// Serve stale cached metadata when upstream is unreachable (default: true).
+    #[serde(default = "default_true")]
+    pub serve_stale: bool,
 }
 
 fn default_terraform_proxy() -> Option<String> {
@@ -444,6 +447,7 @@ impl Default for TerraformConfig {
             proxy_timeout: 30,
             proxy_timeout_dl: 120,
             metadata_ttl: 300,
+            serve_stale: true,
         }
     }
 }
@@ -2478,6 +2482,9 @@ impl Config {
             if let Ok(ttl) = val.parse() {
                 self.terraform.metadata_ttl = ttl;
             }
+        }
+        if let Ok(val) = env::var("NORA_TF_SERVE_STALE") {
+            self.terraform.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
 
         // Ansible Galaxy config

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -116,8 +116,11 @@ async fn provider_versions(
 
     let storage_key = format!("terraform/providers/{}/{}/versions.json", ns, ptype);
 
-    // TTL cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Read cache eagerly — preserve for serve-stale fallback (#532)
+    let cached_data = state.storage.get(&storage_key).await.ok();
+
+    // TTL cache — serve fresh if within TTL
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
@@ -166,7 +169,7 @@ async fn provider_versions(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(provider = format!("{}/{}", ns, ptype), error = ?e, "Terraform upstream error");
-            StatusCode::BAD_GATEWAY.into_response()
+            serve_stale_or_bad_gateway(&state, cached_data, "provider_versions")
         }
     }
 }
@@ -211,13 +214,22 @@ async fn provider_download_meta(
         ns, ptype, ver, os, arch
     );
 
-    // TTL cache for metadata
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Read cache eagerly — preserve for serve-stale fallback (#532).
+    // Strip internal fields now so stale response is client-safe.
+    let cached_data = state
+        .storage
+        .get(&storage_key)
+        .await
+        .ok()
+        .map(|d| Bytes::from(strip_nora_internal_fields(&d)));
+
+    // TTL cache — serve fresh if within TTL
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
                 state.metrics.record_cache_hit("terraform");
-                return with_json(strip_nora_internal_fields(&data));
+                return with_json(data.to_vec());
             }
         }
     }
@@ -267,7 +279,7 @@ async fn provider_download_meta(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "Terraform download metadata error");
-            StatusCode::BAD_GATEWAY.into_response()
+            serve_stale_or_bad_gateway(&state, cached_data, "provider_download_meta")
         }
     }
 }
@@ -361,8 +373,11 @@ async fn module_versions(
         ns, name, provider
     );
 
-    // TTL cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Read cache eagerly — preserve for serve-stale fallback (#532)
+    let cached_data = state.storage.get(&storage_key).await.ok();
+
+    // TTL cache — serve fresh if within TTL
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.terraform.metadata_ttl) {
                 state.metrics.record_download("terraform");
@@ -412,7 +427,7 @@ async fn module_versions(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
             tracing::debug!(error = ?e, "Terraform module versions error");
-            StatusCode::BAD_GATEWAY.into_response()
+            serve_stale_or_bad_gateway(&state, cached_data, "module_versions")
         }
     }
 }
@@ -731,6 +746,39 @@ fn with_json(data: Vec<u8>) -> Response {
         data,
     )
         .into_response()
+}
+
+/// Serve stale cached metadata when upstream is unreachable, or 502 if no cache.
+fn serve_stale_or_bad_gateway(state: &AppState, cached: Option<Bytes>, endpoint: &str) -> Response {
+    if let Some(data) = cached {
+        if state.config.terraform.serve_stale {
+            tracing::warn!(
+                registry = "terraform",
+                endpoint,
+                "Upstream unreachable, serving stale cached metadata"
+            );
+            return (
+                StatusCode::OK,
+                [
+                    (
+                        header::CONTENT_TYPE,
+                        HeaderValue::from_static("application/json"),
+                    ),
+                    (
+                        header::CACHE_CONTROL,
+                        HeaderValue::from_static("public, max-age=0, must-revalidate"),
+                    ),
+                    (
+                        axum::http::header::HeaderName::from_static("x-nora-stale"),
+                        axum::http::header::HeaderValue::from_static("true"),
+                    ),
+                ],
+                data.to_vec(),
+            )
+                .into_response();
+        }
+    }
+    StatusCode::BAD_GATEWAY.into_response()
 }
 
 fn with_binary(data: Vec<u8>) -> Response {
@@ -1438,5 +1486,93 @@ mod integration_tests {
         )
         .await;
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Stale cache + unreachable upstream + serve_stale=true → 200 with X-Nora-Stale header (#532)
+    #[tokio::test]
+    async fn test_serve_stale_provider_versions() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+            cfg.terraform.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.terraform.proxy_timeout = 1;
+            cfg.terraform.metadata_ttl = 0; // force TTL expiry
+            cfg.terraform.serve_stale = true;
+        });
+
+        // Pre-populate cache
+        ctx.state
+            .storage
+            .put(
+                "terraform/providers/hashicorp/aws/versions.json",
+                br#"{"versions":[{"version":"5.0.0"}]}"#,
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/hashicorp/aws/versions",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get("x-nora-stale").map(|v| v.as_bytes()),
+            Some(b"true".as_ref()),
+        );
+        let body = body_bytes(resp).await;
+        assert!(String::from_utf8_lossy(&body).contains("5.0.0"));
+    }
+
+    /// Stale cache + unreachable upstream + serve_stale=false → 502 (#532)
+    #[tokio::test]
+    async fn test_serve_stale_disabled_returns_502() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+            cfg.terraform.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.terraform.proxy_timeout = 1;
+            cfg.terraform.metadata_ttl = 0;
+            cfg.terraform.serve_stale = false;
+        });
+
+        ctx.state
+            .storage
+            .put(
+                "terraform/providers/hashicorp/aws/versions.json",
+                br#"{"versions":[{"version":"5.0.0"}]}"#,
+            )
+            .await
+            .unwrap();
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/hashicorp/aws/versions",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert!(resp.headers().get("x-nora-stale").is_none());
+    }
+
+    /// No cache + unreachable upstream → 502 regardless of serve_stale (#532)
+    #[tokio::test]
+    async fn test_no_cache_upstream_down_returns_502() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.terraform.enabled = true;
+            cfg.terraform.proxy = Some("http://127.0.0.1:1".to_string());
+            cfg.terraform.proxy_timeout = 1;
+            cfg.terraform.serve_stale = true;
+        });
+
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/terraform/v1/providers/hashicorp/aws/versions",
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
     }
 }


### PR DESCRIPTION
## Summary

- Terraform provider/module version endpoints now serve stale cached metadata when upstream is unreachable, instead of returning 502
- Adds `serve_stale` config field (default: true, env: `NORA_TF_SERVE_STALE`)
- Stale responses include `X-Nora-Stale: true` header and `max-age=0, must-revalidate`
- Cache is read eagerly before upstream call to preserve data for fallback

Closes #532

## Test plan

- [x] `test_serve_stale_provider_versions` — upstream down, cache exists → 200 + stale header
- [x] `test_serve_stale_disabled_returns_502` — serve_stale=false → 502
- [x] `test_no_cache_upstream_down_returns_502` — no cache + upstream down → 502
- [x] All 1171 existing tests pass
- [x] cargo clippy clean
- [x] cargo fmt clean