### PR TITLE
feat(registry): align serve-stale across all handlers

### DIFF
--- a/nora-registry/src/config/registry/conan.rs
+++ b/nora-registry/src/config/registry/conan.rs
@@ -19,6 +19,8 @@ pub struct ConanConfig {
     pub proxy_timeout_dl: u64,
     #[serde(default = "super::super::default_metadata_ttl")]
     pub metadata_ttl: i64,
+    #[serde(default = "super::super::default_true")]
+    pub serve_stale: bool,
 }
 
 fn default_conan_proxy() -> Option<String> {
@@ -34,6 +36,7 @@ impl Default for ConanConfig {
             proxy_timeout: 30,
             proxy_timeout_dl: 120,
             metadata_ttl: 300,
+            serve_stale: true,
         }
     }
 }
@@ -65,6 +68,9 @@ impl ConanConfig {
         }
         if let Ok(val) = env::var("NORA_CONAN_METADATA_TTL") {
             super::super::parse_env_warn("NORA_CONAN_METADATA_TTL", &val, &mut self.metadata_ttl);
+        }
+        if let Ok(val) = env::var("NORA_CONAN_SERVE_STALE") {
+            self.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
     }
 }

--- a/nora-registry/src/config/registry/gems.rs
+++ b/nora-registry/src/config/registry/gems.rs
@@ -17,6 +17,8 @@ pub struct GemsConfig {
     pub proxy_timeout: u64,
     #[serde(default = "super::super::default_metadata_ttl")]
     pub metadata_ttl: i64,
+    #[serde(default = "super::super::default_true")]
+    pub serve_stale: bool,
 }
 
 fn default_gems_proxy() -> Option<String> {
@@ -31,6 +33,7 @@ impl Default for GemsConfig {
             proxy_auth: None,
             proxy_timeout: 30,
             metadata_ttl: 300,
+            serve_stale: true,
         }
     }
 }
@@ -55,6 +58,9 @@ impl GemsConfig {
         }
         if let Ok(val) = env::var("NORA_GEMS_METADATA_TTL") {
             super::super::parse_env_warn("NORA_GEMS_METADATA_TTL", &val, &mut self.metadata_ttl);
+        }
+        if let Ok(val) = env::var("NORA_GEMS_SERVE_STALE") {
+            self.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
     }
 }

--- a/nora-registry/src/config/registry/npm.rs
+++ b/nora-registry/src/config/registry/npm.rs
@@ -17,6 +17,8 @@ pub struct NpmConfig {
     pub proxy_timeout: u64,
     #[serde(default = "super::super::default_metadata_ttl")]
     pub metadata_ttl: i64,
+    #[serde(default = "super::super::default_true")]
+    pub serve_stale: bool,
 }
 
 impl Default for NpmConfig {
@@ -27,6 +29,7 @@ impl Default for NpmConfig {
             proxy_auth: None,
             proxy_timeout: 30,
             metadata_ttl: 300,
+            serve_stale: true,
         }
     }
 }
@@ -51,6 +54,9 @@ impl NpmConfig {
         }
         if let Ok(val) = env::var("NORA_NPM_METADATA_TTL") {
             super::super::parse_env_warn("NORA_NPM_METADATA_TTL", &val, &mut self.metadata_ttl);
+        }
+        if let Ok(val) = env::var("NORA_NPM_SERVE_STALE") {
+            self.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
     }
 }

--- a/nora-registry/src/config/registry/pub_dart.rs
+++ b/nora-registry/src/config/registry/pub_dart.rs
@@ -17,6 +17,8 @@ pub struct PubDartConfig {
     pub proxy_timeout: u64,
     #[serde(default = "super::super::default_metadata_ttl")]
     pub metadata_ttl: i64,
+    #[serde(default = "super::super::default_true")]
+    pub serve_stale: bool,
 }
 
 fn default_pub_proxy() -> Option<String> {
@@ -31,6 +33,7 @@ impl Default for PubDartConfig {
             proxy_auth: None,
             proxy_timeout: 30,
             metadata_ttl: 300,
+            serve_stale: true,
         }
     }
 }
@@ -55,6 +58,9 @@ impl PubDartConfig {
         }
         if let Ok(val) = env::var("NORA_PUB_METADATA_TTL") {
             super::super::parse_env_warn("NORA_PUB_METADATA_TTL", &val, &mut self.metadata_ttl);
+        }
+        if let Ok(val) = env::var("NORA_PUB_SERVE_STALE") {
+            self.serve_stale = !matches!(val.as_str(), "false" | "0");
         }
     }
 }

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -186,8 +186,9 @@ async fn recipe_latest(
     let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
     let storage_key = format!("conan/{}/latest.json", ref_str);
 
-    // TTL cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Eager cache read — preserve data for serve-stale fallback
+    let cached_data = state.storage.get(&storage_key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
@@ -204,7 +205,7 @@ async fn recipe_latest(
         ref_str
     );
 
-    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str, cached_data).await
 }
 
 // ── Recipe revisions (TTL cached) ─────────────────────────────────────
