### PR TITLE
fix: v0.9.3 security patches — null byte rejection + Cargo User-Agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,7 +83,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -94,7 +94,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -883,7 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1914,7 +1914,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2752,7 +2752,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3079,7 +3079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3164,9 +3164,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3183,7 +3183,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3939,7 +3939,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "arc-swap",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.2"
+version = "0.9.3"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -316,7 +316,8 @@ fn log_outbound_proxy() {
 /// When `timeout` is `Some`, a default request timeout is set on the client
 /// (used by `nora mirror` for long-running downloads).
 fn build_http_client(tls: &TlsConfig, timeout: Option<std::time::Duration>) -> reqwest::Client {
-    let mut builder = reqwest::ClientBuilder::new();
+    let mut builder =
+        reqwest::ClientBuilder::new().user_agent(format!("nora/{}", env!("CARGO_PKG_VERSION")));
 
     if let Some(t) = timeout {
         builder = builder.timeout(t);
@@ -1245,9 +1246,11 @@ async fn run_server(mut config: Config, storage: Storage) {
         // Middleware layer order — LOAD-BEARING, do not reorder (#542).
         //
         // In axum, last .layer() = outermost (runs first). Execution order:
-        //   metrics → auth → leak_detection → request_id → handler
+        //   reject_null_bytes → metrics → auth → leak_detection → request_id → handler
         //
-        // metrics MUST be outermost so it counts ALL responses including
+        // reject_null_bytes MUST be outermost to block null-byte path attacks
+        // before any processing occurs.
+        // metrics MUST be next-outermost so it counts ALL responses including
         // auth rejections (401/403/429) in nora_http_requests_total.
         // request_id is innermost so the ID is available to handlers.
         .layer(middleware::from_fn(request_id::request_id_middleware))
@@ -1260,6 +1263,7 @@ async fn run_server(mut config: Config, storage: Storage) {
             auth::auth_middleware,
         ))
         .layer(middleware::from_fn(metrics::metrics_middleware))
+        .layer(middleware::from_fn(validation::reject_null_bytes_middleware))
         .with_state(state.clone());
 
     // Clean up stale Docker upload temp files from previous runs (#530).

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.9.2",
+        version = "0.9.3",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -6,6 +6,12 @@
 //! Provides security validation to prevent path traversal attacks and
 //! ensure inputs conform to protocol specifications.
 
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
 use std::fmt;
 
 /// Validation errors
@@ -327,6 +333,28 @@ pub fn validate_docker_reference(reference: &str) -> Result<(), ValidationError>
     }
 
     Ok(())
+}
+
+/// Middleware that rejects requests with null bytes in the URI path.
+///
+/// Null bytes in URLs are used in path-traversal attacks. Axum URL-decodes
+/// `%00` before passing the path to handlers, which can cause panics or
+/// unexpected 500 errors. This middleware intercepts null bytes early and
+/// returns a clean 400 Bad Request.
+pub async fn reject_null_bytes_middleware(request: Request<Body>, next: Next) -> Response {
+    let path = request.uri().path();
+
+    // Check for literal null byte (already URL-decoded by hyper) or
+    // percent-encoded null byte in the raw URI.
+    if path.contains('\0') || path.contains("%00") || path.contains("%2500") {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Bad Request: null byte in URL path",
+        )
+            .into_response();
+    }
+
+    next.run(request).await
 }
 
 #[cfg(test)]

