### PR TITLE
feat(docker): stream blob downloads without buffering full blobs in RAM (#580)

### DIFF
--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -428,6 +428,77 @@ pub fn verify_integrity(
     }
 }
 
+/// Verify artifact integrity using a pre-computed hash string (#580).
+///
+/// Not yet called — API preparation for streaming download path (Commit 1).
+#[allow(dead_code)] // TODO(#580): remove when streaming handler calls this
+///
+/// Same logic as [`verify_integrity`] but accepts the hash directly instead
+/// of computing it from raw data. Used by streaming download paths where
+/// SHA-256 was computed incrementally during the download.
+///
+/// `hash` must be in `sha256:<64hex>` format (e.g., from Docker content-
+/// addressable digest).
+pub fn verify_integrity_by_hash(
+    engine: &CurationEngine,
+    registry: RegistryType,
+    name: &str,
+    version: Option<&str>,
+    hash: &str,
+) -> Option<Response> {
+    debug_assert!(
+        hash.starts_with("sha256:") && hash.len() == 71,
+        "verify_integrity_by_hash: expected sha256:<64hex>, got: {hash}"
+    );
+
+    if !engine.is_active() {
+        return None;
+    }
+
+    let request = FilterRequest {
+        registry,
+        upstream: None,
+        name: name.to_string(),
+        version: version.map(|v| v.to_string()),
+        integrity: Some(hash.to_string()),
+        bypass: false,
+        publish_date: None,
+    };
+
+    let result = engine.evaluate(&request);
+
+    match &result.decision {
+        Decision::Block { rule, reason } => {
+            if !rule.contains("integrity") {
+                return None;
+            }
+            if result.audited {
+                tracing::info!(
+                    registry = %registry,
+                    package = %name,
+                    version = version.unwrap_or("*"),
+                    rule = %rule,
+                    reason = %reason,
+                    "[AUDIT] Integrity check would block download (hash-based)"
+                );
+                None
+            } else {
+                Some(
+                    BlockedResponse {
+                        rule: rule.clone(),
+                        reason: reason.clone(),
+                        registry: registry.to_string(),
+                        package: name.to_string(),
+                        version: version.map(|v| v.to_string()),
+                    }
+                    .into_response(),
+                )
+            }
+        }
+        Decision::Allow | Decision::Skip => None,
+    }
+}
+
 // ============================================================================
 // Version parsers for filename-based registries (issue #187)
 // ============================================================================
@@ -2792,6 +2863,75 @@ mod tests {
             "pre-download with integrity=None must not block: got {:?}",
             decision
         );
+    }
+
+    // ── verify_integrity_by_hash tests (#580) ──────────────────────────
+
+    #[test]
+    fn test_verify_integrity_by_hash_mode_off_returns_none() {
+        let engine = super::CurationEngine::new(CurationConfig::default());
+        let hash = format!("sha256:{}", hex::encode(sha2::Sha256::digest(b"data")));
+        let result = super::verify_integrity_by_hash(
+            &engine,
+            super::RegistryType::Docker,
+            "library/nginx",
+            Some("latest"),
+            &hash,
+        );
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_verify_integrity_by_hash_matching() {
+        let hash = format!("sha256:{}", hex::encode(sha2::Sha256::digest(b"blob-data")));
+        let allowlist_json = serde_json::json!({
+            "version": 1,
+            "entries": [{
+                "registry": "docker",
+                "name": "library/nginx",
+                "version": "latest",
+                "integrity": hash,
+                "integrity_source": "manual"
+            }]
+        });
+        let dir = tempfile::TempDir::new().unwrap();
+        let path = dir.path().join("allowlist.json");
+        std::fs::write(&path, serde_json::to_string(&allowlist_json).unwrap()).unwrap();
+
+        let mut config = CurationConfig::default();
+        config.mode = super::super::config::CurationMode::Enforce;
+        let mut engine = super::CurationEngine::new(config);
+        let filter = super::AllowlistFilter::from_file(path.to_str().unwrap(), false).unwrap();
+        engine.add_filter(Box::new(filter));
+
+        let result = super::verify_integrity_by_hash(
+            &engine,
+            super::RegistryType::Docker,
+            "library/nginx",
+            Some("latest"),
+            &hash,
+        );
+        assert!(result.is_none(), "matching hash should pass");
+    }
+
+    #[test]
+    fn test_verify_integrity_by_hash_consistent_with_verify_integrity() {
+        // verify_integrity_by_hash with the same hash that verify_integrity
+        // would compute must produce the same result.
+        let data = b"consistency-check";
+        let hash = format!("sha256:{}", hex::encode(sha2::Sha256::digest(data)));
+        let engine = super::CurationEngine::new(CurationConfig::default());
+
+        let result_data =
+            super::verify_integrity(&engine, super::RegistryType::Docker, "test", None, data);
+        let result_hash = super::verify_integrity_by_hash(
+            &engine,
+            super::RegistryType::Docker,
+            "test",
+            None,
+            &hash,
+        );
+        assert_eq!(result_data.is_none(), result_hash.is_none());
     }
 
     #[test]

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -90,6 +90,31 @@ impl HashPinStore {
         }
     }
 
+    /// Record a pre-computed SHA-256 hash for a storage key.
+    ///
+    /// Used by streaming paths where the hash was already computed
+    /// incrementally during download — avoids re-reading the file (#580).
+    ///
+    /// `hash` must be a lowercase hex-encoded SHA-256 (64 chars).
+    pub fn record_hash(&self, key: &str, hash: &str) {
+        debug_assert!(
+            hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()),
+            "record_hash: expected 64-char hex SHA-256, got: {hash}"
+        );
+
+        let should_write = {
+            let mut pins = self.pins.write();
+            let changed = pins.get(key).is_none_or(|existing| *existing != hash);
+            if changed {
+                pins.insert(key.to_string(), hash.to_string());
+            }
+            changed
+        };
+        if should_write {
+            Self::append_to_file(&self.path, key, hash);
+        }
+    }
+
     /// Verify data integrity against pinned hash. Called on every `get()`.
     ///
     /// Returns `true` if the hash matches or no pin exists for this key.
