### PR TITLE
fix(secrets): preserve VarError context in env provider

### DIFF
--- a/nora-registry/src/secrets/env.rs
+++ b/nora-registry/src/secrets/env.rs
@@ -49,7 +49,12 @@ impl Default for EnvProvider {
 #[async_trait]
 impl SecretsProvider for EnvProvider {
     async fn get_secret(&self, key: &str) -> Result<ProtectedString, SecretsError> {
-        let value = env::var(key).map_err(|_| SecretsError::NotFound(key.to_string()))?;
+        let value = env::var(key).map_err(|e| match e {
+            env::VarError::NotPresent => SecretsError::NotFound(key.to_string()),
+            env::VarError::NotUnicode(_) => {
+                SecretsError::Provider(format!("environment variable '{key}' is not valid UTF-8"))
+            }
+        })?;
 
         if self.clear_after_read {
             env::remove_var(key);


### PR DESCRIPTION
## Summary
- `env::var` errors in the environment secrets provider were flattened to `SecretsError::NotFound` via `map_err(|_| ...)`, masking the `NotUnicode` case (a present-but-invalid-UTF-8 variable) as "not found".
- Now `NotPresent` maps to `NotFound` and `NotUnicode` maps to a `Provider` error that names the variable, so a misconfigured value is distinguishable from an absent secret.

## Test plan
- [x] `cargo test --bin nora secrets` — 18 passed
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check`