--- a/tests/e2e/tests/contracts/registry-contracts.ts
+++ b/tests/e2e/tests/contracts/registry-contracts.ts
@@ -1,0 +1,415 @@
+/**
+ * UI Contract Definitions for NORA Registry
+ *
+ * Single source of truth for what each registry page MUST render.
+ * Selectors verified against nora-registry/src/ui/templates.rs and components.rs.
+ */
+
+// --- Types ---
+
+export interface ListPageContract {
+  /** URL slug: /ui/{slug} */
+  slug: string;
+  /** Expected H1 title text */
+  title: string;
+  /** Column headers in the list table (Name is always first) */
+  columnHeaders: string[];
+  /** Label for the count column (Tags, Versions, Items) */
+  countColumnLabel: string;
+  /** Whether the registry uses hierarchical (directory) browsing */
+  isHierarchical: boolean;
+  /** Whether a search input is expected */
+  hasSearch: boolean;
+  /** HTMX search endpoint: /api/ui/{slug}/search */
+  searchEndpoint: string;
+}
+
+export interface DetailPageContract {
+  /** URL slug used in breadcrumb link: /ui/{slug} */
+  slug: string;
+  /** Text shown in the breadcrumb root link back to list */
+  breadcrumbRootText: string;
+  /** Whether an install command section is rendered */
+  hasInstallCommand: boolean;
+  /** Label for the install section (e.g. "Pull Command", "Install") */
+  installSectionLabel?: string;
+  /** Pattern the install command must match */
+  installCommandPattern?: RegExp;
+  /** Column headers in the detail/versions table */
+  tableColumnHeaders: string[];
+  /** Whether a metadata panel is rendered */
+  hasMetadataPanel: boolean;
+  /** Whether version rows are clickable (NuGet-style interactive selection) */
+  hasClickableVersionRows: boolean;
+}
+
+export interface RegistryContract {
+  /** Registry type slug */
+  slug: string;
+  /** Human-readable display name (used in H1 titles, registry cards) */
+  displayName: string;
+  /** Short name shown in the sidebar navigation */
+  sidebarName: string;
+  /** List page contract */
+  list: ListPageContract;
+  /** Detail page contract */
+  detail: DetailPageContract;
+}
+
+export interface DashboardContract {
+  /** CSS selectors for stats cards */
+  statsIds: string[];
+  /** Selector for registry card links */
+  registryCardSelector: string;
+  /** Whether mount points table is expected */
+  hasMountPointsTable: boolean;
+  /** Whether activity log section is expected */
+  hasActivityLog: boolean;
+}
+
+// --- Registry Contracts ---
+
+export const REGISTRIES: RegistryContract[] = [
+  {
+    slug: 'docker',
+    displayName: 'Docker Registry',
+    sidebarName: 'Docker',
+    list: {
+      slug: 'docker',
+      title: 'Docker Registry',
+      columnHeaders: ['Name', 'Tags', 'Size', 'Updated'],
+      countColumnLabel: 'Tags',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/docker/search',
+    },
+    detail: {
+      slug: 'docker',
+      breadcrumbRootText: 'Docker',
+      hasInstallCommand: true,
+      installSectionLabel: 'Pull Command',
+      installCommandPattern: /docker pull .+\/.+/,
+      tableColumnHeaders: ['Tag', 'Size', 'Created'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'npm',
+    displayName: 'npm Registry',
+    sidebarName: 'npm',
+    list: {
+      slug: 'npm',
+      title: 'npm Registry',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/npm/search',
+    },
+    detail: {
+      slug: 'npm',
+      breadcrumbRootText: 'npm',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /npm install .+ --registry .+\/npm/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'maven',
+    displayName: 'Maven Repository',
+    sidebarName: 'Maven',
+    list: {
+      slug: 'maven',
+      title: 'Maven Repository',
+      columnHeaders: ['Name', 'Files', 'Size', 'Updated'],
+      countColumnLabel: 'Files',
+      isHierarchical: true,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/maven/search',
+    },
+    detail: {
+      slug: 'maven',
+      breadcrumbRootText: 'Maven',
+      hasInstallCommand: true,
+      installSectionLabel: 'Maven Dependency',
+      installCommandPattern: /<dependency>/,
+      tableColumnHeaders: ['Filename', 'Size'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'cargo',
+    displayName: 'Cargo Registry',
+    sidebarName: 'Cargo',
+    list: {
+      slug: 'cargo',
+      title: 'Cargo Registry',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/cargo/search',
+    },
+    detail: {
+      slug: 'cargo',
+      breadcrumbRootText: 'Cargo Registry',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /cargo add .+/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'pypi',
+    displayName: 'PyPI Repository',
+    sidebarName: 'PyPI',
+    list: {
+      slug: 'pypi',
+      title: 'PyPI Repository',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/pypi/search',
+    },
+    detail: {
+      slug: 'pypi',
+      breadcrumbRootText: 'PyPI Repository',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /pip install .+ --index-url .+\/simple/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'go',
+    displayName: 'Go Modules',
+    sidebarName: 'Go',
+    list: {
+      slug: 'go',
+      title: 'Go Modules',
+      columnHeaders: ['Name', 'Files', 'Size', 'Updated'],
+      countColumnLabel: 'Files',
+      isHierarchical: true,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/go/search',
+    },
+    detail: {
+      slug: 'go',
+      breadcrumbRootText: 'Go Modules',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /GOPROXY=.+\/go.+go get .+/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'raw',
+    displayName: 'Raw Storage',
+    sidebarName: 'Raw',
+    list: {
+      slug: 'raw',
+      title: 'Raw Storage',
+      columnHeaders: ['Name', 'Files', 'Size', 'Updated'],
+      countColumnLabel: 'Files',
+      isHierarchical: true,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/raw/search',
+    },
+    detail: {
+      slug: 'raw',
+      breadcrumbRootText: 'Raw Storage',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /curl -O .+\/raw\/.+/,
+      tableColumnHeaders: ['Filename', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'gems',
+    displayName: 'RubyGems',
+    sidebarName: 'RubyGems',
+    list: {
+      slug: 'gems',
+      title: 'RubyGems',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/gems/search',
+    },
+    detail: {
+      slug: 'gems',
+      breadcrumbRootText: 'RubyGems',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /gem install .+ --source .+\/gems/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'terraform',
+    displayName: 'Terraform Registry',
+    sidebarName: 'Terraform',
+    list: {
+      slug: 'terraform',
+      title: 'Terraform Registry',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/terraform/search',
+    },
+    detail: {
+      slug: 'terraform',
+      breadcrumbRootText: 'Terraform Registry',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /source\s*=\s*".+\/terraform\/.+"/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'ansible',
+    displayName: 'Ansible Galaxy',
+    sidebarName: 'Ansible',
+    list: {
+      slug: 'ansible',
+      title: 'Ansible Galaxy',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/ansible/search',
+    },
+    detail: {
+      slug: 'ansible',
+      breadcrumbRootText: 'Ansible Galaxy',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /ansible-galaxy collection install .+/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'nuget',
+    displayName: 'NuGet Gallery',
+    sidebarName: 'NuGet',
+    list: {
+      slug: 'nuget',
+      title: 'NuGet Gallery',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/nuget/search',
+    },
+    detail: {
+      slug: 'nuget',
+      breadcrumbRootText: 'NuGet Gallery',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /dotnet add package .+/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: true,
+    },
+  },
+  {
+    slug: 'pub',
+    displayName: 'Pub (Dart/Flutter)',
+    sidebarName: 'pub.dev',
+    list: {
+      slug: 'pub',
+      title: 'Pub (Dart/Flutter)',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/pub/search',
+    },
+    detail: {
+      slug: 'pub',
+      breadcrumbRootText: 'Pub',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /hosted:\s*.+\/pub/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+  {
+    slug: 'conan',
+    displayName: 'Conan (C/C++)',
+    sidebarName: 'Conan',
+    list: {
+      slug: 'conan',
+      title: 'Conan (C/C++)',
+      columnHeaders: ['Name', 'Versions', 'Size', 'Updated'],
+      countColumnLabel: 'Versions',
+      isHierarchical: false,
+      hasSearch: true,
+      searchEndpoint: '/api/ui/conan/search',
+    },
+    detail: {
+      slug: 'conan',
+      breadcrumbRootText: 'Conan (C/C++)',
+      hasInstallCommand: true,
+      installSectionLabel: 'Install Command',
+      installCommandPattern: /conan install .+/,
+      tableColumnHeaders: ['Versions', 'Size', 'Published'],
+      hasMetadataPanel: false,
+      hasClickableVersionRows: false,
+    },
+  },
+];
+
+// --- Dashboard Contract ---
+
+export const DASHBOARD: DashboardContract = {
+  statsIds: [
+    '#stat-downloads',
+    '#stat-uploads',
+    '#stat-artifacts',
+    '#stat-cache-hit',
+    '#stat-storage',
+  ],
+  registryCardSelector: 'a[id^="registry-"]',
+  hasMountPointsTable: true,
+  hasActivityLog: true,
+};
+
+// --- Helpers ---
+
+/** Get a registry contract by slug */
+export function getRegistry(slug: string): RegistryContract {
+  const r = REGISTRIES.find((r) => r.slug === slug);
+  if (!r) throw new Error(`Unknown registry slug: ${slug}`);
+  return r;
+}
+
+/** All registry slugs */
+export const ALL_SLUGS = REGISTRIES.map((r) => r.slug);
+
+/** Sidebar nav labels — short names shown in sidebar for all registries + Dashboard */
+export const SIDEBAR_LABELS = ['Dashboard', ...REGISTRIES.map((r) => r.sidebarName)];

--- a/tests/e2e/tests/contracts/seed.ts
+++ b/tests/e2e/tests/contracts/seed.ts
@@ -1,0 +1,204 @@
+/**
+ * Test data seeding helpers for UI contract tests.
+ *
+ * All seeders are idempotent — they use deterministic names and
+ * handle 409/conflict responses gracefully. Patterns follow
+ * existing docker-proxy.spec.ts and npm-proxy.spec.ts.
+ */
+
+import { APIRequestContext } from '@playwright/test';
+import * as crypto from 'crypto';
+
+export interface SeedResult {
+  docker: { name: string; tags: string[] };
+  npm: { name: string; version: string };
+  raw: { path: string };
+  maven: { group: string; artifact: string; version: string; path: string };
+}
+
+/**
+ * Push a Docker image with two tags.
+ * Follows the OCI distribution spec: blob upload → config blob → manifest PUT.
+ */
+export async function seedDocker(
+  request: APIRequestContext
+): Promise<SeedResult['docker']> {
+  const name = 'e2e-ui-docker';
+  const tags = ['1.0.0', 'latest'];
+
+  // Push layer blob
+  const blobData = 'e2e-ui-test-layer-content';
+  const blobDigest =
+    'sha256:' + crypto.createHash('sha256').update(blobData).digest('hex');
+
+  await request.post(`/v2/${name}/blobs/uploads/?digest=${blobDigest}`, {
+    data: blobData,
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+
+  // Push config blob
+  const configData = '{}';
+  const configDigest =
+    'sha256:' + crypto.createHash('sha256').update(configData).digest('hex');
+
+  await request.post(`/v2/${name}/blobs/uploads/?digest=${configDigest}`, {
+    data: configData,
+    headers: { 'Content-Type': 'application/octet-stream' },
+  });
+
+  // Push manifest for each tag
+  const manifest = {
+    schemaVersion: 2,
+    mediaType: 'application/vnd.oci.image.manifest.v1+json',
+    config: {
+      mediaType: 'application/vnd.oci.image.config.v1+json',
+      digest: configDigest,
+      size: configData.length,
+    },
+    layers: [
+      {
+        mediaType: 'application/vnd.oci.image.layer.v1.tar+gzip',
+        digest: blobDigest,
+        size: blobData.length,
+      },
+    ],
+  };
+
+  for (const tag of tags) {
+    const resp = await request.put(`/v2/${name}/manifests/${tag}`, {
+      data: manifest,
+      headers: {
+        'Content-Type': 'application/vnd.oci.image.manifest.v1+json',
+      },
+    });
+    // 201 = created, 409 = already exists — both OK
+    if (resp.status() !== 201 && resp.status() !== 409) {
+      throw new Error(
+        `seedDocker: unexpected status ${resp.status()} for tag ${tag}`
+      );
+    }
+  }
+
+  return { name, tags };
+}
+
+/**
+ * Publish an npm package with metadata.
+ * Uses the npm publish endpoint (PUT /npm/{name}).
+ */
+export async function seedNpm(
+  request: APIRequestContext
+): Promise<SeedResult['npm']> {
+  const name = 'e2e-ui-npm';
+  const version = '1.0.0';
+
+  const publishBody = {
+    name,
+    description: 'E2E UI contract test package',
+    versions: {
+      [version]: {
+        name,
+        version,
+        description: 'E2E UI contract test package',
+        author: 'nora-e2e',
+        license: 'MIT',
+        dist: {},
+      },
+    },
+    'dist-tags': { latest: version },
+    _attachments: {
+      [`${name}-${version}.tgz`]: {
+        data: 'dGVzdA==', // base64("test")
+        content_type: 'application/octet-stream',
+      },
+    },
+  };
+
+  const resp = await request.put(`/npm/${name}`, {
+    data: publishBody,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  // 201 = created, 409 = already exists — both OK
+  if (resp.status() !== 201 && resp.status() !== 409) {
+    throw new Error(`seedNpm: unexpected status ${resp.status()}`);
+  }
+
+  return { name, version };
+}
+
+/**
+ * Upload a raw file.
+ */
+export async function seedRaw(
+  request: APIRequestContext
+): Promise<SeedResult['raw']> {
+  const path = 'e2e-ui-raw/test.txt';
+
+  const resp = await request.put(`/raw/${path}`, {
+    data: 'e2e-ui-raw-test-content',
+  });
+
+  // 201 = created, 200 = overwritten, 409 = already exists — all OK
+  if (!resp.ok() && resp.status() !== 201 && resp.status() !== 409) {
+    throw new Error(`seedRaw: unexpected status ${resp.status()}`);
+  }
+
+  return { path };
+}
+
+/**
+ * Upload a Maven artifact (JAR + POM).
+ */
+export async function seedMaven(
+  request: APIRequestContext
+): Promise<SeedResult['maven']> {
+  const group = 'com/e2e';
+  const artifact = 'ui-test';
+  const version = '1.0';
+  const basePath = `/maven2/${group}/${artifact}/${version}`;
+
+  // Upload JAR
+  const jarResp = await request.put(
+    `${basePath}/${artifact}-${version}.jar`,
+    { data: 'fake-jar-content' }
+  );
+  if (jarResp.status() !== 201 && jarResp.status() !== 200 && jarResp.status() !== 409) {
+    throw new Error(`seedMaven jar: unexpected status ${jarResp.status()}`);
+  }
+
+  // Upload POM
+  const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.e2e</groupId>
+  <artifactId>${artifact}</artifactId>
+  <version>${version}</version>
+</project>`;
+
+  const pomResp = await request.put(
+    `${basePath}/${artifact}-${version}.pom`,
+    { data: pomContent }
+  );
+  if (pomResp.status() !== 201 && pomResp.status() !== 200 && pomResp.status() !== 409) {
+    throw new Error(`seedMaven pom: unexpected status ${pomResp.status()}`);
+  }
+
+  return { group, artifact, version, path: `${group}/${artifact}` };
+}
+
+/**
+ * Run all seeders. Returns a combined result object.
+ */
+export async function seedAll(
+  request: APIRequestContext
+): Promise<SeedResult> {
+  const [docker, npm, raw, maven] = await Promise.all([
+    seedDocker(request),
+    seedNpm(request),
+    seedRaw(request),
+    seedMaven(request),
+  ]);
+
+  return { docker, npm, raw, maven };
+}

--- a/tests/e2e/tests/ui-contracts.spec.ts
+++ b/tests/e2e/tests/ui-contracts.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * UI Contract Tests for NORA Registry
+ *
+ * Data-driven tests that verify every registry's web UI renders
+ * the correct structure: titles, columns, breadcrumbs, install
+ * commands, search inputs, and dashboard elements.
+ *
+ * Contracts are defined in ./contracts/registry-contracts.ts
+ * Seeding helpers are in ./contracts/seed.ts
+ */
+
+import { test, expect } from '@playwright/test';
+import {
+  REGISTRIES,
+  DASHBOARD,
+  SIDEBAR_LABELS,
+  getRegistry,
+} from './contracts/registry-contracts';
+import { seedAll, SeedResult } from './contracts/seed';
+
+// ── Shared seed state ──────────────────────────────────────────────
+
+let seed: SeedResult;
+
+test.beforeAll(async ({ request }) => {
+  seed = await seedAll(request);
+  // Give NORA a moment to index the seeded artifacts
+  await new Promise((r) => setTimeout(r, 1500));
+});
+
+// ══════════════════════════════════════════════════════════════════
+//  Dashboard
+// ══════════════════════════════════════════════════════════════════
+
+test.describe('Dashboard', () => {
+  test('page title contains Nora', async ({ page }) => {
+    await page.goto('/ui/');
+    await expect(page).toHaveTitle(/nora/i);
+  });
+
+  test('all 5 stats cards are visible', async ({ page }) => {
+    await page.goto('/ui/');
+    for (const id of DASHBOARD.statsIds) {
+      await expect(page.locator(id)).toBeVisible();
+    }
+  });
+
+  test('registry cards present (7–13)', async ({ page }) => {
+    await page.goto('/ui/');
+    const cards = page.locator(DASHBOARD.registryCardSelector);
+    const count = await cards.count();
+    expect(count).toBeGreaterThanOrEqual(7);
+    expect(count).toBeLessThanOrEqual(13);
+  });
+
+  test('mount points table visible', async ({ page }) => {
+    await page.goto('/ui/');
+    // Mount points table has "Mount Path" column header
+    await expect(
+      page.locator('th', { hasText: /mount\s*path/i }).first()
+    ).toBeVisible();
+  });
+
+  test('activity log section visible', async ({ page }) => {
+    await page.goto('/ui/');
+    await expect(page.locator('#activity-log')).toBeVisible();
+  });
+
+  test('sidebar has all navigation links', async ({ page }) => {
+    await page.goto('/ui/');
+    const sidebar = page.locator('#sidebar');
+    for (const label of SIDEBAR_LABELS) {
+      await expect(
+        sidebar.getByText(label, { exact: false }).first()
+      ).toBeVisible();
+    }
+  });
+
+  test('header has brand and language switcher', async ({ page }) => {
+    await page.goto('/ui/');
+    // Brand
+    await expect(page.getByText(/nora/i).first()).toBeVisible();
+    // Language switcher — EN and RU links (use exact match to avoid sidebar false positives)
+    await expect(page.getByRole('link', { name: 'EN', exact: true })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'RU', exact: true })).toBeVisible();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+//  Registry List Pages (loop over all 13)
+// ══════════════════════════════════════════════════════════════════
+
+for (const reg of REGISTRIES) {
+  test.describe(`List page: ${reg.displayName}`, () => {
+    test('H1 contains correct title', async ({ page }) => {
+      await page.goto(`/ui/${reg.list.slug}`);
+      const h1 = page.locator('h1');
+      await expect(h1).toContainText(reg.list.title);
+    });
+
+    test('table column headers match contract', async ({ page }) => {
+      await page.goto(`/ui/${reg.list.slug}`);
+      const headers = page.locator('thead th');
+      const count = await headers.count();
+      expect(count).toBe(reg.list.columnHeaders.length);
+      for (let i = 0; i < reg.list.columnHeaders.length; i++) {
+        await expect(headers.nth(i)).toContainText(
+          reg.list.columnHeaders[i],
+          { ignoreCase: true }
+        );
+      }
+    });
+
+    test('search input present with correct hx-get', async ({ page }) => {
+      await page.goto(`/ui/${reg.list.slug}`);
+      const input = page.locator('input[name="q"]');
+      await expect(input).toBeVisible();
+      const hxGet = await input.getAttribute('hx-get');
+      expect(hxGet).toBe(reg.list.searchEndpoint);
+    });
+
+    test('#repo-table-body present', async ({ page }) => {
+      await page.goto(`/ui/${reg.list.slug}`);
+      await expect(page.locator('#repo-table-body')).toBeAttached();
+    });
+
+    test('sidebar highlights active registry', async ({ page }) => {
+      await page.goto(`/ui/${reg.list.slug}`);
+      // The active nav item should have a distinct visual style
+      // Check that the sidebar contains a link to this registry (uses short sidebar name)
+      const sidebar = page.locator('#sidebar');
+      await expect(
+        sidebar.getByText(reg.sidebarName, { exact: false }).first()
+      ).toBeVisible();
+    });
+  });
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  Detail Pages — Docker
+// ══════════════════════════════════════════════════════════════════
+
+test.describe('Detail page: Docker', () => {
+  const contract = getRegistry('docker');
+
+  test('breadcrumb links back to /ui/docker', async ({ page }) => {
+    await page.goto(`/ui/docker/${seed.docker.name}`);
+    // Scope to main content to avoid matching sidebar link
+    const crumb = page.locator('main a[href="/ui/docker"]').first();
+    await expect(crumb).toBeVisible();
+    await expect(crumb).toContainText(contract.detail.breadcrumbRootText);
+  });
+
+  test('Pull Command section visible with correct format', async ({
+    page,
+  }) => {
+    await page.goto(`/ui/docker/${seed.docker.name}`);
+    // Docker uses hardcoded "Pull Command" heading
+    await expect(page.getByText('Pull Command')).toBeVisible();
+    // The pull command in a <code> element
+    const code = page.locator('code').first();
+    const text = await code.textContent();
+    expect(text).toMatch(contract.detail.installCommandPattern!);
+  });
+
+  test('tags table has correct column headers', async ({ page }) => {
+    await page.goto(`/ui/docker/${seed.docker.name}`);
+    for (const col of contract.detail.tableColumnHeaders) {
+      await expect(
+        page.locator('th', { hasText: new RegExp(col, 'i') }).first()
+      ).toBeAttached();
+    }
+  });
+
+  test('seeded tags are visible', async ({ page }) => {
+    await page.goto(`/ui/docker/${seed.docker.name}`);
+    for (const tag of seed.docker.tags) {
+      await expect(page.getByText(tag, { exact: true }).first()).toBeVisible();
+    }
+  });
+
+  test('no metadata panel', async ({ page }) => {
+    await page.goto(`/ui/docker/${seed.docker.name}`);
+    // Docker detail does not render a metadata panel
+    // Metadata panel would have id or class — verify absence
+    const content = await page.textContent('body');
+    expect(content).not.toContain('metadata-panel');
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+//  Detail Pages — npm
+// ══════════════════════════════════════════════════════════════════
+
+test.describe('Detail page: npm', () => {
+  const contract = getRegistry('npm');
+
+  test('breadcrumb links back to /ui/npm', async ({ page }) => {
+    await page.goto(`/ui/npm/${seed.npm.name}`);
+    // Scope to main content to avoid matching sidebar link
+    const crumb = page.locator('main a[href="/ui/npm"]').first();
+    await expect(crumb).toBeVisible();
+    await expect(crumb).toContainText(contract.detail.breadcrumbRootText);
+  });
+
+  test('#install-cmd visible and matches pattern', async ({ page }) => {
+    await page.goto(`/ui/npm/${seed.npm.name}`);
+    const cmd = page.locator('#install-cmd');
+    await expect(cmd).toBeVisible();
+    const text = await cmd.textContent();
+    expect(text).toMatch(contract.detail.installCommandPattern!);
+  });
+
+  test('#copy-btn present', async ({ page }) => {
+    await page.goto(`/ui/npm/${seed.npm.name}`);
+    await expect(page.locator('#copy-btn')).toBeVisible();
+  });
+
+  test('version rows with data-version attribute', async ({ page }) => {
+    await page.goto(`/ui/npm/${seed.npm.name}`);
+    const rows = page.locator('.version-row[data-version]');
+    const count = await rows.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+//  Detail Pages — Maven
+// ══════════════════════════════════════════════════════════════════
+
+test.describe('Detail page: Maven', () => {
+  const contract = getRegistry('maven');
+
+  test('Maven Dependency XML block present', async ({ page }) => {
+    const mavenPath = `${seed.maven.group}/${seed.maven.artifact}/${seed.maven.version}`;
+    await page.goto(`/ui/maven/${mavenPath}`);
+    // The dependency XML block should contain <dependency>, <groupId>, <artifactId>, <version>
+    const pre = page.locator('pre').first();
+    const text = await pre.textContent();
+    expect(text).toContain('<dependency>');
+    expect(text).toContain('<groupId>');
+    expect(text).toContain('<artifactId>');
+    expect(text).toContain('<version>');
+  });
+
+  test('artifacts table has Filename and Size columns', async ({ page }) => {
+    const mavenPath = `${seed.maven.group}/${seed.maven.artifact}/${seed.maven.version}`;
+    await page.goto(`/ui/maven/${mavenPath}`);
+    for (const col of contract.detail.tableColumnHeaders) {
+      await expect(
+        page.locator('th', { hasText: new RegExp(col, 'i') }).first()
+      ).toBeAttached();
+    }
+  });
+
+  test('artifact filenames linked to /maven2/...', async ({ page }) => {
+    const mavenPath = `${seed.maven.group}/${seed.maven.artifact}/${seed.maven.version}`;
+    await page.goto(`/ui/maven/${mavenPath}`);
+    const links = page.locator('a[href^="/maven2/"]');
+    const count = await links.count();
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('hierarchical breadcrumbs are clickable', async ({ page }) => {
+    const mavenPath = `${seed.maven.group}/${seed.maven.artifact}/${seed.maven.version}`;
+    await page.goto(`/ui/maven/${mavenPath}`);
+    // Breadcrumb root: "Maven" linking to /ui/maven (scope to main to avoid sidebar)
+    const root = page.locator('main a[href="/ui/maven"]').first();
+    await expect(root).toBeVisible();
+    await expect(root).toContainText(contract.detail.breadcrumbRootText);
+    // Intermediate segments should be clickable links
+    const crumbLinks = page.locator(
+      'a[href^="/ui/maven/"]'
+    );
+    const count = await crumbLinks.count();
+    // At least 2 intermediate segments for com/e2e/ui-test/1.0
+    expect(count).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+//  Detail Pages — Raw
+// ══════════════════════════════════════════════════════════════════
+
+test.describe('Detail page: Raw', () => {
+  const contract = getRegistry('raw');
+
+  test('breadcrumb links back to Raw', async ({ page }) => {
+    // raw path is "e2e-ui-raw" (the directory group)
+    const rawGroup = seed.raw.path.split('/')[0];
+    await page.goto(`/ui/raw/${rawGroup}`);
+    // Scope to main content to avoid matching sidebar link
+    const crumb = page.locator('main a[href="/ui/raw"]').first();
+    await expect(crumb).toBeVisible();
+    await expect(crumb).toContainText('Raw');
+  });
+
+  test('install command matches curl pattern', async ({ page }) => {
+    const rawGroup = seed.raw.path.split('/')[0];
+    await page.goto(`/ui/raw/${rawGroup}`);
+    const cmd = page.locator('#install-cmd');
+    await expect(cmd).toBeVisible();
+    const text = await cmd.textContent();
+    expect(text).toMatch(contract.detail.installCommandPattern!);
+  });
+
+  test('file visible in table', async ({ page }) => {
+    const rawGroup = seed.raw.path.split('/')[0];
+    await page.goto(`/ui/raw/${rawGroup}`);
+    // The nested file "test.txt" should be visible
+    await expect(page.getByText('test.txt').first()).toBeVisible();
+  });
+});
+
+// ══════════════════════════════════════════════════════════════════
+//  Special Interactions
+// ══════════════════════════════════════════════════════════════════
+
+test.describe('Special interactions', () => {
+  test('search input triggers HTMX update of #repo-table-body', async ({
+    page,
+  }) => {
+    await page.goto('/ui/npm');
+    const input = page.locator('input[name="q"]');
+    await expect(input).toBeVisible();
+    // Verify HTMX attributes
+    const hxTarget = await input.getAttribute('hx-target');
+    expect(hxTarget).toBe('#repo-table-body');
+    const hxTrigger = await input.getAttribute('hx-trigger');
+    expect(hxTrigger).toContain('keyup');
+  });
+
+  test('NuGet version row has data-version for interactive install', async ({
+    page,
+    request,
+  }) => {
+    // Seed a NuGet package first
+    const nugetPkg = 'e2e-ui-nuget';
+    const nupkgData = Buffer.alloc(32); // minimal .nupkg stub
+    const resp = await request.put(
+      `/nuget/v2/package/${nugetPkg}/${nugetPkg}.1.0.0.nupkg`,
+      {
+        data: nupkgData,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      }
+    );
+    // Ignore errors — package may already exist or endpoint may differ
+    if (resp.ok() || resp.status() === 201 || resp.status() === 409) {
+      await page.goto(`/ui/nuget/${nugetPkg}`);
+      const rows = page.locator('.version-row[data-version]');
+      const count = await rows.count();
+      if (count > 0) {
+        // Clicking a version row should exist without error
+        const firstVersion = await rows.first().getAttribute('data-version');
+        expect(firstVersion).toBeTruthy();
+      }
+    }
+  });
+});

--- a/tests/e2e/tests/ui-screenshots.spec.ts
+++ b/tests/e2e/tests/ui-screenshots.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Visual Regression Tests for NORA Registry UI
+ *
+ * Uses Playwright's toHaveScreenshot() for pixel-level comparison.
+ * Baselines are committed to git — they ARE the visual contract.
+ *
+ * First run:  npx playwright test ui-screenshots --update-snapshots
+ * Later runs: npx playwright test ui-screenshots
+ *
+ * Tolerance: 1% pixel diff (maxDiffPixelRatio: 0.01)
+ * Viewport:  1280x720 (fixed for deterministic screenshots)
+ */
+
+import { test, expect } from '@playwright/test';
+import { REGISTRIES } from './contracts/registry-contracts';
+import { seedAll, SeedResult } from './contracts/seed';
+
+let seed: SeedResult;
+
+test.beforeAll(async ({ request }) => {
+  seed = await seedAll(request);
+  await new Promise((r) => setTimeout(r, 1500));
+});
+
+// Fixed viewport for stable screenshots
+test.use({ viewport: { width: 1280, height: 720 } });
+
+// ── Dashboard ──────────────────────────────────────────────────
+
+test('dashboard', async ({ page }) => {
+  await page.goto('/ui/');
+  // Wait for stats to load
+  await page.waitForSelector('#stat-downloads', { state: 'visible' });
+  await expect(page).toHaveScreenshot('dashboard.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+// ── Registry List Pages ────────────────────────────────────────
+
+for (const reg of REGISTRIES) {
+  test(`list: ${reg.slug}`, async ({ page }) => {
+    await page.goto(`/ui/${reg.list.slug}`);
+    await page.waitForSelector('#repo-table-body', { state: 'attached' });
+    // Small delay for any HTMX-driven content to settle
+    await page.waitForTimeout(300);
+    await expect(page).toHaveScreenshot(`list-${reg.slug}.png`, {
+      maxDiffPixelRatio: 0.01,
+    });
+  });
+}
+
+// ── Detail Pages (seeded registries only) ──────────────────────
+
+test('detail: docker', async ({ page }) => {
+  await page.goto(`/ui/docker/${seed.docker.name}`);
+  await page.waitForSelector('h1', { state: 'visible' });
+  await expect(page).toHaveScreenshot('detail-docker.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('detail: npm', async ({ page }) => {
+  await page.goto(`/ui/npm/${seed.npm.name}`);
+  await page.waitForSelector('#install-cmd', { state: 'visible' });
+  await expect(page).toHaveScreenshot('detail-npm.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('detail: maven', async ({ page }) => {
+  const mavenPath = `${seed.maven.group}/${seed.maven.artifact}/${seed.maven.version}`;
+  await page.goto(`/ui/maven/${mavenPath}`);
+  await page.waitForSelector('pre', { state: 'visible' });
+  await expect(page).toHaveScreenshot('detail-maven.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});
+
+test('detail: raw', async ({ page }) => {
+  const rawGroup = seed.raw.path.split('/')[0];
+  await page.goto(`/ui/raw/${rawGroup}`);
+  await page.waitForSelector('h1', { state: 'visible' });
+  await expect(page).toHaveScreenshot('detail-raw.png', {
+    maxDiffPixelRatio: 0.01,
+  });
+});


### PR DESCRIPTION
## Summary

- **Null byte rejection middleware**: outermost Axum layer returns 400 for paths containing `\0`, `%00`, or `%2500`. Previously caused 500/panic in handlers.
- **Cargo proxy User-Agent**: `nora/<version>` header on the shared HTTP client. crates.io and sparse index mirrors return 403 without it.
- **Version bump**: 0.9.2 → 0.9.3 (Cargo.toml, openapi.rs)
- **Playwright E2E tests**: contract tests for all 13 registry UI pages + visual regression screenshots

## Test plan

- [x] `cargo test` — 1204 passed, 0 failed
- [x] `cargo clippy -D warnings` — clean
- [x] E2E on AI server: 22/22 PASS (all protocols)
- [x] A/B on demo.getnora.io (HTTPS, Let's Encrypt):
  - v0.9.2: 22 PASS / 5 FAIL
  - v0.9.3: 26 PASS / 1 FAIL (1 = raw pull auth, expected)
  - 3 bugs fixed, 0 regressions