@@ -302,6 +327,52 @@ mod tests {
 
         assert_eq!(store.len(), 0);
         assert!(!path.exists(), "empty store should not create file");
+    }
+
+    #[test]
+    fn test_record_hash_and_verify() {
+        let dir = TempDir::new().unwrap();
+        let store = HashPinStore::new(pin_path(&dir));
+
+        // Pre-computed SHA-256 of b"streaming-data"
+        let hash = HashPinStore::sha256_hex(b"streaming-data");
+        store.record_hash("docker/blob/sha256:abc", &hash);
+
+        assert_eq!(store.len(), 1);
+        assert!(store.verify("docker/blob/sha256:abc", b"streaming-data"));
+        assert!(!store.verify("docker/blob/sha256:abc", b"tampered"));
+    }
+
+    #[test]
+    fn test_record_hash_persists_on_reload() {
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+
+        let hash = HashPinStore::sha256_hex(b"persistent");
+        {
+            let store = HashPinStore::new(&path);
+            store.record_hash("key/hash", &hash);
+        }
+
+        // Reload
+        let store = HashPinStore::new(&path);
+        assert_eq!(store.len(), 1);
+        assert!(store.verify("key/hash", b"persistent"));
+    }
+
+    #[test]
+    fn test_record_hash_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+        let store = HashPinStore::new(&path);
+
+        let hash = HashPinStore::sha256_hex(b"data");
+        store.record_hash("key", &hash);
+        store.record_hash("key", &hash);
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(lines.len(), 1, "duplicate record_hash should be idempotent");
     }
 
     #[test]

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1266,9 +1266,10 @@ async fn run_server(mut config: Config, storage: Storage) {
         .layer(middleware::from_fn(validation::reject_null_bytes_middleware))
         .with_state(state.clone());
 
-    // Clean up stale Docker upload temp files from previous runs (#530).
+    // Clean up stale Docker temp files from previous runs (#530, #580).
     if state.config.docker.enabled {
         registry::docker::cleanup_upload_temp_dir(&state.config.storage.path);
+        registry::docker::cleanup_proxy_temp_dir(&state.config.storage.path);
     }
 
     let addr = state.config.server.bind_addr();
@@ -1330,9 +1331,14 @@ async fn run_server(mut config: Config, storage: Storage) {
             }
 
             // Every 5 minutes (tick_count % 10 == 0): evict unused publish locks
+            // + clean up stale proxy temp files (#580)
             if tick_count.is_multiple_of(10) {
                 let mut locks = metrics_state.publish_locks.lock();
                 locks.retain(|_, arc| Arc::strong_count(arc) > 1);
+                let storage_path = metrics_state.config.storage.path.clone();
+                tokio::task::spawn_blocking(move || {
+                    registry::docker::cleanup_proxy_temp_dir(&storage_path);
+                });
             }
         }
     });

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -12,8 +12,9 @@ use axum::{
 };
 use memchr::memmem;
 use prometheus::{
-    register_histogram_vec, register_int_counter_vec, register_int_gauge_vec, Encoder,
-    HistogramVec, IntCounterVec, IntGaugeVec, TextEncoder,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge,
+    register_int_gauge_vec, Encoder, HistogramVec, IntCounter, IntCounterVec, IntGauge,
+    IntGaugeVec, TextEncoder,
 };
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
@@ -171,6 +172,30 @@ static LEAK_DETECTION_SKIPPED: LazyLock<IntCounterVec> = LazyLock::new(|| {
         &["reason"]
     )
     .expect("failed to create LEAK_DETECTION_SKIPPED metric at startup")
+});
+
+/// Active streaming proxy downloads in progress (#580).
+///
+/// Incremented when `fetch_blob_from_upstream` starts streaming, decremented
+/// on completion or error. Used to detect concurrent download pressure.
+pub static PROXY_ACTIVE_DOWNLOADS: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!(
+        "nora_proxy_active_downloads",
+        "Number of Docker blob proxy downloads currently in progress"
+    )
+    .expect("failed to create PROXY_ACTIVE_DOWNLOADS metric at startup")
+});
+
+/// Total bytes successfully downloaded from upstream via proxy (#580).
+///
+/// Only incremented after a complete, verified download (not on failures).
+/// Use with `rate()` in Prometheus to track upstream bandwidth consumption.
+pub static PROXY_DOWNLOAD_BYTES: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "nora_proxy_download_bytes_total",
+        "Total bytes successfully downloaded from upstream Docker registries"
+    )
+    .expect("failed to create PROXY_DOWNLOAD_BYTES metric at startup")
 });
 
 /// Maximum response body size to scan for upstream URL leaks (2 MB).

--- a/nora-registry/src/mirror/docker.rs
+++ b/nora-registry/src/mirror/docker.rs
@@ -219,7 +219,9 @@ async fn mirror_single_image(
                 continue;
             }
 
