### PR TITLE
ci: fix SLSA provenance — use tag ref instead of SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,7 +317,7 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.build.outputs.hash }}"
       upload-assets: true


### PR DESCRIPTION
## Summary

- SLSA Provenance/final fails on v0.9.3 release (3/3 runs)
- Root cause: `generate-builder.sh` in slsa-github-generator v2.1.0 validates `BUILDER_REF` format and rejects raw SHA, expecting `refs/tags/vX.Y.Z`
- After re-tagging v0.9.3, GitHub Actions rerun passes SHA instead of tag ref
- Fix: use `@v2.1.0` tag ref instead of `@f7dd8c54c...` SHA pin

## Error

```
Invalid ref: f7dd8c54c2067bafc12ca7a55595d5ee9b75204a. Expected ref of the form refs/tags/vX.Y.Z
```