### PR TITLE
fix(docker): add NORA_PUBLIC_URL to release Dockerfile

### DIFF
--- a/deploy/Dockerfile.release
+++ b/deploy/Dockerfile.release
@@ -23,6 +23,7 @@ RUN chmod +x /usr/local/bin/nora
 ENV RUST_LOG=info \
     NORA_HOST=0.0.0.0 \
     NORA_PORT=4000 \
+    NORA_PUBLIC_URL=http://localhost:4000 \
     NORA_STORAGE_PATH=/data/storage \
     NORA_AUTH_TOKEN_STORAGE=/data/tokens
 
@@ -31,7 +32,7 @@ VOLUME ["/data"]
 USER nora
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget -q --spider http://localhost:4000/health || exit 1
+  CMD wget -q --spider http://127.0.0.1:4000/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/nora"]
 CMD ["serve"]


### PR DESCRIPTION
## Summary

- Add missing `NORA_PUBLIC_URL=http://localhost:4000` to `deploy/Dockerfile.release`
- Fix HEALTHCHECK to use `127.0.0.1` instead of `localhost` (IPv6 compat)

`deploy/Dockerfile.release` is used by the release workflow for the Alpine multi-arch image. It was missing `NORA_PUBLIC_URL` (added to the main `Dockerfile` in 7b36476 but not propagated here), causing the Alpine container to panic on startup when `NORA_HOST=0.0.0.0`.

This is the root cause of the post-release gate failure on v0.9.3 — only the Alpine image was affected because RED OS and Astra are built from the main `Dockerfile` which already has the fix.

## Test plan

- [x] `docker inspect` confirmed Alpine v0.9.3 image missing `NORA_PUBLIC_URL`
- [x] `docker inspect` confirmed RED OS v0.9.3 image has `NORA_PUBLIC_URL` (built from main Dockerfile)
- [x] `docker logs` on failed container shows panic: "NORA_PUBLIC_URL is required when host is '0.0.0.0'"