-            let blob_data = crate::registry::docker::fetch_blob_from_upstream(
+            let mirror_temp = std::env::temp_dir().join("nora-mirror");
+            let _ = std::fs::create_dir_all(&mirror_temp);
+            let fetched = crate::registry::docker::fetch_blob_from_upstream(
                 client,
                 &image.registry,
                 &image.name,
@@ -229,10 +231,14 @@ async fn mirror_single_image(
                 60, // per-chunk read timeout
                 None,
                 &noop_cb,
+                &mirror_temp,
             )
             .await
             .map_err(|e| format!("Failed to fetch blob {}: {:?}", digest, e))?;
 
+            let blob_data = tokio::fs::read(&fetched.path)
+                .await
+                .map_err(|e| format!("Failed to read fetched blob: {}", e))?;
             bytes += blob_data.len() as u64;
             push_blob(client, nora_base, &image.name, digest, &blob_data)
                 .await

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1200,7 +1200,7 @@ async fn upload_blob(
 
     // Move temp file into storage — no RAM copy of the blob
     let key = format!("docker/{}/blobs/{}", name, digest);
-    match state.storage.put_from_path(&key, &temp_path).await {
+    match state.storage.put_from_path(&key, &temp_path, None).await {
         Ok(()) => {
             state.metrics.record_upload("docker");
             state.audit.log(AuditEntry::new(

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -3921,4 +3921,126 @@ mod integration_tests {
         assert!(!c2.denied);
         assert!(c2.denied_response().is_none());
     }
+
+    // ── #580/#581: streaming proxy blob integrity (content-addressable) ──
+
+    /// Security-critical (#581): an upstream that returns bytes whose SHA-256 does
+    /// not match the requested content-addressable digest must be rejected with
+    /// 502, and the poisoned bytes must never enter the cache, the pin store, or
+    /// be served — and the streaming temp file must be cleaned up.
+    #[tokio::test]
+    async fn test_docker_proxy_blob_sha256_mismatch_rejected() {
+        use crate::config::DockerUpstream;
+        use crate::test_helpers::create_test_context_with_config;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+
+        // The requested digest is the SHA-256 of the *real* content...
+        let requested_digest = format!(
+            "sha256:{}",
+            hex::encode(sha2::Sha256::digest(b"the real layer"))
+        );
+        // ...but the upstream serves unrelated (poisoned) bytes for that digest.
+        let poisoned = b"poisoned bytes that do not hash to the requested digest".to_vec();
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/library/test/blobs/{requested_digest}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(poisoned))
+            .mount(&upstream)
+            .await;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.docker.upstreams = vec![DockerUpstream {
+                url: upstream.uri(),
+                auth: None,
+                namespace: None,
+                prefix: None,
+            }];
+        });
+
+        let response = send(
+            &ctx.app,
+            Method::GET,
+            &format!("/v2/library/test/blobs/{requested_digest}"),
+            Body::empty(),
+        )
+        .await;
+
+        // Mismatch → 502 Bad Gateway (verify-before-serve, no tee to client).
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+
+        // Poisoned blob must NOT have been cached under the docker blob key
+        // (computed via the same canonicalize/blob_key path the handler uses).
+        let c = super::canonicalize("library/test", &ctx.state.config.docker);
+        let key = super::blob_key(c.namespace.as_deref(), &c.name, &requested_digest);
+        assert!(
+            ctx.state.storage.get(&key).await.is_err(),
+            "poisoned blob must not be cached"
+        );
+
+        // TempFileGuard must have cleaned up — no leftover proxy temp files.
+        let proxy_tmp =
+            std::path::Path::new(&ctx.state.config.storage.path).join("tmp/docker-proxy");
+        let leftover = std::fs::read_dir(&proxy_tmp)
+            .map(|rd| rd.filter_map(|e| e.ok()).count())
+            .unwrap_or(0);
+        assert_eq!(leftover, 0, "temp files must be cleaned up after rejection");
+    }
+
+    /// Positive control for the integrity check: when the upstream bytes hash to
+    /// the requested digest, the blob is verified, cached, and streamed back to
+    /// the client via the get_reader path (#580) with a 200.
+    #[tokio::test]
+    async fn test_docker_proxy_blob_sha256_match_served_and_cached() {
+        use crate::config::DockerUpstream;
+        use crate::test_helpers::create_test_context_with_config;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        let content = b"a genuine docker layer payload".to_vec();
+        let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(&content)));
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/library/ok/blobs/{digest}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(content.clone()))
+            .mount(&upstream)
+            .await;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.docker.upstreams = vec![DockerUpstream {
+                url: upstream.uri(),
+                auth: None,
+                namespace: None,
+                prefix: None,
+            }];
+        });
+
+        let response = send(
+            &ctx.app,
+            Method::GET,
+            &format!("/v2/library/ok/blobs/{digest}"),
+            Body::empty(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_bytes(response).await;
+        assert_eq!(
+            body.as_ref(),
+            content.as_slice(),
+            "served body must match upstream"
+        );
+
+        // Verified blob is cached synchronously under the docker blob key
+        // (computed via the same canonicalize/blob_key path the handler uses).
+        let c = super::canonicalize("library/ok", &ctx.state.config.docker);
+        let key = super::blob_key(c.namespace.as_deref(), &c.name, &digest);
+        assert!(
+            ctx.state.storage.get(&key).await.is_ok(),
+            "verified blob must be cached"
+        );
+    }
 }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -14,7 +14,7 @@ use crate::validation::{
 };
 use crate::AppState;
 use axum::{
-    body::Bytes,
+    body::{Body, Bytes},
     extract::{Path, State},
     http::{header, HeaderName, Method, StatusCode, Uri},
     response::{IntoResponse, Response},
@@ -28,6 +28,7 @@ use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio_util::io::ReaderStream;
 
 // ============================================================================
 // Namespaced key builders (issue #323)
@@ -211,6 +212,25 @@ async fn storage_get_with_fallback(
     match storage.get(ns_key).await {
         Ok(data) => Ok(data),
         Err(_) if ns_key != legacy_key => storage.get(legacy_key).await,
+        Err(e) => Err(e),
+    }
+}
+
+/// Open a streaming reader for a blob, trying namespaced then legacy key (#580).
+async fn storage_get_reader_with_fallback(
+    storage: &Storage,
+    ns_key: &str,
+    legacy_key: &str,
+) -> Result<
+    (
+        u64,
+        std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
+    ),
+    crate::storage::StorageError,
+> {
+    match storage.get_reader(ns_key).await {
+        Ok(reader) => Ok(reader),
+        Err(_) if ns_key != legacy_key => storage.get_reader(legacy_key).await,
         Err(e) => Err(e),
     }
 }
@@ -806,15 +826,18 @@ async fn download_blob(
     let key = blob_key(ns.as_deref(), &name, &digest);
     let legacy_key = blob_key(None, &name, &digest);
 
-    // Try local storage first (namespaced key, then legacy fallback)
-    if let Ok(data) = storage_get_with_fallback(&state.storage, &key, &legacy_key).await {
-        // Curation integrity verification (issue #189)
-        if let Some(response) = crate::curation::verify_integrity(
+    // Try local storage first — streaming read, never loads full blob into RAM (#580)
+    if let Ok((size, reader)) =
+        storage_get_reader_with_fallback(&state.storage, &key, &legacy_key).await
+    {
+        // Curation integrity check using digest from URL (no full-data rehash).
+        // Docker blobs are content-addressed: the URL digest IS the integrity.
+        if let Some(response) = crate::curation::verify_integrity_by_hash(
             &state.curation().curation_engine,
             crate::curation::RegistryType::Docker,
             &name,
             Some(&digest),
-            &data,
+            &digest,
         ) {
             return response;
         }
@@ -827,15 +850,15 @@ async fn download_blob(
             "docker",
             "LOCAL",
         ));
-        return (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, "application/octet-stream"),
-                (header::CACHE_CONTROL, "public, max-age=31536000, immutable"),
-            ],
-            data,
-        )
-            .into_response();
+        let stream = ReaderStream::new(reader);
+        return Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .header(header::CONTENT_LENGTH, size)
+            .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+            .header("docker-content-digest", &digest)
+            .body(Body::from_stream(stream))
+            .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
 
     let temp_dir = proxy_temp_dir(&state.config.storage.path);
@@ -928,35 +951,26 @@ async fn download_blob(
                         }
                     }
 
-                    // Serve response: read from storage (cache hit) since the blob
-                    // is now persisted. This avoids holding the temp file open and
-                    // uses the standard cache-hit path.
-                    // For the rare case where put_from_path failed, re-read from
-                    // the temp file (guard hasn't been disarmed).
+                    // Serve response via streaming — never load full blob into RAM (#580).
+                    // Two paths: storage (put succeeded) or temp file (put failed).
                     if fetched._guard.path.is_none() {
-                        // Successfully stored — serve from storage (standard path)
-                        match state.storage.get(&key).await {
-                            Ok(data) => {
-                                return (
-                                    StatusCode::OK,
-                                    [
-                                        (
-                                            header::CONTENT_TYPE,
-                                            "application/octet-stream".to_string(),
-                                        ),
-                                        (header::CONTENT_LENGTH, file_size.to_string()),
-                                        (
-                                            HeaderName::from_static("docker-content-digest"),
-                                            digest.clone(),
-                                        ),
-                                        (
-                                            header::CACHE_CONTROL,
-                                            "public, max-age=31536000, immutable".to_string(),
-                                        ),
-                                    ],
-                                    data,
-                                )
-                                    .into_response();
+                        // Successfully stored — stream from storage
+                        match state.storage.get_reader(&key).await {
+                            Ok((size, reader)) => {
+                                let stream = ReaderStream::new(reader);
+                                return Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(header::CONTENT_TYPE, "application/octet-stream")
+                                    .header(header::CONTENT_LENGTH, size)
+                                    .header(
+                                        header::CACHE_CONTROL,
+                                        "public, max-age=31536000, immutable",
+                                    )
+                                    .header("docker-content-digest", &digest)
+                                    .body(Body::from_stream(stream))
+                                    .unwrap_or_else(|_| {
+                                        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                                    });
                             }
                             Err(e) => {
                                 tracing::error!(error = %e, key = %key, "Failed to read just-stored blob");
@@ -964,28 +978,22 @@ async fn download_blob(
                             }
                         }
                     } else {
-                        // put_from_path failed — serve from temp file directly
-                        match tokio::fs::read(&fetched.path).await {
-                            Ok(data) => {
-                                return (
-                                    StatusCode::OK,
-                                    [
-                                        (
-                                            header::CONTENT_TYPE,
-                                            "application/octet-stream".to_string(),
-                                        ),
-                                        (header::CONTENT_LENGTH, data.len().to_string()),
-                                        (
-                                            HeaderName::from_static("docker-content-digest"),
-                                            digest.clone(),
-                                        ),
-                                    ],
-                                    Bytes::from(data),
-                                )
-                                    .into_response();
+                        // put_from_path failed — stream from temp file directly
+                        match tokio::fs::File::open(&fetched.path).await {
+                            Ok(file) => {
+                                let stream = ReaderStream::new(file);
+                                return Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(header::CONTENT_TYPE, "application/octet-stream")
+                                    .header(header::CONTENT_LENGTH, file_size)
+                                    .header("docker-content-digest", &digest)
+                                    .body(Body::from_stream(stream))
+                                    .unwrap_or_else(|_| {
+                                        StatusCode::INTERNAL_SERVER_ERROR.into_response()
+                                    });
                             }
                             Err(e) => {
-                                tracing::error!(error = %e, "Failed to read temp blob file");
+                                tracing::error!(error = %e, "Failed to open temp blob file for streaming");
                                 return StatusCode::INTERNAL_SERVER_ERROR.into_response();
                             }
                         }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -319,6 +319,42 @@ fn upload_temp_dir(data_dir: &str) -> std::path::PathBuf {
     dir
 }
 
+fn proxy_temp_dir(data_dir: &str) -> std::path::PathBuf {
+    let dir = std::path::PathBuf::from(data_dir).join("tmp/docker-proxy");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        tracing::error!(path = %dir.display(), error = %e, "failed to create proxy temp directory");
+    }
+    dir
+}
+
+/// RAII guard that deletes a temp file on drop unless disarmed.
+///
+/// Ensures temp files are cleaned up on ALL error paths (network errors,
+/// hash mismatch, panics, early returns via `?` operator) — #580.
+pub(crate) struct TempFileGuard {
+    path: Option<std::path::PathBuf>,
+}
+
+impl TempFileGuard {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    /// Disarm the guard — caller takes ownership of cleanup.
+    /// Call this after successful `put_from_path` (which moves/deletes the file).
+    fn disarm(&mut self) {
+        self.path = None;
+    }
+}
+
+impl Drop for TempFileGuard {
+    fn drop(&mut self) {
+        if let Some(ref path) = self.path {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+}
+
 /// Validate that an upload UUID from URL path is safe (no path traversal).
 ///
 /// Accepts only lowercase hex + hyphens (UUID-4 format) up to 36 chars.
@@ -752,83 +788,162 @@ async fn download_blob(
             .into_response();
     }
 
+    let temp_dir = proxy_temp_dir(&state.config.storage.path);
+
     // Try upstream proxies (prefix-matched → single upstream, otherwise → fallback chain)
-    for upstream in &upstreams_to_try {
-        match fetch_blob_from_upstream(
-            &state.http_client,
-            &upstream.url,
-            &name,
-            &digest,
-            &state.docker_auth,
-            state.config.docker.proxy_timeout,
-            state.config.docker.read_timeout,
-            expose_opt(&upstream.auth),
-            &state.circuit_breaker,
-        )
-        .await
-        {
-            Ok(data) => {
-                state.metrics.record_download("docker");
-                state.metrics.record_cache_miss("docker");
-                state.activity.push(ActivityEntry::new(
-                    ActionType::ProxyFetch,
-                    format!("{}@{}", name, &digest[..19.min(digest.len())]),
-                    "docker",
-                    "PROXY",
-                ));
+    // Includes library/ fallback for single-segment names (Docker Hub official images).
+    let names_to_try: Vec<String> = if name.contains('/') {
+        vec![name.clone()]
+    } else {
+        vec![name.clone(), format!("library/{}", name)]
+    };
 
-                // Convert Vec<u8> to Bytes first — Bytes::clone() is O(1) refcount
-                // instead of Vec::clone() which copies the entire buffer (#526).
-                let data = Bytes::from(data);
-                state.spawn_cache("docker", key.clone(), data.clone());
-
-                return (
-                    StatusCode::OK,
-                    [(header::CONTENT_TYPE, "application/octet-stream")],
-                    data,
-                )
-                    .into_response();
-            }
-            Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
-            Err(e) => {
-                tracing::debug!(error = ?e, upstream = %upstream.url, name = %name, "Docker blob proxy fetch failed, trying next");
-                continue;
-            }
-        }
-    }
-
-    // Auto-prepend library/ for single-segment names (Docker Hub official images)
-    if !name.contains('/') {
-        let library_name = format!("library/{}", name);
+    for try_name in &names_to_try {
         for upstream in &upstreams_to_try {
             match fetch_blob_from_upstream(
                 &state.http_client,
                 &upstream.url,
-                &library_name,
+                try_name,
                 &digest,
                 &state.docker_auth,
                 state.config.docker.proxy_timeout,
                 state.config.docker.read_timeout,
                 expose_opt(&upstream.auth),
                 &state.circuit_breaker,
+                &temp_dir,
             )
             .await
             {
-                Ok(data) => {
-                    // Convert Vec<u8> to Bytes first — O(1) clone (#526)
-                    let data = Bytes::from(data);
-                    state.spawn_cache("docker", key.clone(), data.clone());
+                Ok(mut fetched) => {
+                    // Verify SHA-256 against digest from URL (curation fail-closed)
+                    let expected_hash = digest.strip_prefix("sha256:").unwrap_or(&digest);
+                    if fetched.sha256 != expected_hash {
+                        tracing::warn!(
+                            name = %try_name,
+                            digest = %digest,
+                            expected = %expected_hash,
+                            actual = %fetched.sha256,
+                            "Docker blob SHA-256 mismatch from upstream — rejecting"
+                        );
+                        // TempFileGuard drops and cleans up
+                        return StatusCode::BAD_GATEWAY.into_response();
+                    }
 
-                    return (
-                        StatusCode::OK,
-                        [(header::CONTENT_TYPE, "application/octet-stream")],
-                        data,
-                    )
-                        .into_response();
+                    // Curation integrity check with pre-computed hash (#580)
+                    let hash_with_prefix = format!("sha256:{}", fetched.sha256);
+                    if let Some(response) = crate::curation::verify_integrity_by_hash(
+                        &state.curation().curation_engine,
+                        crate::curation::RegistryType::Docker,
+                        try_name,
+                        Some(&digest),
+                        &hash_with_prefix,
+                    ) {
+                        return response;
+                    }
+
+                    state.metrics.record_download("docker");
+                    state.metrics.record_cache_miss("docker");
+                    state.activity.push(ActivityEntry::new(
+                        ActionType::ProxyFetch,
+                        format!("{}@{}", try_name, &digest[..19.min(digest.len())]),
+                        "docker",
+                        "PROXY",
+                    ));
+
+                    // Read temp file size for Content-Length (always known — file is complete)
+                    let file_size = tokio::fs::metadata(&fetched.path)
+                        .await
+                        .map(|m| m.len())
+                        .unwrap_or(0);
+
+                    // Store blob: atomic move temp → storage with SHA-256 pin (#580)
+                    let sha_for_pin = fetched.sha256.clone();
+                    match state
+                        .storage
+                        .put_from_path(&key, &fetched.path, Some(&sha_for_pin))
+                        .await
+                    {
+                        Ok(()) => {
+                            // put_from_path moved/deleted the file — disarm guard
+                            fetched._guard.disarm();
+                            state.repo_index.invalidate("docker");
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                error = %e,
+                                key = %key,
+                                "Failed to store proxied blob — serving from upstream anyway"
+                            );
+                            // Guard will clean up temp file on drop
+                        }
+                    }
+
+                    // Serve response: read from storage (cache hit) since the blob
+                    // is now persisted. This avoids holding the temp file open and
+                    // uses the standard cache-hit path.
+                    // For the rare case where put_from_path failed, re-read from
+                    // the temp file (guard hasn't been disarmed).
+                    if fetched._guard.path.is_none() {
+                        // Successfully stored — serve from storage (standard path)
+                        match state.storage.get(&key).await {
+                            Ok(data) => {
+                                return (
+                                    StatusCode::OK,
+                                    [
+                                        (
+                                            header::CONTENT_TYPE,
+                                            "application/octet-stream".to_string(),
+                                        ),
+                                        (header::CONTENT_LENGTH, file_size.to_string()),
+                                        (
+                                            HeaderName::from_static("docker-content-digest"),
+                                            digest.clone(),
+                                        ),
+                                        (
+                                            header::CACHE_CONTROL,
+                                            "public, max-age=31536000, immutable".to_string(),
+                                        ),
+                                    ],
+                                    data,
+                                )
+                                    .into_response();
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, key = %key, "Failed to read just-stored blob");
+                                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                            }
+                        }
+                    } else {
+                        // put_from_path failed — serve from temp file directly
+                        match tokio::fs::read(&fetched.path).await {
+                            Ok(data) => {
+                                return (
+                                    StatusCode::OK,
+                                    [
+                                        (
+                                            header::CONTENT_TYPE,
+                                            "application/octet-stream".to_string(),
+                                        ),
+                                        (header::CONTENT_LENGTH, data.len().to_string()),
+                                        (
+                                            HeaderName::from_static("docker-content-digest"),
+                                            digest.clone(),
+                                        ),
+                                    ],
+                                    Bytes::from(data),
+                                )
+                                    .into_response();
+                            }
+                            Err(e) => {
+                                tracing::error!(error = %e, "Failed to read temp blob file");
+                                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                            }
+                        }
+                    }
                 }
                 Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),
                 Err(e) => {
-                    tracing::debug!(error = ?e, upstream = %upstream.url, name = %library_name, "Docker blob proxy fetch failed, trying next");
+                    tracing::debug!(error = ?e, upstream = %upstream.url, name = %try_name, "Docker blob proxy fetch failed, trying next");
                     continue;
                 }
             }
@@ -1889,7 +2004,24 @@ async fn delete_blob(
 
 // ============================================================================
 
-/// Fetch a blob from an upstream Docker registry.
+/// Result of a successful streaming blob fetch from upstream (#580).
+pub struct FetchedBlob {
+    /// Path to temp file containing the complete blob data.
+    pub path: std::path::PathBuf,
+    /// SHA-256 hex digest computed incrementally during download (64 chars, lowercase).
+    pub sha256: String,
+    /// Content-Length from upstream response, if provided (None for chunked responses).
+    /// Used by mirror and future streaming response paths.
+    #[allow(dead_code)]
+    pub content_length: Option<u64>,
+    /// RAII guard — deletes temp file on drop unless disarmed.
+    pub _guard: TempFileGuard,
+}
+
+/// Fetch a blob from an upstream Docker registry, streaming to a temp file (#580).
+///
+/// Streams the upstream response to a temp file in `temp_dir` with incremental
+/// SHA-256 hashing. Never accumulates the full blob in RAM.
 ///
 /// Uses per-chunk `read_timeout` instead of a total request timeout so that
 /// large blob downloads (multi-GB images) don't time out on slow connections.
@@ -1905,7 +2037,8 @@ pub async fn fetch_blob_from_upstream(
     read_timeout: u64,
     basic_auth: Option<&str>,
     cb: &CircuitBreakerRegistry,
-) -> Result<Vec<u8>, ProxyError> {
+    temp_dir: &std::path::Path,
+) -> Result<FetchedBlob, ProxyError> {
     let cb_key = format!("docker:{}", upstream_url.trim_end_matches('/'));
     cb.check(&cb_key)?;
 
@@ -1961,18 +2094,33 @@ pub async fn fetch_blob_from_upstream(
         return Err(ProxyError::Upstream(status));
     }
 
-    // Stream body with per-chunk read timeout
-    let content_length = response.content_length().unwrap_or(0) as usize;
+    // Upstream Content-Length (None if chunked transfer-encoding)
+    let upstream_content_length = response.content_length();
+
+    // Create temp file in storage directory (same filesystem for atomic rename)
+    let temp_path = temp_dir.join(format!("proxy-{}", uuid::Uuid::new_v4()));
+    let guard = TempFileGuard::new(temp_path.clone());
+    let mut file = tokio::fs::File::create(&temp_path)
+        .await
+        .map_err(|e| ProxyError::Network(format!("temp file create: {}", e)))?;
+
+    // Stream body with per-chunk read timeout + incremental SHA-256
+    use sha2::Digest;
     let mut stream = response.bytes_stream();
-    let mut data = Vec::with_capacity(content_length);
+    let mut hasher = sha2::Sha256::new();
     let chunk_timeout = Duration::from_secs(read_timeout);
 
     loop {
         // CANCEL-SAFETY: timeout wraps a single stream.next() call. On timeout,
-        // the partial chunk is discarded and we return a ProxyError — no
-        // accumulated state is lost since `data` is local and the error aborts.
+        // TempFileGuard drops and deletes the partial file — no leaked state.
         match tokio::time::timeout(chunk_timeout, stream.next()).await {
-            Ok(Some(Ok(chunk))) => data.extend_from_slice(&chunk),
+            Ok(Some(Ok(chunk))) => {
+                hasher.update(&chunk);
+                use tokio::io::AsyncWriteExt;
+                file.write_all(&chunk)
+                    .await
+                    .map_err(|e| ProxyError::Network(format!("temp file write: {}", e)))?;
+            }
             Ok(Some(Err(e))) => {
                 cb.record_failure(&cb_key);
                 return Err(ProxyError::Network(format!("chunk read error: {}", e)));
@@ -1988,8 +2136,25 @@ pub async fn fetch_blob_from_upstream(
         }
     }
 
+    // Flush to disk before returning
+    use tokio::io::AsyncWriteExt;
+    file.flush()
+        .await
+        .map_err(|e| ProxyError::Network(format!("temp file flush: {}", e)))?;
+    drop(file);
+
+    let sha256 = hex::encode(sha2::Digest::finalize(hasher));
     cb.record_success(&cb_key);
-    Ok(data)
+
+    // Transfer guard ownership to FetchedBlob — caller is responsible for
+    // disarming after successful put_from_path (which moves the temp file).
+    // If caller drops FetchedBlob without disarming, temp file is cleaned up.
+    Ok(FetchedBlob {
+        path: temp_path,
+        sha256,
+        content_length: upstream_content_length,
+        _guard: guard,
+    })
 }
 
 /// Fetch a manifest from an upstream Docker registry

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -355,6 +355,18 @@ impl Drop for TempFileGuard {
     }
 }
 
+/// RAII guard for `PROXY_ACTIVE_DOWNLOADS` gauge — decrements on drop (#580).
+///
+/// Guarantees the gauge stays accurate on all exit paths including panics,
+/// early `?` returns, and tokio task cancellation.
+struct ProxyDownloadGuard;
+
+impl Drop for ProxyDownloadGuard {
+    fn drop(&mut self) {
+        crate::metrics::PROXY_ACTIVE_DOWNLOADS.dec();
+    }
+}
+
 /// Validate that an upload UUID from URL path is safe (no path traversal).
 ///
 /// Accepts only lowercase hex + hyphens (UUID-4 format) up to 36 chars.
@@ -400,6 +412,44 @@ pub fn cleanup_upload_temp_dir(data_dir: &str) {
     }
     if removed > 0 {
         tracing::info!(removed, dir = %dir.display(), "Cleaned up stale Docker upload temp files on startup");
+    }
+}
+
+/// Max age for proxy temp files before cleanup removes them (#580).
+///
+/// 4 hours — long enough for slow multi-GB downloads over constrained links,
+/// short enough to reclaim disk from orphaned files (crash, cancel, OOM).
+const PROXY_TEMP_MAX_AGE: std::time::Duration = std::time::Duration::from_secs(4 * 60 * 60);
+
+/// Remove stale temp files from the Docker proxy download directory (#580).
+///
+/// Files older than `PROXY_TEMP_MAX_AGE` are removed. Called at startup
+/// (catches orphans from crashes) and periodically from the background task.
+/// Logs warnings on errors but never panics — cleanup is best-effort.
+pub fn cleanup_proxy_temp_dir(data_dir: &str) {
+    let dir = std::path::PathBuf::from(data_dir).join("tmp/docker-proxy");
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return,
+        Err(e) => {
+            tracing::warn!(path = %dir.display(), error = %e, "Failed to read proxy temp directory for cleanup");
+            return;
+        }
+    };
+    let mut removed = 0u64;
+    for entry in entries.flatten() {
+        let is_stale = entry
+            .metadata()
+            .ok()
+            .and_then(|m| m.modified().ok())
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age >= PROXY_TEMP_MAX_AGE);
+        if is_stale && std::fs::remove_file(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+    if removed > 0 {
+        tracing::info!(removed, dir = %dir.display(), "Cleaned up stale proxy temp files");
     }
 }
 
@@ -2039,6 +2089,20 @@ pub async fn fetch_blob_from_upstream(
     cb: &CircuitBreakerRegistry,
     temp_dir: &std::path::Path,
 ) -> Result<FetchedBlob, ProxyError> {
+    use crate::metrics::{PROXY_ACTIVE_DOWNLOADS, PROXY_DOWNLOAD_BYTES};
+
+    // Track active concurrent proxy downloads. ProxyDownloadGuard decrements
+    // on drop (success, error, or cancellation — all paths).
+    PROXY_ACTIVE_DOWNLOADS.inc();
+    let _download_gauge_guard = ProxyDownloadGuard;
+
+    tracing::info!(
+        blob.name = %name,
+        blob.digest = %digest,
+        upstream = %upstream_url,
+        "Proxy blob download started"
+    );
+
     let cb_key = format!("docker:{}", upstream_url.trim_end_matches('/'));
     cb.check(&cb_key)?;
 
@@ -2109,6 +2173,7 @@ pub async fn fetch_blob_from_upstream(
     let mut stream = response.bytes_stream();
     let mut hasher = sha2::Sha256::new();
     let chunk_timeout = Duration::from_secs(read_timeout);
+    let mut bytes_written: u64 = 0;
 
     loop {
         // CANCEL-SAFETY: timeout wraps a single stream.next() call. On timeout,
@@ -2120,6 +2185,7 @@ pub async fn fetch_blob_from_upstream(
                 file.write_all(&chunk)
                     .await
                     .map_err(|e| ProxyError::Network(format!("temp file write: {}", e)))?;
+                bytes_written += chunk.len() as u64;
             }
             Ok(Some(Err(e))) => {
                 cb.record_failure(&cb_key);
@@ -2145,6 +2211,13 @@ pub async fn fetch_blob_from_upstream(
 
     let sha256 = hex::encode(sha2::Digest::finalize(hasher));
     cb.record_success(&cb_key);
+    PROXY_DOWNLOAD_BYTES.inc_by(bytes_written);
+
+    tracing::info!(
+        bytes = bytes_written,
+        content_length = ?upstream_content_length,
+        "Proxy blob download complete"
+    );
 
     // Transfer guard ownership to FetchedBlob — caller is responsible for
     // disarming after successful put_from_path (which moves the temp file).

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -4,8 +4,9 @@
 use async_trait::async_trait;
 use axum::body::Bytes;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use tokio::fs;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 
 use super::{FileMeta, Result, StorageBackend, StorageError};
 
@@ -245,6 +246,22 @@ impl StorageBackend for LocalStorage {
             }
             Err(e) => Err(StorageError::Io(e.to_string())),
         }
+    }
+
+    async fn get_reader(&self, key: &str) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        let path = self.key_to_path(key);
+        let file = fs::File::open(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StorageError::NotFound
+            } else {
+                StorageError::Io(e.to_string())
+            }
+        })?;
+        let meta = file
+            .metadata()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+        Ok((meta.len(), Box::pin(file)))
     }
 }
 

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -13,8 +13,10 @@ use crate::validation::{validate_storage_key, ValidationError};
 use async_trait::async_trait;
 use axum::body::Bytes;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::Arc;
 use thiserror::Error;
+use tokio::io::AsyncRead;
 
 /// File metadata
 #[derive(Debug, Clone)]
@@ -60,6 +62,15 @@ pub trait StorageBackend: Send + Sync {
     /// S3 backend: multipart upload from file.
     /// The caller is responsible for deleting `src` on error.
     async fn put_from_path(&self, key: &str, src: &Path) -> Result<()>;
+
+    /// Open an artifact for streaming read without loading it into memory (#580).
+    ///
+    /// Returns `(size_bytes, reader)`. The caller converts the reader to a
+    /// streaming HTTP response via `ReaderStream` + `Body::from_stream()`.
+    ///
+    /// Local backend: `tokio::fs::File::open` + metadata.
+    /// S3 backend: `object_store::get` → byte-stream wrapped in `StreamReader`.
+    async fn get_reader(&self, key: &str) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)>;
 }
 
 /// Storage wrapper for dynamic dispatch with integrity verification.
@@ -249,6 +260,33 @@ impl Storage {
             Err(e) => {
                 STORAGE_OPERATIONS
                     .with_label_values(&["put", "error"])
+                    .inc();
+                Err(e)
+            }
+        }
+    }
+
+    /// Open an artifact for streaming read without loading into memory (#580).
+    ///
+    /// Returns `(size_bytes, reader)`. Pin-store integrity is NOT checked here
+    /// because streaming prevents full-data hashing. Callers that need integrity
+    /// verification should use `verify_integrity_by_hash` with the content digest
+    /// (available from the URL for Docker blobs).
+    pub async fn get_reader(
+        &self,
+        key: &str,
+    ) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        validate_storage_key(key)?;
+        match self.inner.get_reader(key).await {
+            Ok(reader) => {
+                STORAGE_OPERATIONS
+                    .with_label_values(&["get_reader", "ok"])
+                    .inc();
+                Ok(reader)
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS
+                    .with_label_values(&["get_reader", "error"])
                     .inc();
                 Err(e)
             }

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -227,13 +227,23 @@ impl Storage {
 
     /// Move or copy a file from `src` into storage under `key`.
     ///
-    /// Digest is assumed already verified by the caller — pin store is
-    /// not updated (re-reading gigabytes just to hash is wasteful).
-    pub async fn put_from_path(&self, key: &str, src: &Path) -> Result<()> {
+    /// When `sha256` is `Some`, the hash is recorded in the pin store without
+    /// re-reading the file — used by streaming download paths where the hash
+    /// was already computed incrementally (#580).
+    ///
+    /// When `sha256` is `None`, the pin store is not updated (legacy behavior
+    /// for callers that have already verified integrity separately).
+    pub async fn put_from_path(&self, key: &str, src: &Path, sha256: Option<&str>) -> Result<()> {
         validate_storage_key(key)?;
         match self.inner.put_from_path(key, src).await {
             Ok(()) => {
                 STORAGE_OPERATIONS.with_label_values(&["put", "ok"]).inc();
+                if let (Some(hash), Some(ref pins)) = (sha256, &self.pin_store) {
+                    let pins = Arc::clone(pins);
+                    let key = key.to_string();
+                    let hash = hash.to_string();
+                    tokio::task::spawn_blocking(move || pins.record_hash(&key, &hash));
+                }
                 Ok(())
             }
             Err(e) => {

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -7,7 +7,8 @@ use futures::TryStreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path;
 use object_store::{ObjectStore, ObjectStoreExt, PutPayload, WriteMultipart};
-use tokio::io::AsyncReadExt;
+use std::pin::Pin;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::{FileMeta, Result, StorageBackend, StorageError};
 
@@ -237,6 +238,23 @@ impl StorageBackend for S3Storage {
 
         let _ = tokio::fs::remove_file(src).await;
         Ok(())
+    }
+
+    async fn get_reader(&self, key: &str) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        let encoded = encode_s3_key(key);
+        let path = Path::from(encoded);
+        let result = match self.store.get(&path).await {
+            Ok(r) => r,
+            Err(object_store::Error::NotFound { .. }) if key.contains('@') => {
+                let legacy_path = Path::from(encode_s3_key_legacy(key));
+                self.store.get(&legacy_path).await.map_err(map_err)?
+            }
+            Err(e) => return Err(map_err(e)),
+        };
+        let size = result.meta.size;
+        let stream = result.into_stream().map_err(std::io::Error::other);
+        let reader = tokio_util::io::StreamReader::new(stream);
+        Ok((size as u64, Box::pin(reader)))
     }
 }
 

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -6,7 +6,7 @@ use axum::body::Bytes;
 use futures::TryStreamExt;
 use object_store::aws::{AmazonS3, AmazonS3Builder};
 use object_store::path::Path;
-use object_store::{ObjectStore, ObjectStoreExt, PutPayload};
+use object_store::{ObjectStore, ObjectStoreExt, PutPayload, WriteMultipart};
 use tokio::io::AsyncReadExt;
 
 use super::{FileMeta, Result, StorageBackend, StorageError};
@@ -206,19 +206,35 @@ impl StorageBackend for S3Storage {
         let encoded = encode_s3_key(key);
         let s3_path = Path::from(encoded);
 
-        // Read file and upload via object_store PutPayload.
-        // For very large files a multipart upload would be better, but
-        // object_store handles chunking internally when payload exceeds
-        // the part-size threshold.
+        // Streaming multipart upload: read file in 8 MiB chunks, feed to
+        // WriteMultipart which buffers into 5 MiB parts and uploads in
+        // parallel. Never loads the entire file into RAM (#580).
         let mut file = tokio::fs::File::open(src)
             .await
             .map_err(|e| StorageError::Io(e.to_string()))?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf)
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
-        let payload = PutPayload::from(buf);
-        self.store.put(&s3_path, payload).await.map_err(map_err)?;
+
+        // CANCEL-SAFETY: if dropped between put_multipart and finish,
+        // S3 does NOT automatically abort orphaned parts. Cleanup depends
+        // on S3 lifecycle policy (AbortIncompleteMultipartUpload rule).
+        // No partial objects are visible to readers (upload never completed).
+        // finish() calls abort() on its own errors; cancellation (future
+        // dropped) relies on lifecycle policy only.
+        let upload = self.store.put_multipart(&s3_path).await.map_err(map_err)?;
+        let mut writer = WriteMultipart::new(upload);
+
+        let mut buf = vec![0u8; 8 * 1024 * 1024]; // 8 MiB read buffer
+        loop {
+            let n = file
+                .read(&mut buf)
+                .await
+                .map_err(|e| StorageError::Io(e.to_string()))?;
+            if n == 0 {
+                break;
+            }
+            writer.write(&buf[..n]);
+        }
+        writer.finish().await.map_err(map_err)?;
+
         let _ = tokio::fs::remove_file(src).await;
         Ok(())
     }


### PR DESCRIPTION
## What

Docker blob downloads on the proxy/pull path previously loaded the full blob into process memory, so pulling large images caused excessive RSS (#580). This streams blob data end to end:

- upstream → temp file (incremental write, per-chunk read timeout)
- SHA-256 computed incrementally while streaming
- client response streamed from storage/temp via `get_reader` → `Body::from_stream`

No full blob is held in RAM on the proxy pull path. Both storage backends are covered (local `File::open`, S3 `into_stream`).

## Integrity

Because the SHA-256 is computed during the streamed download, it is verified against the requested content-addressable digest **before** the blob is cached and **before** any byte is sent to the client. On mismatch the response is `502`, the blob is not cached, and the temp file is cleaned up. There is no tee-to-client, so verification always precedes serving — this also closes the content-integrity gap.

## Scope

"No full blob in RAM" applies to the **proxy pull** path. The S3 upload path (`WriteMultipart` backpressure) and the `nora mirror` path are not covered here and remain follow-ups; the mirror integrity gap is tracked in #587.

## Commits

- prepare streaming download API surface (`get_reader`, hash-based integrity verify)
- streaming blob download via temp file + incremental SHA-256
- proxy download observability + temp cleanup (RAII guards, stale sweeper)
- stream blob responses without RAM buffering
- integration tests for the integrity reject and serve-and-cache paths

## Tests

Integration tests cover SHA-256 mismatch → `502` (not cached, temp cleaned) and the positive control (verified → `200`, served, cached). Full docker module green; `cargo fmt` and `clippy -D warnings` clean.

Closes #580
Closes #581

Thanks @0x62ash for the report.
