### PR TITLE
fix: P1/P2 reliability batch — audit channel, env warnings, metrics order

### DIFF
--- a/nora-registry/src/audit.rs
+++ b/nora-registry/src/audit.rs
@@ -9,6 +9,9 @@
 //!   - `stdout`  — write JSONL to stderr (12-factor compatible)
 //!   - `both`   — write to file AND stderr
 //!   - `off`    — disable audit logging
+//!
+//! Uses a bounded mpsc channel with a single writer task (#543) to avoid
+//! per-entry `spawn_blocking` + Mutex contention under load.
 
 use chrono::{DateTime, Utc};
 use parking_lot::Mutex;
@@ -16,8 +19,13 @@ use serde::{Deserialize, Serialize};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
-use std::sync::Arc;
+use tokio::sync::mpsc;
 use tracing::{info, warn};
+
+/// Channel bound for audit entries. Under normal load, entries are drained
+/// faster than they arrive. The bound provides backpressure under extreme
+/// load — entries exceeding this are dropped with a warning (#543).
+const AUDIT_CHANNEL_BOUND: usize = 10_000;
 
 /// Audit output mode.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
@@ -83,77 +91,157 @@ impl AuditEntry {
 
 pub struct AuditLog {
     path: PathBuf,
-    writer: Arc<Mutex<Option<fs::File>>>,
     mode: AuditMode,
+    /// Channel sender, wrapped in Mutex<Option<>> so `shutdown()` can take it
+    /// through `&self` (needed because AuditLog is behind Arc in AppState).
+    sender: Mutex<Option<mpsc::Sender<AuditEntry>>>,
+    /// Handle to the background writer task, used for graceful shutdown.
+    writer_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl AuditLog {
     pub fn new(storage_path: &str, mode: AuditMode) -> Self {
+        let path = PathBuf::from(storage_path).join("audit.jsonl");
+
         if mode == AuditMode::Off {
             info!("Audit log disabled (mode=off)");
             return Self {
-                path: PathBuf::from(storage_path).join("audit.jsonl"),
-                writer: Arc::new(Mutex::new(None)),
+                path,
                 mode,
+                sender: Mutex::new(None),
+                writer_handle: Mutex::new(None),
             };
         }
 
-        let path = PathBuf::from(storage_path).join("audit.jsonl");
-        let writer = if mode == AuditMode::File || mode == AuditMode::Both {
+        // Open file handle if needed
+        let file = if mode == AuditMode::File || mode == AuditMode::Both {
             if let Some(parent) = path.parent() {
                 let _ = fs::create_dir_all(parent);
             }
             match OpenOptions::new().create(true).append(true).open(&path) {
                 Ok(f) => {
                     info!(path = %path.display(), mode = ?mode, "Audit log initialized");
-                    Arc::new(Mutex::new(Some(f)))
+                    Some(f)
                 }
                 Err(e) => {
                     warn!(path = %path.display(), error = %e, "Failed to open audit log file");
-                    Arc::new(Mutex::new(None))
+                    None
                 }
             }
         } else {
             info!(mode = ?mode, "Audit log initialized (stderr only)");
-            Arc::new(Mutex::new(None))
+            None
         };
 
-        Self { path, writer, mode }
+        let (tx, rx) = mpsc::channel(AUDIT_CHANNEL_BOUND);
+
+        debug_assert!(
+            mode != AuditMode::Off,
+            "channel should not be created when mode is Off"
+        );
+
+        let writer_mode = mode.clone();
+        let handle = tokio::task::spawn_blocking(move || {
+            Self::writer_loop(rx, file, writer_mode);
+        });
+
+        Self {
+            path,
+            mode,
+            sender: Mutex::new(Some(tx)),
+            writer_handle: Mutex::new(Some(handle)),
+        }
     }
 
+    /// Background writer loop — receives entries from the channel and writes
+    /// them to file/stderr. Runs until the channel is closed (all senders dropped).
+    fn writer_loop(
+        mut rx: mpsc::Receiver<AuditEntry>,
+        mut file: Option<fs::File>,
+        mode: AuditMode,
+    ) {
+        // blocking_recv() blocks the current thread until an entry arrives
+        // or the channel is closed. This is correct because we're inside
+        // spawn_blocking.
+        while let Some(entry) = rx.blocking_recv() {
+            Self::write_entry(&entry, &mut file, &mode);
+        }
+
+        // Channel closed — drain any remaining buffered entries
+        while let Ok(entry) = rx.try_recv() {
+            Self::write_entry(&entry, &mut file, &mode);
+        }
+
+        // Final flush on shutdown
+        if let Some(ref mut f) = file {
+            if let Err(e) = f.flush() {
+                tracing::error!(error = %e, "Audit log final flush failed");
+            }
+        }
+    }
+
+    /// Write a single audit entry to file and/or stderr.
+    fn write_entry(entry: &AuditEntry, file: &mut Option<fs::File>, mode: &AuditMode) {
+        let json = match serde_json::to_string(entry) {
+            Ok(j) => j,
+            Err(e) => {
+                tracing::error!(error = %e, "Audit log serialization failed");
+                return;
+            }
+        };
+
+        if *mode == AuditMode::File || *mode == AuditMode::Both {
+            if let Some(ref mut f) = file {
+                if let Err(e) = writeln!(f, "{}", json) {
+                    tracing::error!(error = %e, "Audit log write failed");
+                }
+                if let Err(e) = f.flush() {
+                    tracing::error!(error = %e, "Audit log flush failed");
+                }
+            }
+        }
+
+        if *mode == AuditMode::Stdout || *mode == AuditMode::Both {
+            eprintln!("{}", json);
+        }
+    }
+
+    /// Send an audit entry to the background writer (#543).
+    ///
+    /// Infallible: if the channel is full (extreme backpressure), the entry
+    /// is dropped with a warning. If the channel is closed (shutdown), the
+    /// entry is silently discarded.
     pub fn log(&self, entry: AuditEntry) {
         if self.mode == AuditMode::Off {
             return;
         }
 
-        let writer = Arc::clone(&self.writer);
-        let mode = self.mode.clone();
-        tokio::task::spawn_blocking(move || {
-            let json = match serde_json::to_string(&entry) {
-                Ok(j) => j,
-                Err(e) => {
-                    tracing::error!(error = %e, "Audit log serialization failed");
-                    return;
-                }
-            };
-
-            // Write to file if mode is file or both
-            if mode == AuditMode::File || mode == AuditMode::Both {
-                if let Some(ref mut file) = *writer.lock() {
-                    if let Err(e) = writeln!(file, "{}", json) {
-                        tracing::error!(error = %e, "Audit log write failed");
-                    }
-                    if let Err(e) = file.flush() {
-                        tracing::error!(error = %e, "Audit log flush failed");
-                    }
-                }
+        if let Some(ref sender) = *self.sender.lock() {
+            if let Err(mpsc::error::TrySendError::Full(_)) = sender.try_send(entry) {
+                warn!("Audit log channel full — entry dropped (backpressure)");
             }
+            // TrySendError::Closed is silently ignored — happens during shutdown
+        }
+    }
 
-            // Write to stderr if mode is stdout or both
-            if mode == AuditMode::Stdout || mode == AuditMode::Both {
-                eprintln!("{}", json);
+    /// Graceful shutdown: close the channel and wait for the writer to drain.
+    ///
+    /// Must be called AFTER all background schedulers have finished (#543),
+    /// so their final audit entries are captured.
+    pub async fn shutdown(&self) {
+        // Drop the sender to close the channel
+        self.sender.lock().take();
+
+        // Take the handle out of the mutex BEFORE awaiting (avoid holding
+        // MutexGuard across .await)
+        let handle = self.writer_handle.lock().take();
+
+        // Wait for the writer task to finish draining
+        if let Some(handle) = handle {
+            if let Err(e) = handle.await {
+                tracing::error!(error = %e, "Audit log writer task panicked");
             }
-        });
+        }
     }
 
     pub fn path(&self) -> &PathBuf {
@@ -189,8 +277,11 @@ mod tests {
 
     #[test]
     fn test_audit_log_new_and_path() {
+        // AuditLog::new() spawns a tokio task, so we need a runtime
+        let rt = tokio::runtime::Runtime::new().unwrap();
         let tmp = TempDir::new().unwrap();
-        let log = AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::File);
+        let log =
+            rt.block_on(async { AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::File) });
         assert!(log.path().ends_with("audit.jsonl"));
     }
 
@@ -202,17 +293,11 @@ mod tests {
         let entry = AuditEntry::new("pull", "user1", "lodash", "npm", "downloaded");
         log.log(entry);
 
-        // spawn_blocking is fire-and-forget; retry until flushed (max 1s)
+        // Wait for writer to process by shutting down (drains channel)
         let path = log.path().clone();
-        let mut content = String::new();
-        for _ in 0..20 {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            content = std::fs::read_to_string(&path).unwrap_or_default();
-            if content.contains(r#""action":"pull""#) {
-                break;
-            }
-        }
+        log.shutdown().await;
 
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
         assert!(content.contains(r#""action":"pull""#));
         assert!(content.contains(r#""actor":"user1""#));
         assert!(content.contains(r#""artifact":"lodash""#));
@@ -227,20 +312,11 @@ mod tests {
         log.log(AuditEntry::new("pull", "user", "b", "npm", ""));
         log.log(AuditEntry::new("delete", "admin", "c", "maven", ""));
 
-        // Retry until all 3 entries flushed (max 1s)
         let path = log.path().clone();
-        let mut line_count = 0;
-        for _ in 0..20 {
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-            if let Ok(content) = std::fs::read_to_string(&path) {
-                line_count = content.lines().count();
-                if line_count >= 3 {
-                    break;
-                }
-            }
-        }
+        log.shutdown().await;
 
-        assert_eq!(line_count, 3);
+        let content = std::fs::read_to_string(&path).unwrap_or_default();
+        assert_eq!(content.lines().count(), 3);
     }
 
     #[test]
@@ -289,10 +365,12 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_audit_log_off_mode() {
+    #[tokio::test]
+    async fn test_audit_log_off_mode() {
         let tmp = TempDir::new().unwrap();
         let log = AuditLog::new(tmp.path().to_str().unwrap(), AuditMode::Off);
         assert_eq!(log.mode(), &AuditMode::Off);
+        // Should not panic even when logging to Off mode
+        log.log(AuditEntry::new("test", "test", "test", "test", "test"));
     }
 }

--- a/nora-registry/src/config.rs
+++ b/nora-registry/src/config.rs
@@ -1571,6 +1571,26 @@ impl Default for AuditConfig {
     }
 }
 
+/// Parse an env var value into `target`, warning on failure (#537).
+///
+/// If `val` parses successfully, `*target` is updated. If parsing fails,
+/// a `warn!` is emitted with the variable name and invalid value, and
+/// `*target` is left unchanged (keeps the TOML/default value).
+fn parse_env_warn<T: std::str::FromStr + std::fmt::Display>(name: &str, val: &str, target: &mut T) {
+    match val.parse::<T>() {
+        Ok(parsed) => {
+            *target = parsed;
+        }
+        Err(_) => {
+            tracing::warn!(
+                var = name,
+                value = val,
+                "env override ignored: failed to parse value"
+            );
+        }
+    }
+}
+
 impl Config {
     /// Returns the set of enabled registry types.
     ///
@@ -2128,24 +2148,21 @@ impl Config {
     /// Apply environment variable overrides.
     ///
     /// Returns `Err` if a security-critical enum (curation mode, quarantine mode,
-    /// audit mode) has an unrecognized value — typos must not silently disable security.
+    /// audit mode, storage mode) has an unrecognized value — typos must not silently
+    /// disable security or misconfigure storage.
     fn apply_env_overrides(&mut self) -> Result<(), String> {
         // Server config
         if let Ok(val) = env::var("NORA_HOST") {
             self.server.host = val;
         }
         if let Ok(val) = env::var("NORA_PORT") {
-            if let Ok(port) = val.parse() {
-                self.server.port = port;
-            }
+            parse_env_warn("NORA_PORT", &val, &mut self.server.port);
         }
         if let Ok(val) = env::var("NORA_PUBLIC_URL") {
             self.server.public_url = if val.is_empty() { None } else { Some(val) };
         }
         if let Ok(val) = env::var("NORA_BODY_LIMIT_MB") {
-            if let Ok(mb) = val.parse() {
-                self.server.body_limit_mb = mb;
-            }
+            parse_env_warn("NORA_BODY_LIMIT_MB", &val, &mut self.server.body_limit_mb);
         }
 
         // TLS config
@@ -2156,8 +2173,14 @@ impl Config {
         // Storage config
         if let Ok(val) = env::var("NORA_STORAGE_MODE") {
             self.storage.mode = match val.to_lowercase().as_str() {
+                "local" | "filesystem" => StorageMode::Local,
                 "s3" => StorageMode::S3,
-                _ => StorageMode::Local,
+                other => {
+                    return Err(format!(
+                        "NORA_STORAGE_MODE={:?} is invalid — valid values: local, s3",
+                        other
+                    ))
+                }
             };
         }
         if let Ok(val) = env::var("NORA_STORAGE_PATH") {
@@ -2261,9 +2284,11 @@ impl Config {
                 .collect();
         }
         if let Ok(val) = env::var("NORA_MAVEN_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.maven.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_MAVEN_PROXY_TIMEOUT",
+                &val,
+                &mut self.maven.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_MAVEN_CHECKSUM_VERIFY") {
             self.maven.checksum_verify = val.to_lowercase() == "true" || val == "1";
@@ -2277,14 +2302,10 @@ impl Config {
             self.npm.proxy = if val.is_empty() { None } else { Some(val) };
         }
         if let Ok(val) = env::var("NORA_NPM_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.npm.proxy_timeout = timeout;
-            }
+            parse_env_warn("NORA_NPM_PROXY_TIMEOUT", &val, &mut self.npm.proxy_timeout);
         }
         if let Ok(val) = env::var("NORA_NPM_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.npm.metadata_ttl = ttl;
-            }
+            parse_env_warn("NORA_NPM_METADATA_TTL", &val, &mut self.npm.metadata_ttl);
         }
 
         // npm proxy auth
@@ -2301,9 +2322,11 @@ impl Config {
             self.pypi.proxy = if val.is_empty() { None } else { Some(val) };
         }
         if let Ok(val) = env::var("NORA_PYPI_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.pypi.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_PYPI_PROXY_TIMEOUT",
+                &val,
+                &mut self.pypi.proxy_timeout,
+            );
         }
 
         // PyPI proxy auth
@@ -2317,19 +2340,25 @@ impl Config {
 
         // Docker config
         if let Ok(val) = env::var("NORA_DOCKER_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.docker.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_DOCKER_PROXY_TIMEOUT",
+                &val,
+                &mut self.docker.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_DOCKER_READ_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.docker.read_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_DOCKER_READ_TIMEOUT",
+                &val,
+                &mut self.docker.read_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_DOCKER_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.docker.metadata_ttl = ttl;
-            }
+            parse_env_warn(
+                "NORA_DOCKER_METADATA_TTL",
+                &val,
+                &mut self.docker.metadata_ttl,
+            );
         }
         if let Ok(val) = env::var("NORA_DOCKER_SERVE_STALE") {
             self.docker.serve_stale = !matches!(val.as_str(), "false" | "0");
@@ -2390,19 +2419,17 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_GO_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.go.proxy_timeout = timeout;
-            }
+            parse_env_warn("NORA_GO_PROXY_TIMEOUT", &val, &mut self.go.proxy_timeout);
         }
         if let Ok(val) = env::var("NORA_GO_PROXY_TIMEOUT_ZIP") {
-            if let Ok(timeout) = val.parse() {
-                self.go.proxy_timeout_zip = timeout;
-            }
+            parse_env_warn(
+                "NORA_GO_PROXY_TIMEOUT_ZIP",
+                &val,
+                &mut self.go.proxy_timeout_zip,
+            );
         }
         if let Ok(val) = env::var("NORA_GO_MAX_ZIP_SIZE") {
-            if let Ok(size) = val.parse() {
-                self.go.max_zip_size = size;
-            }
+            parse_env_warn("NORA_GO_MAX_ZIP_SIZE", &val, &mut self.go.max_zip_size);
         }
 
         // Cargo config
@@ -2410,9 +2437,11 @@ impl Config {
             self.cargo.proxy = if val.is_empty() { None } else { Some(val) };
         }
         if let Ok(val) = env::var("NORA_CARGO_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.cargo.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_CARGO_PROXY_TIMEOUT",
+                &val,
+                &mut self.cargo.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_CARGO_PROXY_AUTH") {
             self.cargo.proxy_auth = if val.is_empty() {
@@ -2427,9 +2456,7 @@ impl Config {
             self.raw.enabled = val.to_lowercase() == "true" || val == "1";
         }
         if let Ok(val) = env::var("NORA_RAW_MAX_FILE_SIZE") {
-            if let Ok(size) = val.parse() {
-                self.raw.max_file_size = size;
-            }
+            parse_env_warn("NORA_RAW_MAX_FILE_SIZE", &val, &mut self.raw.max_file_size);
         }
         if let Ok(val) = env::var("NORA_RAW_CACHE_CONTROL") {
             self.raw.cache_control = val;
@@ -2447,14 +2474,14 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_GEMS_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.gems.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_GEMS_PROXY_TIMEOUT",
+                &val,
+                &mut self.gems.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_GEMS_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.gems.metadata_ttl = ttl;
-            }
+            parse_env_warn("NORA_GEMS_METADATA_TTL", &val, &mut self.gems.metadata_ttl);
         }
 
         // Terraform config
@@ -2469,19 +2496,25 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_TF_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.terraform.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_TF_PROXY_TIMEOUT",
+                &val,
+                &mut self.terraform.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_TF_PROXY_TIMEOUT_DL") {
-            if let Ok(timeout) = val.parse() {
-                self.terraform.proxy_timeout_dl = timeout;
-            }
+            parse_env_warn(
+                "NORA_TF_PROXY_TIMEOUT_DL",
+                &val,
+                &mut self.terraform.proxy_timeout_dl,
+            );
         }
         if let Ok(val) = env::var("NORA_TF_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.terraform.metadata_ttl = ttl;
-            }
+            parse_env_warn(
+                "NORA_TF_METADATA_TTL",
+                &val,
+                &mut self.terraform.metadata_ttl,
+            );
         }
         if let Ok(val) = env::var("NORA_TF_SERVE_STALE") {
             self.terraform.serve_stale = !matches!(val.as_str(), "false" | "0");
@@ -2499,14 +2532,18 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_ANSIBLE_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.ansible.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_ANSIBLE_PROXY_TIMEOUT",
+                &val,
+                &mut self.ansible.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_ANSIBLE_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.ansible.metadata_ttl = ttl;
-            }
+            parse_env_warn(
+                "NORA_ANSIBLE_METADATA_TTL",
+                &val,
+                &mut self.ansible.metadata_ttl,
+            );
         }
         if let Ok(val) = env::var("NORA_ANSIBLE_SERVE_STALE") {
             self.ansible.serve_stale = !matches!(val.as_str(), "false" | "0");
@@ -2524,19 +2561,25 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_NUGET_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.nuget.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_NUGET_PROXY_TIMEOUT",
+                &val,
+                &mut self.nuget.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_NUGET_METADATA_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.nuget.metadata_proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_NUGET_METADATA_TIMEOUT",
+                &val,
+                &mut self.nuget.metadata_proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_NUGET_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.nuget.metadata_ttl = ttl;
-            }
+            parse_env_warn(
+                "NORA_NUGET_METADATA_TTL",
+                &val,
+                &mut self.nuget.metadata_ttl,
+            );
         }
         if let Ok(val) = env::var("NORA_NUGET_SERVE_STALE") {
             self.nuget.serve_stale = !matches!(val.as_str(), "false" | "0");
@@ -2564,14 +2607,18 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_PUB_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.pub_dart.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_PUB_PROXY_TIMEOUT",
+                &val,
+                &mut self.pub_dart.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_PUB_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.pub_dart.metadata_ttl = ttl;
-            }
+            parse_env_warn(
+                "NORA_PUB_METADATA_TTL",
+                &val,
+                &mut self.pub_dart.metadata_ttl,
+            );
         }
 
         // Conan proxy config
@@ -2586,19 +2633,25 @@ impl Config {
             };
         }
         if let Ok(val) = env::var("NORA_CONAN_PROXY_TIMEOUT") {
-            if let Ok(timeout) = val.parse() {
-                self.conan.proxy_timeout = timeout;
-            }
+            parse_env_warn(
+                "NORA_CONAN_PROXY_TIMEOUT",
+                &val,
+                &mut self.conan.proxy_timeout,
+            );
         }
         if let Ok(val) = env::var("NORA_CONAN_PROXY_TIMEOUT_DL") {
-            if let Ok(timeout) = val.parse() {
-                self.conan.proxy_timeout_dl = timeout;
-            }
+            parse_env_warn(
+                "NORA_CONAN_PROXY_TIMEOUT_DL",
+                &val,
+                &mut self.conan.proxy_timeout_dl,
+            );
         }
         if let Ok(val) = env::var("NORA_CONAN_METADATA_TTL") {
-            if let Ok(ttl) = val.parse() {
-                self.conan.metadata_ttl = ttl;
-            }
+            parse_env_warn(
+                "NORA_CONAN_METADATA_TTL",
+                &val,
+                &mut self.conan.metadata_ttl,
+            );
         }
 
         // Token storage
@@ -2611,34 +2664,46 @@ impl Config {
             self.rate_limit.enabled = val.to_lowercase() == "true" || val == "1";
         }
         if let Ok(val) = env::var("NORA_RATE_LIMIT_AUTH_RPS") {
-            if let Ok(v) = val.parse::<u64>() {
-                self.rate_limit.auth_rps = v;
-            }
+            parse_env_warn(
+                "NORA_RATE_LIMIT_AUTH_RPS",
+                &val,
+                &mut self.rate_limit.auth_rps,
+            );
         }
         if let Ok(val) = env::var("NORA_RATE_LIMIT_AUTH_BURST") {
-            if let Ok(v) = val.parse::<u32>() {
-                self.rate_limit.auth_burst = v;
-            }
+            parse_env_warn(
+                "NORA_RATE_LIMIT_AUTH_BURST",
+                &val,
+                &mut self.rate_limit.auth_burst,
+            );
         }
         if let Ok(val) = env::var("NORA_RATE_LIMIT_UPLOAD_RPS") {
-            if let Ok(v) = val.parse::<u64>() {
-                self.rate_limit.upload_rps = v;
-            }
+            parse_env_warn(
+                "NORA_RATE_LIMIT_UPLOAD_RPS",
+                &val,
+                &mut self.rate_limit.upload_rps,
+            );
         }
         if let Ok(val) = env::var("NORA_RATE_LIMIT_UPLOAD_BURST") {
-            if let Ok(v) = val.parse::<u32>() {
-                self.rate_limit.upload_burst = v;
-            }
+            parse_env_warn(
+                "NORA_RATE_LIMIT_UPLOAD_BURST",
+                &val,
+                &mut self.rate_limit.upload_burst,
+            );
         }
         if let Ok(val) = env::var("NORA_RATE_LIMIT_GENERAL_RPS") {
-            if let Ok(v) = val.parse::<u64>() {
-                self.rate_limit.general_rps = v;
-            }
+            parse_env_warn(
+                "NORA_RATE_LIMIT_GENERAL_RPS",
+                &val,
+                &mut self.rate_limit.general_rps,
+            );
         }
         if let Ok(val) = env::var("NORA_RATE_LIMIT_GENERAL_BURST") {
-            if let Ok(v) = val.parse::<u32>() {
-                self.rate_limit.general_burst = v;
-            }
+            parse_env_warn(
+                "NORA_RATE_LIMIT_GENERAL_BURST",
+                &val,
+                &mut self.rate_limit.general_burst,
+            );
         }
 
         // GC config
@@ -2646,9 +2711,7 @@ impl Config {
             self.gc.enabled = val.to_lowercase() == "true" || val == "1";
         }
         if let Ok(val) = env::var("NORA_GC_INTERVAL") {
-            if let Ok(v) = val.parse() {
-                self.gc.interval = v;
-            }
+            parse_env_warn("NORA_GC_INTERVAL", &val, &mut self.gc.interval);
         }
         if let Ok(val) = env::var("NORA_GC_DRY_RUN") {
             self.gc.dry_run = val.to_lowercase() == "true" || val == "1";
@@ -2659,9 +2722,11 @@ impl Config {
             self.retention.enabled = val.to_lowercase() == "true" || val == "1";
         }
         if let Ok(val) = env::var("NORA_RETENTION_INTERVAL") {
-            if let Ok(v) = val.parse() {
-                self.retention.interval = v;
-            }
+            parse_env_warn(
+                "NORA_RETENTION_INTERVAL",
+                &val,
+                &mut self.retention.interval,
+            );
         }
         if let Ok(val) = env::var("NORA_RETENTION_DRY_RUN") {
             self.retention.dry_run = val.to_lowercase() == "true" || val == "1";
@@ -2732,14 +2797,18 @@ impl Config {
             self.circuit_breaker.enabled = val.to_lowercase() == "true" || val == "1";
         }
         if let Ok(val) = env::var("NORA_CB_THRESHOLD") {
-            if let Ok(v) = val.parse() {
-                self.circuit_breaker.failure_threshold = v;
-            }
+            parse_env_warn(
+                "NORA_CB_THRESHOLD",
+                &val,
+                &mut self.circuit_breaker.failure_threshold,
+            );
         }
         if let Ok(val) = env::var("NORA_CB_RESET_TIMEOUT") {
-            if let Ok(v) = val.parse() {
-                self.circuit_breaker.reset_timeout = v;
-            }
+            parse_env_warn(
+                "NORA_CB_RESET_TIMEOUT",
+                &val,
+                &mut self.circuit_breaker.reset_timeout,
+            );
         }
 
         // Per-registry curation overrides
@@ -3049,6 +3118,55 @@ mod tests {
         std::env::remove_var("NORA_STORAGE_PATH");
         std::env::remove_var("NORA_STORAGE_BUCKET");
         std::env::remove_var("NORA_STORAGE_S3_REGION");
+    }
+
+    #[test]
+    fn test_env_override_storage_mode_local() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_STORAGE_MODE", "local");
+        config.apply_env_overrides().unwrap();
+        assert_eq!(config.storage.mode, StorageMode::Local);
+        std::env::remove_var("NORA_STORAGE_MODE");
+    }
+
+    #[test]
+    fn test_env_override_storage_mode_case_insensitive() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_STORAGE_MODE", "S3");
+        config.apply_env_overrides().unwrap();
+        assert_eq!(config.storage.mode, StorageMode::S3);
+        std::env::remove_var("NORA_STORAGE_MODE");
+    }
+
+    #[test]
+    fn test_env_override_storage_mode_rejects_unknown() {
+        let mut config = Config::default();
+        std::env::set_var("NORA_STORAGE_MODE", "redis");
+        let result = config.apply_env_overrides();
+        assert!(result.is_err(), "unknown storage mode must be rejected");
+        assert!(result.unwrap_err().contains("NORA_STORAGE_MODE"));
+        std::env::remove_var("NORA_STORAGE_MODE");
+    }
+
+    #[test]
+    fn test_parse_env_warn_valid_u16() {
+        let mut port: u16 = 5000;
+        parse_env_warn("NORA_PORT", "8080", &mut port);
+        assert_eq!(port, 8080);
+    }
+
+    #[test]
+    fn test_parse_env_warn_invalid_keeps_original() {
+        let mut port: u16 = 5000;
+        parse_env_warn("NORA_PORT", "not-a-number", &mut port);
+        assert_eq!(port, 5000, "invalid parse must keep original value");
+    }
+
+    #[test]
+    fn test_parse_env_warn_empty_keeps_original() {
+        let mut timeout: u64 = 30;
+        parse_env_warn("NORA_TIMEOUT", "", &mut timeout);
+        assert_eq!(timeout, 30, "empty string must keep original value");
     }
 
     #[test]

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -510,6 +510,7 @@ async fn main() {
                             result.deleted_keys, result.bytes_freed, result.duration_secs
                         ),
                     ));
+                    audit.shutdown().await;
                 }
                 print_retention_coverage(&storage, &config.retention.rules).await;
             }
@@ -1241,8 +1242,15 @@ async fn run_server(mut config: Config, storage: Storage) {
             axum::http::header::HeaderName::from_static("content-security-policy"),
             HeaderValue::from_static("default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'"),
         ))
+        // Middleware layer order — LOAD-BEARING, do not reorder (#542).
+        //
+        // In axum, last .layer() = outermost (runs first). Execution order:
+        //   metrics → auth → leak_detection → request_id → handler
+        //
+        // metrics MUST be outermost so it counts ALL responses including
+        // auth rejections (401/403/429) in nora_http_requests_total.
+        // request_id is innermost so the ID is available to handlers.
         .layer(middleware::from_fn(request_id::request_id_middleware))
-        .layer(middleware::from_fn(metrics::metrics_middleware))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             metrics::leak_detection_middleware,
@@ -1251,6 +1259,7 @@ async fn run_server(mut config: Config, storage: Storage) {
             state.clone(),
             auth::auth_middleware,
         ))
+        .layer(middleware::from_fn(metrics::metrics_middleware))
         .with_state(state.clone());
 
     // Clean up stale Docker upload temp files from previous runs (#530).
@@ -1368,6 +1377,9 @@ async fn run_server(mut config: Config, storage: Storage) {
             warn!("Background schedulers did not finish within 10s, proceeding with shutdown");
         }
     }
+
+    // Drain audit log — AFTER schedulers finish so their final entries are captured (#543)
+    state.audit.shutdown().await;
 
     // Save metrics on shutdown
     state.metrics.save().await;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -42,7 +42,7 @@ pub fn routes() -> Router<AppState> {
 /// 2. Safety net: byte-level replace of upstream URL prefix in serialized output
 fn rewrite_tarball_urls(data: &[u8], nora_base: &str, upstream_url: &str) -> Result<Vec<u8>, ()> {
     let mut json: serde_json::Value = serde_json::from_slice(data).map_err(|e| {
-        tracing::debug!(error = %e, "npm: JSON parse failed in rewrite_tarball_urls");
+        tracing::warn!(error = %e, "npm: JSON parse failed in rewrite_tarball_urls");
     })?;
 
     let upstream_trimmed = upstream_url.trim_end_matches('/');
@@ -65,7 +65,7 @@ fn rewrite_tarball_urls(data: &[u8], nora_base: &str, upstream_url: &str) -> Res
     }
 
     let output = serde_json::to_vec(&json).map_err(|e| {
-        tracing::debug!(error = %e, "npm: JSON serialize failed in rewrite_tarball_urls");
+        tracing::warn!(error = %e, "npm: JSON serialize failed in rewrite_tarball_urls");
     })?;
 
     // Safety net: byte-level replace of any remaining upstream URL prefix (#439).


### PR DESCRIPTION
## Summary

- **#481**: Upgrade npm `rewrite_tarball_urls` error logging from `debug!` to `warn!` so JSON parse/serialize failures are visible in production logs
- **#537**: Extract `parse_env_warn<T>` helper for 31 env override sites — invalid values now emit `warn!` instead of being silently ignored; reject unknown `NORA_STORAGE_MODE` values with an explicit error
- **#542**: Reorder middleware layers so `metrics_middleware` is outermost — auth rejections (401/403/429) are now counted in `nora_http_requests_total`
- **#543**: Replace per-entry `spawn_blocking` + `Arc<Mutex<File>>` in audit log with bounded mpsc channel (10K) and single writer task; add graceful `shutdown()` with channel drain

Closes #481, closes #537, closes #542, closes #543

## Changes

| File | Lines | What |
|------|-------|------|
| `audit.rs` | +124/-69 | mpsc channel rewrite, shutdown, 8 tests |
| `config.rs` | +245/-112 | `parse_env_warn` helper, StorageMode validation, 6 tests |
| `main.rs` | +12/-2 | middleware reorder, audit shutdown calls |
| `npm.rs` | +2/-2 | debug→warn |

## Test plan

- [x] 1204 tests pass (6 new)
- [x] `cargo clippy -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] semgrep: 0 new findings
- [x] arch-predict: 0 new errors
- [x] cargo-deny + cargo-audit: clean
- [x] typos: clean
- [x] OPSEC check: clean