@@ -220,7 +221,8 @@ async fn recipe_revisions(
     let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
     let storage_key = format!("conan/{}/revisions.json", ref_str);
 
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    let cached_data = state.storage.get(&storage_key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
@@ -237,7 +239,7 @@ async fn recipe_revisions(
         ref_str
     );
 
-    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str, cached_data).await
 }
 
 // ── Recipe file listing (immutable — scoped to revision) ──────────────
@@ -419,7 +421,8 @@ async fn package_latest(
         ref_str, rrev, pkg_id
     );
 
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    let cached_data = state.storage.get(&storage_key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
@@ -438,7 +441,7 @@ async fn package_latest(
         pkg_id
     );
 
-    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str, cached_data).await
 }
 
 // ── Package revisions (TTL cached) ────────────────────────────────────
@@ -470,7 +473,8 @@ async fn package_revisions(
         ref_str, rrev, pkg_id
     );
 
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    let cached_data = state.storage.get(&storage_key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.conan.metadata_ttl) {
                 state.metrics.record_download("conan");
@@ -489,7 +493,7 @@ async fn package_revisions(
         pkg_id
     );
 
-    fetch_and_cache_json(&state, &url, &storage_key, &ref_str).await
+    fetch_and_cache_json(&state, &url, &storage_key, &ref_str, cached_data).await
 }
 
 // ── Package file listing (immutable — scoped to PREV) ─────────────────
