### PR TITLE
fix(security): P2 security hardening batch (#535, #536, #538, #539, #540, #541)

### DIFF
--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1093,7 +1093,8 @@ async fn run_server(mut config: Config, storage: Storage) {
 
     let app_routes = if rate_limit_enabled {
         // Create rate limiters before moving config to state
-        let auth_limiter = rate_limit::auth_rate_limiter(&config.rate_limit);
+        let auth_limiter =
+            rate_limit::auth_rate_limiter(&config.rate_limit, config.auth.trusted_proxies.clone());
         let upload_limiter = rate_limit::upload_rate_limiter(&config.rate_limit);
         let general_limiter = rate_limit::general_rate_limiter(&config.rate_limit);
 

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -349,21 +349,22 @@ pub async fn leak_detection_middleware(
         Ok(bytes) => bytes,
         Err(_) => {
             // Defense-in-depth: should be unreachable with correct size pre-check.
-            // Body is already consumed — cannot restore. Log and return empty.
+            // Body is already consumed — cannot restore. Return 502 so clients
+            // know the response is broken, not 200-with-empty-body (#540).
             LEAK_DETECTION_SKIPPED
                 .with_label_values(&["body_read_error"])
                 .inc();
-            tracing::warn!(
+            tracing::error!(
                 path = path.as_str(),
                 size_hint = ?size_hint_exact,
                 content_length = ?content_length,
-                "leak_detection: body read failed after size pre-check passed — returning empty body"
+                "leak_detection: body read failed after size pre-check passed — response body lost"
             );
-            let mut error_parts = parts;
-            error_parts
-                .headers
-                .remove(axum::http::header::CONTENT_LENGTH);
-            return Response::from_parts(error_parts, Body::empty());
+            return (
+                axum::http::StatusCode::BAD_GATEWAY,
+                "upstream response error",
+            )
+                .into_response();
         }
     };
 

--- a/nora-registry/src/rate_limit.rs
+++ b/nora-registry/src/rate_limit.rs
@@ -8,9 +8,12 @@
 //! - DoS attacks on upload endpoints
 //! - General API abuse
 
-use crate::config::RateLimitConfig;
+use crate::auth::resolve_client_ip;
+use crate::config::{RateLimitConfig, TrustedProxies};
+use std::net::IpAddr;
+use tower_governor::errors::GovernorError;
 use tower_governor::governor::GovernorConfigBuilder;
-use tower_governor::key_extractor::SmartIpKeyExtractor;
+use tower_governor::key_extractor::{KeyExtractor, SmartIpKeyExtractor};
 
 /// Convert a "requests per second" value to a replenishment period.
 ///
@@ -25,15 +28,58 @@ fn rps_to_period(rps: u64) -> u64 {
     (1000 / rps.max(1)).max(1)
 }
 
-/// Create rate limiter layer for auth endpoints (strict protection against brute-force)
+/// Key extractor that resolves the real client IP using NORA's trusted proxy
+/// configuration, rather than blindly trusting X-Forwarded-For headers (#541).
+///
+/// Uses [`resolve_client_ip`] which only honors XFF/X-Real-IP from peers in
+/// the configured `trusted_proxies` list. Untrusted peers always get rate-limited
+/// by their TCP peer IP, preventing XFF spoofing to bypass rate limits.
+#[derive(Debug, Clone)]
+pub struct TrustedProxyKeyExtractor {
+    trusted_proxies: TrustedProxies,
+}
+
+impl TrustedProxyKeyExtractor {
+    pub fn new(trusted_proxies: TrustedProxies) -> Self {
+        Self { trusted_proxies }
+    }
+}
+
+impl KeyExtractor for TrustedProxyKeyExtractor {
+    type Key = IpAddr;
+
+    fn extract<T>(&self, req: &axum::http::Request<T>) -> Result<Self::Key, GovernorError> {
+        let peer_ip = req
+            .extensions()
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0.ip())
+            .ok_or(GovernorError::UnableToExtractKey)?;
+
+        let client_ip = resolve_client_ip(peer_ip, req.headers(), &self.trusted_proxies);
+
+        debug_assert!(
+            client_ip.is_ipv4() || client_ip.is_ipv6(),
+            "resolved IP must be valid"
+        );
+
+        Ok(client_ip)
+    }
+}
+
+/// Create rate limiter layer for auth endpoints (strict protection against brute-force).
+///
+/// Uses [`TrustedProxyKeyExtractor`] to resolve real client IPs, preventing
+/// both proxy-IP-sharing (all clients in one bucket) and XFF spoofing.
 pub fn auth_rate_limiter(
     config: &RateLimitConfig,
+    trusted_proxies: TrustedProxies,
 ) -> tower_governor::GovernorLayer<
-    tower_governor::key_extractor::PeerIpKeyExtractor,
+    TrustedProxyKeyExtractor,
     governor::middleware::StateInformationMiddleware,
     axum::body::Body,
 > {
     let gov_config = GovernorConfigBuilder::default()
+        .key_extractor(TrustedProxyKeyExtractor::new(trusted_proxies))
         .per_millisecond(rps_to_period(config.auth_rps))
         .burst_size(config.auth_burst)
         .use_headers()
@@ -87,6 +133,7 @@ pub fn general_rate_limiter(
 mod tests {
     use super::*;
     use crate::config::RateLimitConfig;
+    use std::net::SocketAddr;
 
     #[test]
     fn test_default_config() {
@@ -100,7 +147,7 @@ mod tests {
     #[test]
     fn test_auth_rate_limiter_creation() {
         let config = RateLimitConfig::default();
-        let _limiter = auth_rate_limiter(&config);
+        let _limiter = auth_rate_limiter(&config, TrustedProxies::default_loopback());
     }
 
     #[test]
@@ -126,7 +173,7 @@ mod tests {
             general_rps: 200,
             general_burst: 400,
         };
-        let _auth = auth_rate_limiter(&config);
+        let _auth = auth_rate_limiter(&config, TrustedProxies::default_loopback());
         let _upload = upload_rate_limiter(&config);
         let _general = general_rate_limiter(&config);
     }
@@ -146,5 +193,59 @@ mod tests {
         // >1000 rps → clamped to 1ms (prevents zero period)
         assert_eq!(rps_to_period(2000), 1);
         assert_eq!(rps_to_period(10000), 1);
+    }
+
+    #[test]
+    fn test_trusted_proxy_extractor_uses_peer_for_untrusted() {
+        use axum::http::Request;
+
+        let proxies = TrustedProxies::parse("10.0.0.0/8");
+        let extractor = TrustedProxyKeyExtractor::new(proxies);
+
+        // Untrusted peer (192.168.1.1) with spoofed XFF — should use peer IP
+        let mut req = Request::builder().body(()).unwrap();
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(SocketAddr::from((
+                [192, 168, 1, 1],
+                1234,
+            ))));
+        req.headers_mut()
+            .insert("x-forwarded-for", "1.2.3.4".parse().unwrap());
+
+        let key = extractor.extract(&req).unwrap();
+        assert_eq!(key, IpAddr::from([192, 168, 1, 1]));
+    }
+
+    #[test]
+    fn test_trusted_proxy_extractor_uses_xff_for_trusted() {
+        use axum::http::Request;
+
+        let proxies = TrustedProxies::parse("10.0.0.0/8");
+        let extractor = TrustedProxyKeyExtractor::new(proxies);
+
+        // Trusted peer (10.0.0.1) with real XFF — should use XFF client IP
+        let mut req = Request::builder().body(()).unwrap();
+        req.extensions_mut()
+            .insert(axum::extract::ConnectInfo(SocketAddr::from((
+                [10, 0, 0, 1],
+                1234,
+            ))));
+        req.headers_mut()
+            .insert("x-forwarded-for", "5.6.7.8".parse().unwrap());
+
+        let key = extractor.extract(&req).unwrap();
+        assert_eq!(key, IpAddr::from([5, 6, 7, 8]));
+    }
+
+    #[test]
+    fn test_trusted_proxy_extractor_no_connect_info() {
+        use axum::http::Request;
+
+        let proxies = TrustedProxies::default_loopback();
+        let extractor = TrustedProxyKeyExtractor::new(proxies);
+
+        let req = Request::builder().body(()).unwrap();
+        let result = extractor.extract(&req);
+        assert!(result.is_err());
     }
 }

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -889,12 +889,20 @@ async fn extract_nuget_publish_date(
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let pages = json.get("items")?.as_array()?;
     for page in pages {
-        let items = page.get("items")?.as_array()?;
+        // Pages may be non-inline (only @id pointer, no items array) per NuGet V3 spec.
+        // Skip instead of aborting the entire function (#535).
+        let Some(items) = page.get("items").and_then(|i| i.as_array()) else {
+            continue;
+        };
         for item in items {
-            let entry = item.get("catalogEntry")?;
-            let ver = entry.get("version")?.as_str()?;
+            let Some(entry) = item.get("catalogEntry") else {
+                continue;
+            };
+            let Some(ver) = entry.get("version").and_then(|v| v.as_str()) else {
+                continue;
+            };
             if ver.eq_ignore_ascii_case(version) {
-                let date_str = entry.get("published")?.as_str()?;
+                let date_str = entry.get("published").and_then(|d| d.as_str())?;
                 return crate::curation::parse_iso8601_to_unix(date_str);
             }
         }
@@ -1769,6 +1777,40 @@ mod integration_tests {
 
         let result = super::extract_nuget_publish_date(&storage, "nonexistent", "1.0.0").await;
         assert!(result.is_none());
+    }
+
+    /// Regression test for #535: pages without inline items must not abort
+    /// date extraction for subsequent pages.
+    #[tokio::test]
+    async fn test_extract_nuget_publish_date_sparse_pages() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        // Page 0: non-inline (only @id, no items array).
+        // Page 1: inline with the target version.
+        let meta = serde_json::json!({
+            "items": [
+                { "@id": "https://upstream/page/0" },
+                {
+                    "items": [{
+                        "catalogEntry": {
+                            "version": "2.0.0",
+                            "published": "2024-06-15T12:00:00Z"
+                        }
+                    }]
+                }
+            ]
+        });
+        storage
+            .put(
+                "nuget/registration/sparse-pkg/index.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        // Before #535 fix: this returned None because page 0 had no "items".
+        let result = super::extract_nuget_publish_date(&storage, "sparse-pkg", "2.0.0").await;
+        assert!(result.is_some(), "date must be found despite sparse page 0");
     }
 
     #[tokio::test]

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -4,6 +4,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::method_not_allowed;
+use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -46,6 +47,9 @@ async fn download(
     }
 
     let key = format!("raw/{}", path);
+    if validate_storage_key(&key).is_err() {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
 
     // mtime fallback — Raw is always hosted (no proxy)
     let publish_date = crate::curation::extract_mtime_as_publish_date(&state.storage, &key).await;
@@ -118,6 +122,11 @@ async fn upload(
         return StatusCode::NOT_FOUND.into_response();
     }
 
+    let key = format!("raw/{}", path);
+    if validate_storage_key(&key).is_err() {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
+
     if !path.is_ascii() {
         return (
             StatusCode::BAD_REQUEST,
@@ -146,8 +155,6 @@ async fn upload(
         .get(header::IF_MATCH)
         .and_then(|v| v.to_str().ok())
         .map(|s| s.trim().to_string());
-
-    let key = format!("raw/{}", path);
 
     let lock = state.publish_lock(&key);
     let _guard = lock.lock().await;
@@ -273,6 +280,9 @@ async fn delete_file(State(state): State<AppState>, Path(path): Path<String>) ->
     }
 
     let key = format!("raw/{}", path);
+    if validate_storage_key(&key).is_err() {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
     match state.storage.delete(&key).await {
         Ok(()) => {
             state
@@ -295,6 +305,9 @@ async fn check_exists(State(state): State<AppState>, Path(path): Path<String>) -
     }
 
     let key = format!("raw/{}", path);
+    if validate_storage_key(&key).is_err() {
+        return StatusCode::BAD_REQUEST.into_response();
+    }
     match state.storage.stat(&key).await {
         Some(meta) => {
             let mut builder = axum::http::Response::builder()

--- a/nora-registry/src/request_id.rs
+++ b/nora-registry/src/request_id.rs
@@ -31,6 +31,26 @@ impl std::ops::Deref for RequestId {
     }
 }
 
+/// Maximum length for an externally-provided request ID.
+/// UUID is 36 chars; 128 is generous for any legitimate correlation ID.
+const MAX_REQUEST_ID_LEN: usize = 128;
+
+/// Validate an external request ID: printable ASCII only, bounded length.
+/// Returns `None` if the value is unsafe for log inclusion (#539).
+fn sanitize_request_id(raw: &str) -> Option<&str> {
+    if raw.is_empty() || raw.len() > MAX_REQUEST_ID_LEN {
+        return None;
+    }
+    // Only allow printable ASCII (0x21..=0x7E). Reject space (0x20) to prevent
+    // log field splitting, and control chars (0x00..=0x1F, 0x7F) to prevent
+    // log injection.
+    if raw.bytes().all(|b| (0x21..=0x7E).contains(&b)) {
+        Some(raw)
+    } else {
+        None
+    }
+}
+
 /// Middleware that adds a unique request ID to each request.
 ///
 /// The request ID is:
@@ -42,13 +62,20 @@ impl std::ops::Deref for RequestId {
 /// - Added to the response `X-Request-ID` header
 /// - Included in the tracing span for log correlation
 pub async fn request_id_middleware(mut request: Request<Body>, next: Next) -> Response {
-    // Check if request already has an ID (from upstream proxy/gateway)
+    // Check if request already has an ID (from upstream proxy/gateway).
+    // Sanitize to prevent log injection via control chars or oversized values (#539).
     let request_id = request
         .headers()
         .get(&REQUEST_ID_HEADER)
         .and_then(|v| v.to_str().ok())
+        .and_then(sanitize_request_id)
         .map(String::from)
         .unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    debug_assert!(
+        request_id.len() <= MAX_REQUEST_ID_LEN && request_id.is_ascii(),
+        "request_id postcondition violated"
+    );
 
     // Store in request extensions for handlers to access
     request
@@ -110,6 +137,59 @@ mod tests {
         let id = RequestId("req-12345".to_string());
         assert!(id.starts_with("req-"));
         assert_eq!(id.len(), 9);
+    }
+
+    // --- sanitize_request_id tests (#539) ---
+
+    #[test]
+    fn test_sanitize_valid_uuid() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        assert_eq!(sanitize_request_id(uuid), Some(uuid));
+    }
+
+    #[test]
+    fn test_sanitize_rejects_empty() {
+        assert_eq!(sanitize_request_id(""), None);
+    }
+
+    #[test]
+    fn test_sanitize_rejects_too_long() {
+        let long = "a".repeat(MAX_REQUEST_ID_LEN + 1);
+        assert_eq!(sanitize_request_id(&long), None);
+    }
+
+    #[test]
+    fn test_sanitize_max_length_accepted() {
+        let exact = "a".repeat(MAX_REQUEST_ID_LEN);
+        assert_eq!(sanitize_request_id(&exact), Some(exact.as_str()));
+    }
+
+    #[test]
+    fn test_sanitize_rejects_newline() {
+        assert_eq!(sanitize_request_id("real-id\nfake-log-line"), None);
+    }
+
+    #[test]
+    fn test_sanitize_rejects_tab() {
+        assert_eq!(sanitize_request_id("id\twith-tab"), None);
+    }
+
+    #[test]
+    fn test_sanitize_rejects_null_byte() {
+        assert_eq!(sanitize_request_id("id\0null"), None);
+    }
+
+    #[test]
+    fn test_sanitize_rejects_space() {
+        assert_eq!(sanitize_request_id("id with space"), None);
+    }
+
+    #[test]
+    fn test_sanitize_allows_printable_ascii() {
+        assert_eq!(
+            sanitize_request_id("req-123_abc.XYZ~!@#"),
+            Some("req-123_abc.XYZ~!@#")
+        );
     }
 }
 

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -588,7 +588,7 @@ pub async fn get_npm_detail(
                     let published = time_obj
                         .and_then(|t| t.get(version))
                         .and_then(|p| p.as_str())
-                        .map(|s| s[..10].to_string())
+                        .map(|s| s.get(..10).unwrap_or(s).to_string())
                         .unwrap_or_else(|| "N/A".to_string());
 
                     // Count pre-release, skip unless toggled


### PR DESCRIPTION
## Summary

P2 security hardening — 6 fixes in a single batch:

- **#535** (nuget): `extract_nuget_publish_date` used `?` operator that aborted on NuGet V3 sparse pages (non-inline pages without items array). Changed to `continue` so subsequent pages are still scanned. Prevents curation date-check bypass on registries with sparse indices.
- **#536** (npm/ui): `s[..10]` panics on upstream npm timestamps shorter than 10 chars. Changed to `s.get(..10).unwrap_or(s)` for safe slicing.
- **#538** (raw): Raw handler was the only registry format without `validate_storage_key()` at the handler level. Added to all 4 handlers (download, upload, delete, check_exists) for defense-in-depth.
- **#539** (request_id): External `X-Request-ID` headers were used without sanitization, enabling log injection via control chars or oversized values. Added `sanitize_request_id()` that accepts only printable ASCII (0x21-0x7E), max 128 chars.
- **#540** (metrics): Leak detection body read failure returned 200 with empty body — silent data loss. Changed to 502 with error message so clients detect the failure.
- **#541** (rate_limit): Auth rate limiter used `PeerIpKeyExtractor` (TCP peer IP only), making all clients behind a shared proxy share one rate-limit bucket. Replaced with custom `TrustedProxyKeyExtractor` that reuses `resolve_client_ip()` to properly resolve real client IPs from trusted proxies only, preventing XFF spoofing to bypass brute-force protection.

**Note:** Issue #471 (Host header injection in base URL) was verified as already fixed — `nora_base_url()` uses `config.server.public_url`, not request headers.

## Test plan

- [x] 1194 existing tests pass (0 regressions)
- [x] New test: `test_extract_nuget_publish_date_sparse_pages` — multi-page index where page 0 has no inline items
- [x] New tests: 9 unit tests for `sanitize_request_id` (UUID, empty, too long, max length, newline, tab, null byte, space, printable ASCII)
- [x] New tests: 3 unit tests for `TrustedProxyKeyExtractor` (untrusted peer ignores XFF, trusted peer uses XFF, no ConnectInfo returns error)
- [x] `cargo fmt --check` — PASS
- [x] `cargo clippy -D warnings` — PASS
- [x] `cargo-deny` + `cargo-audit` — PASS
- [x] Semgrep security scan — PASS (baseline 1110 warnings unchanged)
- [x] Architectural prediction — PASS (0 errors)

Closes #535, #536, #538, #539, #540, #541