### PR TITLE
fix(security): P0/P1 batch — path traversal, rate limit, GC race, sync I/O

### DIFF
--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1988,8 +1988,8 @@ impl Config {
             );
         }
         if self.curation.on_failure != CurationOnFailure::Closed {
-            warnings.push(
-                "curation.on_failure is not yet implemented — the setting is parsed but has no effect. All filter errors are treated as closed (blocked). This field will be removed in v0.9".to_string(),
+            errors.push(
+                "curation.on_failure=\"open\" is not implemented and would silently degrade to fail-closed. Remove the setting or set on_failure=\"closed\" explicitly. This field will be removed in v0.9".to_string(),
             );
         }
 
@@ -3668,15 +3668,15 @@ mod tests {
     }
 
     #[test]
-    fn test_curation_on_failure_open_emits_warning() {
+    fn test_curation_on_failure_open_emits_error() {
         let mut config = Config::default();
         config.curation.on_failure = CurationOnFailure::Open;
-        let (warnings, _errors) = config.validate_with_config_path(None);
+        let (_warnings, errors) = config.validate_with_config_path(None);
         assert!(
-            warnings
+            errors
                 .iter()
-                .any(|w| w.contains("on_failure is not yet implemented")),
-            "expected deprecation warning for on_failure=open"
+                .any(|e| e.contains("on_failure=\"open\" is not implemented")),
+            "expected hard error for on_failure=open"
         );
     }
 

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -140,6 +140,10 @@ pub async fn run_gc(storage: &Storage, publish_locks: &PublishLocks, dry_run: bo
             if let Some(meta) = storage.stat(key).await {
                 bytes_freed += meta.size;
             }
+            // Serialize with concurrent publish to prevent deleting an artifact
+            // that is being referenced by a manifest currently being written.
+            let lock = crate::acquire_publish_lock(publish_locks, key);
+            let _guard = lock.lock().await;
             if storage.delete(key).await.is_ok() {
                 deleted += 1;
                 info!("Deleted: {}", key);

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -429,7 +429,14 @@ async fn main() {
             }
         }
         Some(Commands::RetentionPlan) => {
-            let result = retention::run_retention(&storage, &config.retention.rules, true).await;
+            let cli_publish_locks: PublishLocks = Arc::new(parking_lot::Mutex::new(HashMap::new()));
+            let result = retention::run_retention(
+                &storage,
+                &cli_publish_locks,
+                &config.retention.rules,
+                true,
+            )
+            .await;
             println!("Retention Plan (dry-run):");
             println!("  Versions to delete: {}", result.planned);
             println!("  Bytes to free:      {}", result.bytes_freed);
@@ -449,10 +456,16 @@ async fn main() {
             print_retention_coverage(&storage, &config.retention.rules).await;
         }
         Some(Commands::RetentionApply { yes }) => {
+            let cli_publish_locks: PublishLocks = Arc::new(parking_lot::Mutex::new(HashMap::new()));
             if !yes {
                 // Show plan first, require --yes to execute
-                let result =
-                    retention::run_retention(&storage, &config.retention.rules, true).await;
+                let result = retention::run_retention(
+                    &storage,
+                    &cli_publish_locks,
+                    &config.retention.rules,
+                    true,
+                )
+                .await;
                 println!("Retention Plan:");
                 println!("  Versions to delete: {}", result.planned);
                 println!("  Bytes to free:      {}", result.bytes_freed);
@@ -474,8 +487,13 @@ async fn main() {
                 }
                 print_retention_coverage(&storage, &config.retention.rules).await;
             } else {
-                let result =
-                    retention::run_retention(&storage, &config.retention.rules, false).await;
+                let result = retention::run_retention(
+                    &storage,
+                    &cli_publish_locks,
+                    &config.retention.rules,
+                    false,
+                )
+                .await;
                 println!("Retention Applied:");
                 println!("  Versions deleted:   {}", result.planned);
                 println!("  Keys deleted:       {}", result.deleted_keys);
@@ -1183,6 +1201,7 @@ async fn run_server(mut config: Config, storage: Storage) {
     if state.config.retention.enabled && !state.config.retention.rules.is_empty() {
         let handle = retention::spawn_retention_scheduler(
             state.storage.clone(),
+            state.publish_locks.clone(),
             state.config.retention.rules.clone(),
             state.config.retention.interval,
             state.config.retention.dry_run,

--- a/nora-registry/src/rate_limit.rs
+++ b/nora-registry/src/rate_limit.rs
@@ -12,6 +12,19 @@ use crate::config::RateLimitConfig;
 use tower_governor::governor::GovernorConfigBuilder;
 use tower_governor::key_extractor::SmartIpKeyExtractor;
 
+/// Convert a "requests per second" value to a replenishment period.
+///
+/// `GovernorConfigBuilder::per_second(N)` sets the replenishment interval to
+/// N *seconds*, not N requests/second. So `per_second(200)` means 1 token
+/// every 200 seconds = 0.005 rps — the opposite of what we want.
+///
+/// For N rps we need: interval = 1000/N milliseconds per token.
+/// For rps > 1000 the result is clamped to 1ms (= 1000 rps effective max).
+fn rps_to_period(rps: u64) -> u64 {
+    debug_assert!(rps > 0, "rate limit rps must be > 0");
+    (1000 / rps.max(1)).max(1)
+}
+
 /// Create rate limiter layer for auth endpoints (strict protection against brute-force)
 pub fn auth_rate_limiter(
     config: &RateLimitConfig,
@@ -21,7 +34,7 @@ pub fn auth_rate_limiter(
     axum::body::Body,
 > {
     let gov_config = GovernorConfigBuilder::default()
-        .per_second(config.auth_rps)
+        .per_millisecond(rps_to_period(config.auth_rps))
         .burst_size(config.auth_burst)
         .use_headers()
         .finish()
@@ -42,7 +55,7 @@ pub fn upload_rate_limiter(
 > {
     let gov_config = GovernorConfigBuilder::default()
         .key_extractor(SmartIpKeyExtractor)
-        .per_second(config.upload_rps)
+        .per_millisecond(rps_to_period(config.upload_rps))
         .burst_size(config.upload_burst)
         .use_headers()
         .finish()
@@ -61,7 +74,7 @@ pub fn general_rate_limiter(
 > {
     let gov_config = GovernorConfigBuilder::default()
         .key_extractor(SmartIpKeyExtractor)
-        .per_second(config.general_rps)
+        .per_millisecond(rps_to_period(config.general_rps))
         .burst_size(config.general_burst)
         .use_headers()
         .finish()
@@ -116,5 +129,22 @@ mod tests {
         let _auth = auth_rate_limiter(&config);
         let _upload = upload_rate_limiter(&config);
         let _general = general_rate_limiter(&config);
+    }
+
+    #[test]
+    fn test_rps_to_period() {
+        // 1 rps → 1000ms per token
+        assert_eq!(rps_to_period(1), 1000);
+        // 200 rps → 5ms per token
+        assert_eq!(rps_to_period(200), 5);
+        // 100 rps → 10ms per token
+        assert_eq!(rps_to_period(100), 10);
+        // 10 rps → 100ms per token
+        assert_eq!(rps_to_period(10), 100);
+        // 1000 rps → 1ms per token
+        assert_eq!(rps_to_period(1000), 1);
+        // >1000 rps → clamped to 1ms (prevents zero period)
+        assert_eq!(rps_to_period(2000), 1);
+        assert_eq!(rps_to_period(10000), 1);
     }
 }

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -17,6 +17,7 @@ use tracing::info;
 use crate::config::RetentionRule;
 use crate::storage::Storage;
 use crate::validation::ends_with_ci;
+use crate::PublishLocks;
 
 // ============================================================================
 // Prometheus metrics
@@ -302,8 +303,12 @@ async fn collect_npm_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntr
 
     for key in &all_keys {
         // npm/{package}/tarballs/{file} — each tarball is a "version"
+        // Skip metadata.json and checksum files — they are indexes, not versions.
         if let Some(rest) = key.strip_prefix("npm/") {
-            if rest.contains("/tarballs/") && !ends_with_ci(key, ".sha256") {
+            if rest.contains("/tarballs/")
+                && !ends_with_ci(key, ".sha256")
+                && !ends_with_ci(key, "/metadata.json")
+            {
                 let pkg = rest.split("/tarballs/").next().unwrap_or("");
                 if !pkg.is_empty() {
                     packages
@@ -350,7 +355,14 @@ async fn collect_pypi_versions(storage: &Storage) -> Vec<(String, Vec<VersionEnt
 
     for key in &all_keys {
         if let Some(rest) = key.strip_prefix("pypi/") {
-            if !ends_with_ci(key, ".sha256") {
+            // Skip checksums and metadata.json — metadata is the package index,
+            // not a version artifact. Deleting it makes the package undiscoverable.
+            if !ends_with_ci(key, ".sha256")
+                && !ends_with_ci(key, ".sha1")
+                && !ends_with_ci(key, ".md5")
+                && !ends_with_ci(key, ".sha512")
+                && !ends_with_ci(key, "/metadata.json")
+            {
                 let pkg = rest.split('/').next().unwrap_or("");
                 if !pkg.is_empty() {
                     packages
@@ -511,8 +523,13 @@ pub struct RetentionResult {
 }
 
 /// Run retention across all registries.
+///
+/// `publish_locks` serializes deletions with concurrent publish operations
+/// to prevent race conditions (e.g., deleting a blob while a manifest
+/// referencing it is being written).
 pub async fn run_retention(
     storage: &Storage,
+    publish_locks: &PublishLocks,
     rules: &[RetentionRule],
     dry_run: bool,
 ) -> RetentionResult {
@@ -554,6 +571,10 @@ pub async fn run_retention(
         if !dry_run {
             for plan in &plans {
                 for key in &plan.keys {
+                    // Serialize with concurrent publish to prevent deleting
+                    // an artifact that is being referenced by a new publish.
+                    let lock = crate::acquire_publish_lock(publish_locks, key);
+                    let _guard = lock.lock().await;
                     if storage.delete(key).await.is_ok() {
                         total_deleted_keys += 1;
                     }
@@ -632,8 +653,10 @@ fn find_matching_rule<'a>(
 /// Spawn a background retention task that runs periodically.
 /// Accepts a shared cleanup lock to prevent concurrent runs with GC scheduler.
 /// Returns a `JoinHandle` so the caller can await graceful completion on shutdown.
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_retention_scheduler(
     storage: Storage,
+    publish_locks: PublishLocks,
     rules: Vec<RetentionRule>,
     interval_secs: u64,
     dry_run: bool,
@@ -673,7 +696,7 @@ pub fn spawn_retention_scheduler(
                 dry_run = dry_run,
                 "Retention scheduler: starting periodic run"
             );
-            let result = run_retention(&storage, &rules, dry_run).await;
+            let result = run_retention(&storage, &publish_locks, &rules, dry_run).await;
             info!(
                 "Retention scheduler: done in {:.1}s — {} versions, {} keys, {} bytes freed",
                 result.duration_secs, result.planned, result.deleted_keys, result.bytes_freed
@@ -707,6 +730,10 @@ pub fn spawn_retention_scheduler(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+
+    fn test_publish_locks() -> PublishLocks {
+        Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
+    }
 
     fn make_rule(
         keep_last: Option<u32>,
@@ -893,7 +920,7 @@ mod tests {
             exclude_tags: vec![],
         }];
 
-        let result = run_retention(&storage, &rules, false).await;
+        let result = run_retention(&storage, &test_publish_locks(), &rules, false).await;
         assert_eq!(result.planned, 2); // 1.0 and 2.0 deleted, 3.0 kept
         assert!(storage
             .get("maven/com/example/lib/3.0/lib-3.0.jar")
@@ -922,7 +949,7 @@ mod tests {
             exclude_tags: vec![],
         }];
 
-        let result = run_retention(&storage, &rules, true).await;
+        let result = run_retention(&storage, &test_publish_locks(), &rules, true).await;
         assert_eq!(result.planned, 1);
         assert_eq!(result.deleted_keys, 0); // dry run
                                             // Both still exist
@@ -948,7 +975,7 @@ mod tests {
             exclude_tags: vec![],
         }];
 
-        let result = run_retention(&storage, &rules, false).await;
+        let result = run_retention(&storage, &test_publish_locks(), &rules, false).await;
         assert_eq!(result.planned, 0);
     }
 
@@ -973,7 +1000,7 @@ mod tests {
             exclude_tags: vec![],
         }];
 
-        let result = run_retention(&storage, &rules, false).await;
+        let result = run_retention(&storage, &test_publish_locks(), &rules, false).await;
         assert!(result.planned >= 1); // at least 1.0 deleted
     }
 
@@ -1011,7 +1038,7 @@ mod tests {
             exclude_tags: vec![],
         }];
 
-        let result = run_retention(&storage, &rules, false).await;
+        let result = run_retention(&storage, &test_publish_locks(), &rules, false).await;
         assert_eq!(result.planned, 2); // v1.0.0 and v2.0.0 deleted
         assert_eq!(result.deleted_keys, 6); // 3 files per version * 2
                                             // v3.0.0 kept (newest by name tiebreaker)

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -102,7 +102,11 @@ impl Storage {
             Ok(()) => {
                 STORAGE_OPERATIONS.with_label_values(&["put", "ok"]).inc();
                 if let Some(ref pins) = self.pin_store {
-                    pins.record(key, data);
+                    let pins = Arc::clone(pins);
+                    let key = key.to_string();
+                    let data = data.to_vec();
+                    // SHA-256 + sync file append — offload from tokio worker
+                    tokio::task::spawn_blocking(move || pins.record(&key, &data));
                 }
                 Ok(())
             }
@@ -121,7 +125,20 @@ impl Storage {
             Ok(data) => {
                 STORAGE_OPERATIONS.with_label_values(&["get", "ok"]).inc();
                 if let Some(ref pins) = self.pin_store {
-                    if !pins.verify(key, &data) {
+                    let pins = Arc::clone(pins);
+                    let key = key.to_string();
+                    let data_ref = data.clone();
+                    // SHA-256 verification — offload from tokio worker
+                    let ok = match tokio::task::spawn_blocking(move || pins.verify(&key, &data_ref))
+                        .await
+                    {
+                        Ok(result) => result,
+                        Err(e) => {
+                            tracing::warn!(error = %e, "hash verification task failed");
+                            true // fail-open on infra error, not on data
+                        }
+                    };
+                    if !ok {
                         STORAGE_OPERATIONS
                             .with_label_values(&["get", "integrity_fail"])
                             .inc();
@@ -146,7 +163,10 @@ impl Storage {
                     .with_label_values(&["delete", "ok"])
                     .inc();
                 if let Some(ref pins) = self.pin_store {
-                    pins.remove(key);
+                    let pins = Arc::clone(pins);
+                    let key = key.to_string();
+                    // Sync file append — offload from tokio worker
+                    tokio::task::spawn_blocking(move || pins.remove(&key));
                 }
                 Ok(())
             }

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -350,8 +350,16 @@ impl TokenStore {
             .retain(|k, _| !k.starts_with(hash_prefix));
     }
 
-    /// Revoke a token by its hash prefix
+    /// Revoke a token by its hash prefix.
+    ///
+    /// `hash_prefix` must be exactly 16 lowercase hexadecimal characters (the
+    /// first 16 chars of SHA-256(token)). Anything else is rejected to prevent
+    /// path-traversal attacks via crafted prefixes like `../../etc/passwd`.
     pub fn revoke_token(&self, hash_prefix: &str) -> Result<(), TokenError> {
+        // SECURITY: validate format before building filesystem path
+        if !is_valid_hash_prefix(hash_prefix) {
+            return Err(TokenError::NotFound);
+        }
         let file_path = self.storage_path.join(format!("{}.json", hash_prefix));
 
         // TOCTOU fix: try remove directly
@@ -388,6 +396,15 @@ impl TokenStore {
 
         count
     }
+}
+
+/// Validate a hash prefix: must be exactly 16 lowercase hex characters (`[0-9a-f]`).
+///
+/// Token files are named `{sha256(token)[..16]}.json` (always lowercase via
+/// `hex::encode`). We restrict to lowercase only to prevent case-mismatch
+/// issues on case-sensitive filesystems.
+fn is_valid_hash_prefix(s: &str) -> bool {
+    s.len() == 16 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 
 /// Hash a token using Argon2id with random salt
@@ -824,5 +841,44 @@ mod tests {
 
         let tokens = store.list_tokens("testuser");
         assert_eq!(tokens[0].description, Some("CI/CD Pipeline".to_string()));
+    }
+
+    // -- hash_prefix validation (path traversal prevention) --
+
+    #[test]
+    fn test_is_valid_hash_prefix() {
+        assert!(is_valid_hash_prefix("0123456789abcdef"));
+        assert!(is_valid_hash_prefix("deadbeefcafe1234"));
+        // uppercase hex is rejected (token hashes are always lowercase)
+        assert!(!is_valid_hash_prefix("0123456789ABCDEF"));
+    }
+
+    #[test]
+    fn test_is_valid_hash_prefix_rejects_bad() {
+        assert!(!is_valid_hash_prefix(""));
+        assert!(!is_valid_hash_prefix("short"));
+        assert!(!is_valid_hash_prefix("0123456789abcde")); // 15 chars
+        assert!(!is_valid_hash_prefix("0123456789abcdef0")); // 17 chars
+        assert!(!is_valid_hash_prefix("../../etc/passwd")); // path traversal
+        assert!(!is_valid_hash_prefix("..%2f..%2fetcpwd")); // encoded traversal
+        assert!(!is_valid_hash_prefix("zzzzzzzzzzzzzzzz")); // non-hex
+    }
+
+    #[test]
+    fn test_revoke_rejects_path_traversal() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = TokenStore::new(temp_dir.path());
+
+        // Create a decoy file that path traversal would target
+        let decoy = temp_dir.path().join("../decoy.json");
+        let _ = std::fs::write(&decoy, "should not be deleted");
+
+        // Attempt path traversal
+        let result = store.revoke_token("../decoy");
+        assert!(matches!(result, Err(TokenError::NotFound)));
+        let result = store.revoke_token("../../etc/passwd");
+        assert!(matches!(result, Err(TokenError::NotFound)));
+        let result = store.revoke_token("");
+        assert!(matches!(result, Err(TokenError::NotFound)));
     }
 }


### PR DESCRIPTION
## Summary

Batch fix for 5 security and data-integrity issues:

- **Path traversal in token revoke** (P0): `revoke_token()` accepted arbitrary strings as hash prefix, allowing filesystem path traversal. Now validates exactly 16 lowercase hex characters before building path.

- **Rate limit semantic inversion** (P0): `GovernorConfigBuilder::per_second(rps)` was misused — it sets replenishment *interval* in seconds, not rate. `per_second(200)` = 1 req/200s, not 200 rps. Fixed with `per_millisecond(1000/rps)` with `.max(1)` clamp for rps>1000.

- **GC/retention publish_lock race** (P1): Orphan deletion in GC and version deletion in retention did not acquire `publish_lock`, allowing TOCTOU race with concurrent publishes. Also excludes `metadata.json` and checksum files from PyPI/npm retention version collection.

- **Sync I/O blocking tokio** (P1): `HashPinStore::record()/verify()/remove()` performed SHA-256 computation and sync file I/O on tokio worker threads. Moved to `spawn_blocking`.

- **Unimplemented on_failure** (P1): `curation.on_failure="open"` was parsed and accepted but silently behaved as `closed`. Promoted from warning to hard startup error.

## Test plan

- [x] All 1185 existing tests pass
- [x] New tests for hash_prefix validation and path traversal rejection
- [x] New test for rps_to_period conversion (including rps>1000 clamping)
- [x] Updated test for on_failure error (was warning)
- [x] Gate: fmt, clippy, semgrep, arch-predict, rust-analyzers, cargo-deny, cargo-audit — all PASS
- [ ] Manual: verify rate limiting behavior with upload_rps=200
- [ ] Manual: verify GC/retention with publish_lock under concurrent load