### PR TITLE
ci: fix SLSA provenance with SHA-pinned reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,7 @@ jobs:
     with:
       base64-subjects: "${{ needs.build.outputs.hash }}"
       upload-assets: true
+      compile-generator: true
 
   release:
     name: GitHub Release


### PR DESCRIPTION
## Summary

SLSA Provenance fails on v0.9.3 release — `generate-builder.sh` rejects raw SHA as `BUILDER_REF`.

## Root cause

GitHub runner image `20260525.161` (updated May 25) changed how reusable workflow refs are resolved. Previously SHA was resolved to `refs/tags/v2.1.0`, now raw SHA is passed through. Known upstream bug: slsa-framework/slsa-github-generator#4503.

## Fix

Set `compile-generator: true` — compiles SLSA generator from source at the pinned SHA instead of downloading pre-built binary by tag. SHA pin stays intact, OpenSSF Scorecard unaffected.