### PR TITLE
fix(docker): use 127.0.0.1 in HEALTHCHECK and support IPv6 bind addresses (#569)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,7 +85,7 @@ VOLUME ["/data"]
 USER nora
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -sf http://localhost:4000/health || exit 1
+  CMD curl -sf http://127.0.0.1:4000/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/nora"]
 CMD ["serve"]
@@ -113,7 +113,7 @@ VOLUME ["/data"]
 USER nora
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD curl -sf http://localhost:4000/health || exit 1
+  CMD curl -sf http://127.0.0.1:4000/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/nora"]
 CMD ["serve"]
@@ -140,7 +140,7 @@ VOLUME ["/data"]
 USER nora
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -q --spider http://localhost:4000/health || exit 1
+  CMD wget -q --spider http://127.0.0.1:4000/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/nora"]
 CMD ["serve"]

--- a/nora-registry/src/config/server.rs
+++ b/nora-registry/src/config/server.rs
@@ -31,6 +31,18 @@ pub struct TlsConfig {
 }
 
 impl ServerConfig {
+    /// Format bind address for `TcpListener::bind`.
+    ///
+    /// IPv6 addresses contain colons and need bracket notation (`[::]:4000`)
+    /// to avoid ambiguity with the host:port separator (#569).
+    pub fn bind_addr(&self) -> String {
+        if self.host.contains(':') {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+
     /// Apply environment variable overrides for server config.
     pub(super) fn apply_env_overrides(&mut self) {
         if let Ok(val) = env::var("NORA_HOST") {
@@ -45,6 +57,45 @@ impl ServerConfig {
         if let Ok(val) = env::var("NORA_BODY_LIMIT_MB") {
             super::parse_env_warn("NORA_BODY_LIMIT_MB", &val, &mut self.body_limit_mb);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn server(host: &str, port: u16) -> ServerConfig {
+        ServerConfig {
+            host: host.to_string(),
+            port,
+            public_url: None,
+            body_limit_mb: 2048,
+        }
+    }
+
+    #[test]
+    fn bind_addr_ipv4() {
+        assert_eq!(server("0.0.0.0", 4000).bind_addr(), "0.0.0.0:4000");
+        assert_eq!(server("127.0.0.1", 8080).bind_addr(), "127.0.0.1:8080");
+    }
+
+    #[test]
+    fn bind_addr_ipv6() {
+        assert_eq!(server("::", 4000).bind_addr(), "[::]:4000");
+        assert_eq!(server("::1", 4000).bind_addr(), "[::1]:4000");
+        assert_eq!(
+            server("2001:db8::1", 4000).bind_addr(),
+            "[2001:db8::1]:4000"
+        );
+    }
+
+    #[test]
+    fn bind_addr_hostname() {
+        assert_eq!(server("localhost", 4000).bind_addr(), "localhost:4000");
+        assert_eq!(
+            server("registry.example.com", 443).bind_addr(),
+            "registry.example.com:443"
+        );
     }
 }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1271,7 +1271,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         registry::docker::cleanup_upload_temp_dir(&state.config.storage.path);
     }
 
-    let addr = format!("{}:{}", state.config.server.host, state.config.server.port);
+    let addr = state.config.server.bind_addr();
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .expect("Failed to bind");

--- a/scripts/post-release-gate.sh
+++ b/scripts/post-release-gate.sh
@@ -10,7 +10,8 @@ REPO="getnora-io/nora"
 GHCR_REGISTRY="ghcr.io/getnora-io/nora"
 DOCKERHUB_REGISTRY="docker.io/getnora/nora"
 VARIANTS=("" "-redos" "-astra")
-PORT="${GATE_PORT:-14100}"
+BINARY_PORT="${GATE_PORT:-14100}"
+DOCKER_PORT="$((BINARY_PORT + 100))"
 PASSED=0
 FAILED=0
 VERSIONS_COLLECTED=()
@@ -129,7 +130,7 @@ if [ -f "$WORK_DIR/nora-linux-amd64" ] && [ -f "$WORK_DIR/nora-linux-amd64.sha25
 
     # Health check via serve
     NORA_HOST=127.0.0.1 \
-    NORA_PORT=$PORT \
+    NORA_PORT=$BINARY_PORT \
     NORA_STORAGE_PATH="$WORK_DIR/data" \
     NORA_RATE_LIMIT_ENABLED=false \
     "$WORK_DIR/nora-linux-amd64" serve &
@@ -137,7 +138,7 @@ if [ -f "$WORK_DIR/nora-linux-amd64" ] && [ -f "$WORK_DIR/nora-linux-amd64.sha25
 
     HEALTHY=false
     for _ in $(seq 1 20); do
-        if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+        if curl -sf "http://127.0.0.1:${BINARY_PORT}/health" >/dev/null 2>&1; then
             HEALTHY=true
             break
         fi
@@ -145,7 +146,7 @@ if [ -f "$WORK_DIR/nora-linux-amd64" ] && [ -f "$WORK_DIR/nora-linux-amd64.sha25
     done
 
     if [ "$HEALTHY" = true ]; then
-        HEALTH_JSON=$(curl -sf "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo "{}")
+        HEALTH_JSON=$(curl -sf "http://127.0.0.1:${BINARY_PORT}/health" 2>/dev/null || echo "{}")
         HEALTH_VERSION=$(echo "$HEALTH_JSON" | jq -r '.version // empty' 2>/dev/null || echo "")
         if [ "$HEALTH_VERSION" = "$VERSION" ]; then
             pass "Binary /health version = $VERSION"
@@ -185,15 +186,15 @@ for registry in "$GHCR_REGISTRY" "$DOCKERHUB_REGISTRY"; do
 
         # Run container, health check, verify version
         docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
-        docker run --rm -d \
+        docker run -d \
             --name "$CONTAINER_NAME" \
-            -p "${PORT}:4000" \
+            -p "${DOCKER_PORT}:4000" \
             -e NORA_HOST=0.0.0.0 \
             "$IMAGE" >/dev/null 2>&1
 
         HEALTHY=false
         for _ in $(seq 1 15); do
-            if curl -sf "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+            if curl -sf "http://127.0.0.1:${DOCKER_PORT}/health" >/dev/null 2>&1; then
                 HEALTHY=true
                 break
             fi
@@ -201,7 +202,7 @@ for registry in "$GHCR_REGISTRY" "$DOCKERHUB_REGISTRY"; do
         done
 
         if [ "$HEALTHY" = true ]; then
-            DOCKER_HEALTH=$(curl -sf "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo "{}")
+            DOCKER_HEALTH=$(curl -sf "http://127.0.0.1:${DOCKER_PORT}/health" 2>/dev/null || echo "{}")
             DOCKER_VERSION=$(echo "$DOCKER_HEALTH" | jq -r '.version // empty' 2>/dev/null || echo "")
             if [ "$DOCKER_VERSION" = "$VERSION" ]; then
                 pass "Docker $LABEL /health version = $VERSION"
@@ -211,6 +212,9 @@ for registry in "$GHCR_REGISTRY" "$DOCKERHUB_REGISTRY"; do
                 [ -n "$DOCKER_VERSION" ] && VERSIONS_COLLECTED+=("docker-${LABEL}=$DOCKER_VERSION")
             fi
         else
+            echo "  --- docker logs $LABEL ---"
+            docker logs "$CONTAINER_NAME" 2>&1 | tail -20 || true
+            echo "  --- end logs ---"
             fail "Docker $LABEL did not become healthy"
         fi
 


### PR DESCRIPTION
## Summary

- Replace `localhost` with `127.0.0.1` in all three `HEALTHCHECK` directives (Alpine, RED OS, Astra) to avoid IPv6 resolution failures when `localhost` maps to `::1`
- Add `ServerConfig::bind_addr()` method that wraps IPv6 addresses in bracket notation (`[::]:4000`) so `TcpListener::bind` can parse them correctly
- Add unit tests covering IPv4, IPv6, and hostname bind address formatting

## Test plan

- [x] `cargo test` — 1207 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] semgrep — no new findings
- [x] arch-predict — 0 errors
- [x] cargo-deny + cargo-audit — clean
- [ ] Manual: `docker build && docker run` with IPv6-enabled Docker network — HEALTHCHECK passes

Closes #569