@@ -674,6 +678,7 @@ async fn fetch_and_cache_json(
     url: &str,
     storage_key: &str,
     artifact: &str,
+    cached: Option<Bytes>,
 ) -> Response {
     match proxy_fetch_text(
         &state.http_client,
@@ -705,6 +710,35 @@ async fn fetch_and_cache_json(
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(e) => {
+            if let Some(ref data) = cached {
+                if state.config.conan.serve_stale {
+                    tracing::warn!(
+                        registry = "conan",
+                        artifact,
+                        error = ?e,
+                        "Conan upstream error, serving stale metadata"
+                    );
+                    return (
+                        StatusCode::OK,
+                        [
+                            (
+                                header::CONTENT_TYPE,
+                                HeaderValue::from_static("application/json"),
+                            ),
+                            (
+                                header::CACHE_CONTROL,
+                                HeaderValue::from_static("public, max-age=0, must-revalidate"),
+                            ),
+                            (
+                                axum::http::header::HeaderName::from_static("x-nora-stale"),
+                                HeaderValue::from_static("true"),
+                            ),
+                        ],
+                        data.to_vec(),
+                    )
+                        .into_response();
+                }
+            }
             tracing::debug!(url, error = ?e, "Conan upstream error");
             StatusCode::BAD_GATEWAY.into_response()
         }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1486,7 +1486,17 @@ async fn get_manifest(
                 reference = %reference,
                 "Upstream failed, serving stale cached manifest"
             );
-            return serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
+            let mut response =
+                serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
+            response.headers_mut().insert(
+                axum::http::header::HeaderName::from_static("x-nora-stale"),
+                axum::http::header::HeaderValue::from_static("true"),
+            );
+            response.headers_mut().insert(
+                axum::http::header::CACHE_CONTROL,
+                axum::http::header::HeaderValue::from_static("public, max-age=0, must-revalidate"),
+            );
+            return response;
         }
     }
 

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -65,8 +65,9 @@ async fn prerelease_specs_index(State(state): State<AppState>) -> Response {
 async fn fetch_index(state: &AppState, filename: &str) -> Response {
     let storage_key = format!("gems/{}", filename);
 
-    // Check TTL: if cached and fresh, serve from cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Eager cache read — preserve data for serve-stale fallback
+    let cached_data = state.storage.get(&storage_key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.gems.metadata_ttl) {
                 state.metrics.record_download("gems");
@@ -116,6 +117,35 @@ async fn fetch_index(state: &AppState, filename: &str) -> Response {
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
+            if let Some(ref data) = cached_data {
+                if state.config.gems.serve_stale {
+                    tracing::warn!(
+                        registry = "gems",
+                        filename,
+                        error = ?e,
+                        "RubyGems upstream error, serving stale index"
+                    );
+                    return (
+                        StatusCode::OK,
+                        [
+                            (
+                                header::CONTENT_TYPE,
+                                HeaderValue::from_static("application/gzip"),
+                            ),
+                            (
+                                header::CACHE_CONTROL,
+                                HeaderValue::from_static("public, max-age=0, must-revalidate"),
+                            ),
+                            (
+                                axum::http::header::HeaderName::from_static("x-nora-stale"),
+                                HeaderValue::from_static("true"),
+                            ),
+                        ],
+                        data.to_vec(),
+                    )
+                        .into_response();
+                }
+            }
             tracing::debug!(filename, error = ?e, "RubyGems upstream error");
             StatusCode::BAD_GATEWAY.into_response()
         }
@@ -148,8 +178,9 @@ async fn compact_index(
 
     let storage_key = format!("gems/info/{}", name);
 
-    // Check TTL cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Eager cache read — preserve data for serve-stale fallback
+    let cached_data = state.storage.get(&storage_key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&storage_key).await {
             if is_within_ttl(meta.modified, state.config.gems.metadata_ttl) {
                 state.metrics.record_download("gems");
@@ -198,6 +229,35 @@ async fn compact_index(
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
+            if let Some(ref data) = cached_data {
+                if state.config.gems.serve_stale {
+                    tracing::warn!(
+                        registry = "gems",
+                        name = %name,
+                        error = ?e,
+                        "RubyGems upstream error, serving stale compact index"
+                    );
+                    return (
+                        StatusCode::OK,
+                        [
+                            (
+                                header::CONTENT_TYPE,
+                                HeaderValue::from_static("text/plain; charset=utf-8"),
+                            ),
+                            (
+                                header::CACHE_CONTROL,
+                                HeaderValue::from_static("public, max-age=0, must-revalidate"),
+                            ),
+                            (
+                                axum::http::header::HeaderName::from_static("x-nora-stale"),
+                                HeaderValue::from_static("true"),
+                            ),
+                        ],
+                        data.to_vec(),
+                    )
+                        .into_response();
+                }
+            }
             tracing::debug!(error = ?e, "RubyGems compact index error");
             StatusCode::BAD_GATEWAY.into_response()
         }

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -170,7 +170,36 @@ async fn handle_request(
                     if let Some(fresh) = refetch_metadata(&state, &path, &key).await {
                         return with_content_type(false, fresh.into()).into_response();
                     }
-                    // Upstream failed — serve stale cache
+                    // Upstream failed — serve stale if configured, otherwise 502
+                    if state.config.npm.serve_stale {
+                        tracing::warn!(
+                            registry = "npm",
+                            path = %path,
+                            "npm upstream unavailable, serving stale metadata"
+                        );
+                        return (
+                            StatusCode::OK,
+                            [
+                                (
+                                    header::CONTENT_TYPE,
+                                    axum::http::HeaderValue::from_static("application/json"),
+                                ),
+                                (
+                                    header::CACHE_CONTROL,
+                                    axum::http::HeaderValue::from_static(
+                                        "public, max-age=0, must-revalidate",
+                                    ),
+                                ),
+                                (
+                                    axum::http::header::HeaderName::from_static("x-nora-stale"),
+                                    axum::http::HeaderValue::from_static("true"),
+                                ),
+                            ],
+                            data.to_vec(),
+                        )
+                            .into_response();
+                    }
+                    return StatusCode::BAD_GATEWAY.into_response();
                 }
             }
             return with_content_type(false, data).into_response();

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -84,7 +84,8 @@ async fn search_packages(State(state): State<AppState>, RawQuery(raw_query): Raw
         hex::encode(sha2::Sha256::digest(raw_query.as_bytes()))
     );
 
-    if let Ok(data) = state.storage.get(&key).await {
+    let cached_data = state.storage.get(&key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&key).await {
             if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
                 return pub_json_response(data.to_vec());
@@ -116,6 +117,17 @@ async fn search_packages(State(state): State<AppState>, RawQuery(raw_query): Raw
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
+            if let Some(ref data) = cached_data {
+                if state.config.pub_dart.serve_stale {
+                    tracing::warn!(
+                        registry = "pub",
+                        query = raw_query,
+                        error = ?e,
+                        "Pub upstream error, serving stale search results"
+                    );
+                    return pub_stale_json_response(data.to_vec());
+                }
+            }
             tracing::debug!(error = ?e, query = raw_query, "pub search upstream error");
             StatusCode::BAD_GATEWAY.into_response()
         }
@@ -149,7 +161,8 @@ async fn package_listing(
     }
 
     let key = format!("pub/api/packages/{}.json", package);
-    if let Ok(data) = state.storage.get(&key).await {
+    let cached_data = state.storage.get(&key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&key).await {
             if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
                 return pub_json_response(data.to_vec());
@@ -178,6 +191,17 @@ async fn package_listing(
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
+            if let Some(ref data) = cached_data {
+                if state.config.pub_dart.serve_stale {
+                    tracing::warn!(
+                        registry = "pub",
+                        package = %package,
+                        error = ?e,
+                        "Pub upstream error, serving stale package listing"
+                    );
+                    return pub_stale_json_response(data.to_vec());
+                }
+            }
             tracing::debug!(error = ?e, package, "pub package upstream error");
             StatusCode::BAD_GATEWAY.into_response()
         }
@@ -197,7 +221,8 @@ async fn version_metadata(
     }
 
     let key = format!("pub/api/packages/{}/versions/{}.json", package, version);
-    if let Ok(data) = state.storage.get(&key).await {
+    let cached_data = state.storage.get(&key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&key).await {
             if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
                 return pub_json_response(data.to_vec());
@@ -226,6 +251,18 @@ async fn version_metadata(
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
+            if let Some(ref data) = cached_data {
+                if state.config.pub_dart.serve_stale {
+                    tracing::warn!(
+                        registry = "pub",
+                        package = %package,
+                        version = %version,
+                        error = ?e,
+                        "Pub upstream error, serving stale version metadata"
+                    );
+                    return pub_stale_json_response(data.to_vec());
+                }
+            }
             tracing::debug!(error = ?e, package, version, "pub version upstream error");
             StatusCode::BAD_GATEWAY.into_response()
         }
@@ -245,7 +282,8 @@ async fn package_advisories(
     }
 
     let key = format!("pub/api/packages/{}/advisories.json", package);
-    if let Ok(data) = state.storage.get(&key).await {
+    let cached_data = state.storage.get(&key).await.ok();
+    if let Some(ref data) = cached_data {
         if let Some(meta) = state.storage.stat(&key).await {
             if is_within_ttl(meta.modified, state.config.pub_dart.metadata_ttl) {
                 return pub_json_response(data.to_vec());
@@ -271,6 +309,17 @@ async fn package_advisories(
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
+            if let Some(ref data) = cached_data {
+                if state.config.pub_dart.serve_stale {
+                    tracing::warn!(
+                        registry = "pub",
+                        package = %package,
+                        error = ?e,
+                        "Pub upstream error, serving stale advisories"
+                    );
+                    return pub_stale_json_response(data.to_vec());
+                }
+            }
             tracing::debug!(error = ?e, package, "pub advisories upstream error");
             StatusCode::BAD_GATEWAY.into_response()
         }
@@ -447,6 +496,28 @@ fn pub_json_response(data: Vec<u8>) -> Response {
             (
                 header::CACHE_CONTROL,
                 HeaderValue::from_static("public, max-age=300"),
+            ),
+        ],
+        data,
+    )
+        .into_response()
+}
+
+fn pub_stale_json_response(data: Vec<u8>) -> Response {
+    (
+        StatusCode::OK,
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static(PUB_CONTENT_TYPE),
+            ),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=0, must-revalidate"),
+            ),
+            (
+                axum::http::header::HeaderName::from_static("x-nora-stale"),
+                HeaderValue::from_static("true"),
             ),
         ],
         data,

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -105,6 +105,7 @@ fn build_context(
             proxy_auth: None,
             proxy_timeout: 5,
             metadata_ttl: -1,
+            serve_stale: true,
         },
         pypi: PypiConfig {
             enabled: true,


### PR DESCRIPTION
## Summary

- Add `serve_stale` config toggle to npm, Gems, Conan, and Pub/Dart handlers (default: true, env: `NORA_*_SERVE_STALE`)
- Add `X-Nora-Stale: true` and `Cache-Control: public, max-age=0, must-revalidate` headers to Docker stale responses
- When upstream is unreachable and cache exists, serve cached data with stale indicators instead of returning 502
- When `serve_stale=false`, return 502 on upstream failure even if cache is available

Previously 4/8 TTL-caching handlers supported serve-stale (Ansible, Terraform, NuGet, Docker). This aligns the remaining 4 + adds missing stale headers to Docker.

## Changes

| File | Change |
|------|--------|
| `config/registry/{npm,gems,conan,pub_dart}.rs` | +`serve_stale` field, default, env override |
| `registry/docker.rs` | Add stale headers to serve-stale path |
| `registry/npm.rs` | Config gate + stale headers + 502 fallback |
| `registry/gems.rs` | Eager cache read + serve-stale in error arm |
| `registry/conan.rs` | Pass cached data to `fetch_and_cache_json` + serve-stale |
| `registry/pub_dart.rs` | Eager cache read + serve-stale in 4 endpoints |
| `test_helpers.rs` | Add `serve_stale` to NpmConfig init |

## Test plan

- [x] `cargo fmt --check` — pass
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo test` — 1210 tests pass
- [x] Semgrep — no new findings
- [x] OPSEC check — clean
- [ ] Manual: cache artifact → block upstream → verify 200 + `X-Nora-Stale: true`
- [ ] Manual: set `NORA_*_SERVE_STALE=false` → verify 502 on upstream failure

Closes #576