### PR TITLE
security: enforce OIDC namespace_scope on writes (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 ## [Unreleased]
 
+### Security
+- **OIDC `namespace_scope` is now enforced on writes** — it was previously parsed and documented as a per-provider access control but never applied at runtime (fail-open, #583). A provider's `namespace_scope` now restricts which artifact namespaces its tokens may publish to, across docker, raw, npm, maven, pypi and cargo. Matching is segment-aware (`myorg/*` matches `myorg/repo` but never `myorg-evil/...`; use `myorg/**` for everything under `myorg/`).
+  - **BREAKING (behavioral):** if a provider's `namespace_scope` is set to anything other than `["*"]`, out-of-scope writes from that issuer now return `403`. The default `["*"]` is unchanged and remains a no-op, so deployments that never set the field are unaffected. **Check your OIDC config before upgrading.**
+  - To stage the rollout, set `namespace_scope_enforcement = "audit"` on the provider: out-of-scope writes are allowed but logged and counted as `would_deny` via the new `nora_auth_namespace_scope_total{provider,decision}` metric. Switch to `"enforce"` (the default) once the metric is clean.
+  - Scope applies to OIDC identities only; opaque (`nra_`) tokens and Basic auth are unaffected. Reads are never gated.
+
 ## [0.9.3] - 2026-05-30
 
 ### Security

--- a/docs-site/src/content/docs/configuration/authentication.md
+++ b/docs-site/src/content/docs/configuration/authentication.md
@@ -159,6 +159,12 @@ algorithms = ["RS256", "ES256"]
 max_token_lifetime_secs = 900
 enabled = true
 
+# Restrict this issuer to a namespace prefix (default ["*"] = unrestricted).
+# Segment-aware globs: myorg/* = direct children, myorg/** = any depth.
+namespace_scope = ["myorg/**"]
+# "enforce" (default, 403 on out-of-scope writes) or "audit" (log + count only).
+namespace_scope_enforcement = "enforce"
+
 # Role rules: first match wins. Glob patterns on the `sub` claim.
 [[auth.oidc.providers.role_rules]]
 pattern = "repo:myorg/*:ref:refs/heads/main"
@@ -174,6 +180,27 @@ Environment variable override:
 ```bash
 export NORA_AUTH_OIDC_ENABLED=true
 ```
+
+### Namespace Scoping
+
+`namespace_scope` restricts which artifact namespaces an issuer's tokens may **write** to. It applies to publish and delete (PUT/POST/DELETE) on the docker, raw, npm, maven, pypi, and cargo registries. Reads are never gated, and scoping applies to OIDC identities only — not API tokens or Basic auth.
+
+The scope is matched against the artifact's **coordinate** (not the URL path), segment by segment:
+
+| Registry | Coordinate matched | Example scope |
+|----------|--------------------|---------------|
+| docker   | image name (`myorg/app`)          | `myorg/**` |
+| raw      | object path (`myorg/sub/file`)    | `myorg/**` |
+| npm      | package incl. scope (`@myorg/pkg`) | `@myorg/**` |
+| maven    | groupId/artifactId (`com/myorg/lib`) | `com/myorg/**` |
+| pypi     | normalized project name (`myproj`) | `myproj` |
+| cargo    | crate name (`mycrate`)            | `mycrate` |
+
+Matching is anchored on `/` boundaries: `*` matches exactly one segment and `**` matches zero or more. So `myorg/*` matches `myorg/app` but **not** `myorg-evil/app` and **not** `myorg/team/app` — use `myorg/**` for nested paths. The default `["*"]` disables scoping; an empty list `[]` denies all writes (a deliberate lockout). pypi and cargo have flat namespaces (no `/`), so scope them by exact name or use `**`.
+
+A write outside the scope returns `403 Forbidden`.
+
+> **Upgrade note:** until this release, `namespace_scope` was accepted but never enforced. If you already set it to something other than `["*"]`, this version will start returning 403 for out-of-scope writes — review your config before upgrading. To stage the change, set `namespace_scope_enforcement = "audit"`: out-of-scope writes are allowed but logged and counted via the `nora_auth_namespace_scope_total{provider,decision="would_deny"}` metric. Switch back to `"enforce"` once the metric is clean.
 
 ### GitHub Actions Setup
 

--- a/docs-site/src/content/docs/ru/configuration/authentication.md
+++ b/docs-site/src/content/docs/ru/configuration/authentication.md
@@ -159,6 +159,12 @@ algorithms = ["RS256", "ES256"]
 max_token_lifetime_secs = 900
 enabled = true
 
+# Ограничить издателя префиксом namespace (по умолчанию ["*"] = без ограничений).
+# Посегментные glob: myorg/* = прямые потомки, myorg/** = любая глубина.
+namespace_scope = ["myorg/**"]
+# "enforce" (по умолчанию, 403 при выходе за scope) или "audit" (только лог + счётчик).
+namespace_scope_enforcement = "enforce"
+
 # Правила ролей: первое совпадение побеждает. Glob-паттерны по `sub` claim.
 [[auth.oidc.providers.role_rules]]
 pattern = "repo:myorg/*:ref:refs/heads/main"
@@ -174,6 +180,27 @@ role = "read"
 ```bash
 export NORA_AUTH_OIDC_ENABLED=true
 ```
+
+### Ограничение по namespace
+
+`namespace_scope` ограничивает, в какие namespace токены издателя могут **писать**. Применяется к публикации и удалению (PUT/POST/DELETE) для реестров docker, raw, npm, maven, pypi и cargo. Чтение никогда не ограничивается; scope действует только для OIDC-идентичностей (не для API-токенов и не для Basic auth).
+
+Scope сверяется с **координатой** артефакта (а не с URL-путём), посегментно:
+
+| Реестр | Сверяемая координата | Пример scope |
+|--------|----------------------|--------------|
+| docker | имя образа (`myorg/app`)            | `myorg/**` |
+| raw    | путь объекта (`myorg/sub/file`)     | `myorg/**` |
+| npm    | пакет со scope (`@myorg/pkg`)       | `@myorg/**` |
+| maven  | groupId/artifactId (`com/myorg/lib`)| `com/myorg/**` |
+| pypi   | нормализованное имя проекта (`myproj`) | `myproj` |
+| cargo  | имя крейта (`mycrate`)              | `mycrate` |
+
+Сопоставление привязано к границам `/`: `*` соответствует ровно одному сегменту, `**` — нулю или более. Поэтому `myorg/*` совпадает с `myorg/app`, но **не** с `myorg-evil/app` и **не** с `myorg/team/app` — для вложенных путей используйте `myorg/**`. Значение по умолчанию `["*"]` отключает ограничение; пустой список `[]` запрещает любую запись (намеренная блокировка). У pypi и cargo плоское пространство имён (без `/`) — ограничивайте по точному имени или используйте `**`.
+
+Запись вне scope возвращает `403 Forbidden`.
+
+> **Замечание об обновлении:** до этого релиза `namespace_scope` принимался, но не применялся. Если вы уже задали значение, отличное от `["*"]`, эта версия начнёт возвращать 403 для записи вне scope — проверьте конфигурацию перед обновлением. Для поэтапного внедрения задайте `namespace_scope_enforcement = "audit"`: запись вне scope разрешается, но логируется и считается метрикой `nora_auth_namespace_scope_total{provider,decision="would_deny"}`. Верните `"enforce"`, когда метрика будет чистой.
 
 ### Настройка GitHub Actions
 

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -9,10 +9,12 @@
 //! - Brute-force protection with exponential backoff
 
 mod htpasswd;
+mod namespace;
 pub mod oidc;
 mod token_routes;
 
 pub use htpasswd::HtpasswdAuth;
+pub use namespace::{enforce_namespace_scope, NamespaceAuthority};
 pub use oidc::OidcValidator;
 pub use token_routes::{token_routes, TokenListItem, TokenListResponse};
 
@@ -28,7 +30,6 @@ use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
 
-use crate::validation::NamespaceAuthority;
 use crate::AppState;
 
 /// Tracks failed authentication attempts per IP for brute-force protection.
@@ -307,6 +308,7 @@ pub async fn auth_middleware(
                         let authority = NamespaceAuthority::from_oidc_scope(
                             &identity.provider,
                             &identity.namespace_scope,
+                            identity.namespace_scope_enforcement,
                         );
                         request.extensions_mut().insert(authority);
                         return next.run(request).await;
@@ -1140,6 +1142,7 @@ Jd74nq6dNCjpWG4drIsyhqX+
                     algorithms: vec!["RS256".to_string()],
                     max_token_lifetime_secs: 900,
                     namespace_scope: vec!["*".to_string()],
+                    namespace_scope_enforcement: crate::config::ScopeEnforcement::Enforce,
                     enabled: true,
                     role_rules: vec![
                         OidcRoleRule {

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Instant;
 
+use crate::validation::NamespaceAuthority;
 use crate::AppState;
 
 /// Tracks failed authentication attempts per IP for brute-force protection.
@@ -167,16 +168,22 @@ fn extract_client_ip(
 /// Auth middleware - supports Basic auth, Bearer tokens, and OIDC JWT
 pub async fn auth_middleware(
     State(state): State<AppState>,
-    request: Request<Body>,
+    mut request: Request<Body>,
     next: Next,
 ) -> Response {
     // Skip auth if disabled (neither htpasswd nor OIDC configured)
     if !state.config.auth.enabled {
+        request
+            .extensions_mut()
+            .insert(NamespaceAuthority::Unrestricted);
         return next.run(request).await;
     }
 
     // Skip auth for public endpoints
     if is_public_path(request.uri().path()) {
+        request
+            .extensions_mut()
+            .insert(NamespaceAuthority::Unrestricted);
         return next.run(request).await;
     }
 
@@ -202,6 +209,9 @@ pub async fn auth_middleware(
         && !is_token_management
     {
         // Read requests allowed without auth
+        request
+            .extensions_mut()
+            .insert(NamespaceAuthority::Unrestricted);
         return next.run(request).await;
     }
 
@@ -256,6 +266,10 @@ pub async fn auth_middleware(
                     {
                         return (StatusCode::FORBIDDEN, "Read-only token").into_response();
                     }
+                    // Opaque (nra_) tokens are not namespace-scoped (#583 is OIDC-only).
+                    request
+                        .extensions_mut()
+                        .insert(NamespaceAuthority::Unrestricted);
                     return next.run(request).await;
                 }
                 Err(_) => {
@@ -288,6 +302,13 @@ pub async fn auth_middleware(
                             return (StatusCode::FORBIDDEN, "Read-only OIDC identity")
                                 .into_response();
                         }
+                        // Carry the provider's namespace_scope into the request so
+                        // write handlers can enforce it on the artifact coordinate (#583).
+                        let authority = NamespaceAuthority::from_oidc_scope(
+                            &identity.provider,
+                            &identity.namespace_scope,
+                        );
+                        request.extensions_mut().insert(authority);
                         return next.run(request).await;
                     }
                     Err(_) => {
@@ -343,6 +364,10 @@ pub async fn auth_middleware(
     if let Some(ip) = client_ip {
         state.auth_failures.record_success(&ip);
     }
+    // Basic-auth identities are not namespace-scoped (#583 is OIDC-only).
+    request
+        .extensions_mut()
+        .insert(NamespaceAuthority::Unrestricted);
     next.run(request).await
 }
 

--- a/nora-registry/src/auth/namespace.rs
+++ b/nora-registry/src/auth/namespace.rs
@@ -1,0 +1,209 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+
+//! OIDC `namespace_scope` authorization (#583).
+//!
+//! The auth middleware stamps a [`NamespaceAuthority`] into the request
+//! extensions on every path; write handlers call [`enforce_namespace_scope`]
+//! with the artifact coordinate they parsed (never the storage key). The
+//! segment-aware matcher itself lives in `crate::validation` so it can be fuzzed
+//! without pulling in the binary-only metrics/config wired up here.
+
+use std::sync::Arc;
+
+use crate::config::ScopeEnforcement;
+use crate::metrics::NAMESPACE_SCOPE_DECISIONS;
+use crate::validation::namespace_match;
+
+/// Per-request namespace authorization, derived from the authenticated identity.
+///
+/// Present on every request (the middleware inserts it on all paths), so write
+/// handlers can extract it without a fallback.
+#[derive(Clone, Debug)]
+pub enum NamespaceAuthority {
+    /// No namespace restriction: Basic auth, opaque (`nra_`) tokens, anonymous
+    /// reads, auth disabled, or an OIDC provider scoped to `["*"]`.
+    Unrestricted,
+    /// An OIDC identity restricted to the given scope patterns.
+    Scoped {
+        /// Glob patterns from the provider's `namespace_scope` (segment-aware,
+        /// see [`crate::validation::namespace_match`]).
+        patterns: Arc<[String]>,
+        /// Provider name, included in deny logs and the metric (never the token).
+        provider: Arc<str>,
+        /// Whether a mismatch denies (403) or is only audited.
+        mode: ScopeEnforcement,
+    },
+}
+
+impl NamespaceAuthority {
+    /// Build an authority from an OIDC provider's `namespace_scope`.
+    ///
+    /// A scope containing a bare `*` collapses to [`NamespaceAuthority::Unrestricted`]
+    /// so the default `namespace_scope = ["*"]` is a true no-op. An empty scope
+    /// (`[]`) stays `Scoped` with no patterns and therefore denies every write
+    /// (fail-closed) — a deliberate operator lockout.
+    pub fn from_oidc_scope(provider: &str, scope: &[String], mode: ScopeEnforcement) -> Self {
+        if scope.iter().any(|p| p == "*") {
+            return NamespaceAuthority::Unrestricted;
+        }
+        NamespaceAuthority::Scoped {
+            patterns: Arc::from(scope.to_vec()),
+            provider: Arc::from(provider),
+            mode,
+        }
+    }
+}
+
+/// A write was denied because its artifact coordinate fell outside the
+/// authenticated OIDC identity's `namespace_scope`. Callers map this to HTTP 403
+/// and must not touch storage (fail-closed).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceDenied;
+
+/// Enforce an OIDC `namespace_scope` against the artifact `namespace` coordinate
+/// a write handler is about to act on.
+///
+/// `namespace` MUST be the canonical artifact coordinate the handler derived
+/// (docker image name, npm package, raw path, …) — never the raw URL path and
+/// never the storage key, which carry transport prefixes/suffixes that would make
+/// scoping format-dependent and bypassable.
+///
+/// Returns `Ok(())` for an [`NamespaceAuthority::Unrestricted`] authority, when
+/// `namespace` matches a scope pattern, or when the provider is in
+/// [`ScopeEnforcement::Audit`] mode (the mismatch is logged and counted as
+/// `would_deny`, but allowed). Returns `Err(NamespaceDenied)` only for an
+/// enforced mismatch. Every decision increments `nora_auth_namespace_scope_total`.
+pub fn enforce_namespace_scope(
+    authority: &NamespaceAuthority,
+    namespace: &str,
+) -> Result<(), NamespaceDenied> {
+    let (patterns, provider, mode) = match authority {
+        NamespaceAuthority::Unrestricted => return Ok(()),
+        NamespaceAuthority::Scoped {
+            patterns,
+            provider,
+            mode,
+        } => (patterns, provider, *mode),
+    };
+
+    if patterns.iter().any(|p| namespace_match(p, namespace)) {
+        NAMESPACE_SCOPE_DECISIONS
+            .with_label_values(&[provider, "allow"])
+            .inc();
+        return Ok(());
+    }
+
+    match mode {
+        ScopeEnforcement::Enforce => {
+            NAMESPACE_SCOPE_DECISIONS
+                .with_label_values(&[provider, "deny"])
+                .inc();
+            tracing::warn!(
+                provider = %provider,
+                namespace = %namespace,
+                patterns = ?patterns,
+                "OIDC namespace_scope denied write outside provider scope"
+            );
+            Err(NamespaceDenied)
+        }
+        ScopeEnforcement::Audit => {
+            NAMESPACE_SCOPE_DECISIONS
+                .with_label_values(&[provider, "would_deny"])
+                .inc();
+            tracing::warn!(
+                provider = %provider,
+                namespace = %namespace,
+                patterns = ?patterns,
+                "OIDC namespace_scope (audit) would have denied write outside provider scope"
+            );
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn scope(patterns: &[&str]) -> Vec<String> {
+        patterns.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn default_star_scope_is_unrestricted() {
+        // The default `namespace_scope = ["*"]` collapses to Unrestricted (no-op).
+        let auth =
+            NamespaceAuthority::from_oidc_scope("ci", &scope(&["*"]), ScopeEnforcement::Enforce);
+        assert!(matches!(auth, NamespaceAuthority::Unrestricted));
+        assert!(enforce_namespace_scope(&auth, "anyorg/whatever").is_ok());
+        // A `*` anywhere in the list is enough to be unrestricted.
+        let auth = NamespaceAuthority::from_oidc_scope(
+            "ci",
+            &scope(&["myorg/**", "*"]),
+            ScopeEnforcement::Enforce,
+        );
+        assert!(matches!(auth, NamespaceAuthority::Unrestricted));
+    }
+
+    #[test]
+    fn unrestricted_authority_always_allows() {
+        assert!(enforce_namespace_scope(&NamespaceAuthority::Unrestricted, "").is_ok());
+        assert!(enforce_namespace_scope(&NamespaceAuthority::Unrestricted, "a/b/c").is_ok());
+    }
+
+    #[test]
+    fn scoped_enforce_allows_inside_denies_outside() {
+        let auth = NamespaceAuthority::from_oidc_scope(
+            "github",
+            &scope(&["myorg/**"]),
+            ScopeEnforcement::Enforce,
+        );
+        assert!(enforce_namespace_scope(&auth, "myorg/repo").is_ok());
+        assert!(enforce_namespace_scope(&auth, "myorg/team/repo").is_ok());
+        assert_eq!(
+            enforce_namespace_scope(&auth, "other/repo"),
+            Err(NamespaceDenied)
+        );
+        // The #583 lookalike must be denied, not allowed.
+        assert_eq!(
+            enforce_namespace_scope(&auth, "myorg-evil/repo"),
+            Err(NamespaceDenied)
+        );
+    }
+
+    #[test]
+    fn audit_mode_allows_but_never_errors() {
+        let auth = NamespaceAuthority::from_oidc_scope(
+            "github",
+            &scope(&["myorg/**"]),
+            ScopeEnforcement::Audit,
+        );
+        // Inside scope: allowed. Outside scope: still allowed (only counted/logged).
+        assert!(enforce_namespace_scope(&auth, "myorg/repo").is_ok());
+        assert!(enforce_namespace_scope(&auth, "other/repo").is_ok());
+    }
+
+    #[test]
+    fn empty_scope_is_fail_closed() {
+        // `namespace_scope = []` is a deliberate lockout: deny everything.
+        let auth =
+            NamespaceAuthority::from_oidc_scope("ci", &scope(&[]), ScopeEnforcement::Enforce);
+        assert_eq!(
+            enforce_namespace_scope(&auth, "anything"),
+            Err(NamespaceDenied)
+        );
+    }
+
+    #[test]
+    fn empty_namespace_under_scope_is_denied() {
+        // A handler that fails to derive a coordinate must not fall open.
+        let auth = NamespaceAuthority::from_oidc_scope(
+            "ci",
+            &scope(&["myorg/**"]),
+            ScopeEnforcement::Enforce,
+        );
+        assert_eq!(enforce_namespace_scope(&auth, ""), Err(NamespaceDenied));
+    }
+}

--- a/nora-registry/src/auth/oidc.rs
+++ b/nora-registry/src/auth/oidc.rs
@@ -37,6 +37,9 @@ pub struct OidcIdentity {
     pub issuer: String,
     /// Assigned role based on role_rules
     pub role: Role,
+    /// Provider's `namespace_scope` patterns (segment-aware globs). `["*"]` = all
+    /// namespaces. Enforced on writes via `validation::enforce_namespace_scope`.
+    pub namespace_scope: Vec<String>,
 }
 
 /// Standard JWT claims we extract.
@@ -215,6 +218,7 @@ impl OidcValidator {
             subject,
             issuer: provider.issuer.clone(),
             role,
+            namespace_scope: provider.namespace_scope.clone(),
         })
     }
 

--- a/nora-registry/src/auth/oidc.rs
+++ b/nora-registry/src/auth/oidc.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use crate::config::{OidcConfig, OidcProvider};
+use crate::config::{OidcConfig, OidcProvider, ScopeEnforcement};
 use crate::tokens::Role;
 
 /// Result of a successful OIDC authentication.
@@ -38,8 +38,11 @@ pub struct OidcIdentity {
     /// Assigned role based on role_rules
     pub role: Role,
     /// Provider's `namespace_scope` patterns (segment-aware globs). `["*"]` = all
-    /// namespaces. Enforced on writes via `validation::enforce_namespace_scope`.
+    /// namespaces. Enforced on writes via `auth::enforce_namespace_scope`.
     pub namespace_scope: Vec<String>,
+    /// Whether `namespace_scope` is enforced (403 on mismatch) or only audited
+    /// for this provider.
+    pub namespace_scope_enforcement: ScopeEnforcement,
 }
 
 /// Standard JWT claims we extract.
@@ -219,6 +222,7 @@ impl OidcValidator {
             issuer: provider.issuer.clone(),
             role,
             namespace_scope: provider.namespace_scope.clone(),
+            namespace_scope_enforcement: provider.namespace_scope_enforcement,
         })
     }
 
@@ -445,6 +449,7 @@ mod tests {
             algorithms: vec!["RS256".to_string()],
             max_token_lifetime_secs: 900,
             namespace_scope: vec!["*".to_string()],
+            namespace_scope_enforcement: crate::config::ScopeEnforcement::Enforce,
             enabled: true,
             role_rules: vec![
                 OidcRoleRule {

--- a/nora-registry/src/config/auth.rs
+++ b/nora-registry/src/config/auth.rs
@@ -236,6 +236,12 @@ pub struct OidcProvider {
     /// ["*"] = all, ["github/*"] = only repos under github/ prefix.
     #[serde(default = "default_namespace_scope")]
     pub namespace_scope: Vec<String>,
+    /// How `namespace_scope` is applied on writes: `enforce` (deny with 403,
+    /// the default) or `audit` (allow the write but log and count what would
+    /// have been denied). Audit mode lets operators stage a rollout — deploy in
+    /// audit, watch the metric, then switch to enforce (#583).
+    #[serde(default)]
+    pub namespace_scope_enforcement: ScopeEnforcement,
     /// Kill switch — disable this provider without removing config
     #[serde(default = "super::default_true")]
     pub enabled: bool,
@@ -252,6 +258,18 @@ pub struct OidcRoleRule {
     pub pattern: String,
     /// Role to assign: "read", "write", or "admin"
     pub role: String,
+}
+
+/// How an OIDC provider's `namespace_scope` is applied on writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ScopeEnforcement {
+    /// Deny out-of-scope writes with HTTP 403 (default, fail-closed).
+    #[default]
+    Enforce,
+    /// Allow out-of-scope writes but log and count them as `would_deny`. Used to
+    /// stage a rollout before turning on hard denial.
+    Audit,
 }
 
 pub(super) fn default_oidc_leeway() -> u64 {

--- a/nora-registry/src/config/auth.rs
+++ b/nora-registry/src/config/auth.rs
@@ -179,7 +179,16 @@ pub struct AuthConfig {
 /// audience = "nora"
 /// algorithms = ["RS256", "ES256"]
 /// max_token_lifetime_secs = 900
-/// namespace_scope = ["*"]
+/// # Restrict this issuer to artifacts whose coordinate is under `myorg/`.
+/// # Segment-aware: `myorg/*` = direct children only, `myorg/**` = any depth.
+/// # Per format the coordinate is: docker image (`myorg/<img>`), raw path
+/// # (`myorg/<path>`), npm package (`@myorg/*`), maven group/artifact
+/// # (`com/myorg/**`), pypi/cargo the normalized project/crate name.
+/// # `["*"]` (the default) disables scoping for this issuer.
+/// namespace_scope = ["myorg/**"]
+/// # "enforce" (default) denies out-of-scope writes with 403; "audit" allows
+/// # but logs+counts them (nora_auth_namespace_scope_total) for staged rollout.
+/// namespace_scope_enforcement = "enforce"
 ///
 /// [auth.oidc.providers.role_rules]
 /// "repo:myorg/*:ref:refs/heads/main" = "write"

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -23,7 +23,9 @@ mod storage;
 pub use self::audit_cfg::AuditConfig;
 // Re-exports maintain API surface: `crate::config::OidcRoleRule` etc. used by test code in auth/, circuit_breaker/
 #[allow(unused_imports)]
-pub use self::auth::{AuthConfig, OidcConfig, OidcProvider, OidcRoleRule, TrustedProxies};
+pub use self::auth::{
+    AuthConfig, OidcConfig, OidcProvider, OidcRoleRule, ScopeEnforcement, TrustedProxies,
+};
 #[allow(unused_imports)]
 pub use self::circuit_breaker::{CircuitBreakerConfig, CircuitBreakerOverride};
 pub use self::curation::{

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -62,6 +62,18 @@ pub static STORAGE_OPERATIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("failed to create STORAGE_OPERATIONS metric at startup")
 });
 
+/// OIDC namespace_scope enforcement decisions, by provider and decision.
+/// `decision` is one of: allow | deny | would_deny (audit mode). Lets operators
+/// watch a staged rollout before switching a provider from audit to enforce (#583).
+pub static NAMESPACE_SCOPE_DECISIONS: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_auth_namespace_scope_total",
+        "OIDC namespace_scope enforcement decisions",
+        &["provider", "decision"]
+    )
+    .expect("failed to create NAMESPACE_SCOPE_DECISIONS metric at startup")
+});
+
 /// Artifacts count by registry
 #[allow(dead_code)]
 pub static ARTIFACTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -12,12 +12,13 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
-use crate::validation::{enforce_namespace_scope, validate_storage_key, NamespaceAuthority};
+use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
     body::Bytes,

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -17,7 +17,7 @@ use crate::registry::{
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
-use crate::validation::validate_storage_key;
+use crate::validation::{enforce_namespace_scope, validate_storage_key, NamespaceAuthority};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -25,7 +25,7 @@ use axum::{
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, put},
-    Router,
+    Extension, Router,
 };
 use sha2::Digest;
 use std::time::Duration;
@@ -377,7 +377,11 @@ async fn download(
 ///   N bytes:    metadata JSON
 ///   4 bytes LE: .crate tarball length
 ///   M bytes:    .crate tarball
-async fn publish(State(state): State<AppState>, body: Bytes) -> Response {
+async fn publish(
+    State(state): State<AppState>,
+    Extension(authority): Extension<NamespaceAuthority>,
+    body: Bytes,
+) -> Response {
     if body.len() < 8 {
         return (StatusCode::BAD_REQUEST, "Payload too small").into_response();
     }
@@ -437,6 +441,11 @@ async fn publish(State(state): State<AppState>, body: Bytes) -> Response {
     // Normalize to lowercase for consistent storage keys
     let name = name.to_lowercase();
     let vers = vers.to_string();
+
+    // Enforce OIDC namespace_scope on the crate coordinate (#583).
+    if enforce_namespace_scope(&authority, &name).is_err() {
+        return (StatusCode::FORBIDDEN, "Outside namespace scope").into_response();
+    }
 
     // TOCTOU protection: lock per crate (not per version!) to serialize
     // index read-modify-write. The index file is shared across all versions

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -757,6 +757,45 @@ mod tests {
 #[allow(clippy::unwrap_used)]
 mod integration_tests {
     use crate::test_helpers::{body_bytes, create_test_context, send};
+
+    #[tokio::test]
+    async fn test_cargo_namespace_scope_enforced() {
+        use crate::auth::NamespaceAuthority;
+        use crate::config::ScopeEnforcement;
+        use axum::body::Bytes;
+        use axum::extract::State;
+        use axum::Extension;
+
+        let ctx = create_test_context();
+        let scoped = NamespaceAuthority::from_oidc_scope(
+            "ci",
+            &["acme/**".to_string()],
+            ScopeEnforcement::Enforce,
+        );
+
+        // Crate name outside scope -> 403.
+        let metadata =
+            serde_json::json!({"name":"other-crate","vers":"0.1.0","deps":[],"features":{}});
+        let payload = build_publish_payload(&metadata, b"data");
+        let resp = super::publish(
+            State(ctx.state.clone()),
+            Extension(scoped.clone()),
+            Bytes::from(payload),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Crate name covered by the scope -> enforcement passes (not 403).
+        let metadata = serde_json::json!({"name":"acme","vers":"0.1.0","deps":[],"features":{}});
+        let payload = build_publish_payload(&metadata, b"data");
+        let resp = super::publish(
+            State(ctx.state.clone()),
+            Extension(scoped),
+            Bytes::from(payload),
+        )
+        .await;
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    }
     use axum::body::Body;
     use axum::http::{Method, StatusCode};
 

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -2936,6 +2936,62 @@ mod integration_tests {
     use sha2::Digest;
 
     #[tokio::test]
+    async fn test_docker_namespace_scope_enforced() {
+        use crate::auth::NamespaceAuthority;
+        use crate::config::ScopeEnforcement;
+        use axum::body::Bytes;
+        use axum::extract::{Path, State};
+        use axum::http::Uri;
+        use axum::Extension;
+
+        let ctx = create_test_context();
+        let scoped = NamespaceAuthority::from_oidc_scope(
+            "ci",
+            &["myorg/**".to_string()],
+            ScopeEnforcement::Enforce,
+        );
+
+        // Out-of-scope blob upload (POST) -> 403.
+        let resp = super::docker_v2_dispatch(
+            State(ctx.state.clone()),
+            Method::POST,
+            Path("other/app/blobs/uploads/".to_string()),
+            Extension(scoped.clone()),
+            "/v2/other/app/blobs/uploads/".parse::<Uri>().unwrap(),
+            axum::http::HeaderMap::new(),
+            Bytes::new(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // In-scope blob upload start -> not denied (enforcement passes).
+        let resp = super::docker_v2_dispatch(
+            State(ctx.state.clone()),
+            Method::POST,
+            Path("myorg/app/blobs/uploads/".to_string()),
+            Extension(scoped.clone()),
+            "/v2/myorg/app/blobs/uploads/".parse::<Uri>().unwrap(),
+            axum::http::HeaderMap::new(),
+            Bytes::new(),
+        )
+        .await;
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Reads are never gated, even out of scope (404, not 403).
+        let resp = super::docker_v2_dispatch(
+            State(ctx.state.clone()),
+            Method::GET,
+            Path("other/app/manifests/latest".to_string()),
+            Extension(scoped.clone()),
+            "/v2/other/app/manifests/latest".parse::<Uri>().unwrap(),
+            axum::http::HeaderMap::new(),
+            Bytes::new(),
+        )
+        .await;
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
     async fn test_docker_v2_check() {
         let ctx = create_test_context();
         let resp = send(&ctx.app, Method::GET, "/v2/", Body::empty()).await;

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -10,7 +10,8 @@ use crate::registry::{circuit_open_response, method_not_allowed, ProxyError};
 use crate::secrets::expose_opt;
 use crate::storage::Storage;
 use crate::validation::{
-    ends_with_ci, validate_digest, validate_docker_name, validate_docker_reference,
+    ends_with_ci, enforce_namespace_scope, validate_digest, validate_docker_name,
+    validate_docker_reference, NamespaceAuthority,
 };
 use crate::AppState;
 use axum::{
@@ -19,7 +20,7 @@ use axum::{
     http::{header, HeaderName, Method, StatusCode, Uri},
     response::{IntoResponse, Response},
     routing::get,
-    Json, Router,
+    Extension, Json, Router,
 };
 use futures::StreamExt;
 use parking_lot::RwLock;
@@ -564,6 +565,7 @@ async fn docker_v2_dispatch(
     state: State<AppState>,
     method: Method,
     Path(wildcard): Path<String>,
+    Extension(authority): Extension<NamespaceAuthority>,
     uri: Uri,
     headers: axum::http::HeaderMap,
     body: Bytes,
@@ -572,6 +574,13 @@ async fn docker_v2_dispatch(
     if rest.is_empty() {
         return StatusCode::NOT_FOUND.into_response();
     }
+
+    // Writes (push/delete) are gated by OIDC namespace_scope on the image name,
+    // which is the docker namespace coordinate (#583). Reads are never gated here.
+    let is_write = matches!(
+        method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    );
 
     // Parse endpoint pattern from right — handles names containing "blobs", "manifests", etc.
     // Order matters: check blob uploads before blobs (substring overlap).
@@ -583,6 +592,9 @@ async fn docker_v2_dispatch(
         }
         if validate_docker_name(name).is_err() {
             return (StatusCode::BAD_REQUEST, "Invalid image name").into_response();
+        }
+        if is_write && enforce_namespace_scope(&authority, name).is_err() {
+            return StatusCode::FORBIDDEN.into_response();
         }
         return if after.is_empty() {
             match method {
@@ -617,6 +629,9 @@ async fn docker_v2_dispatch(
         if validate_docker_name(name).is_err() {
             return (StatusCode::BAD_REQUEST, "Invalid image name").into_response();
         }
+        if is_write && enforce_namespace_scope(&authority, name).is_err() {
+            return StatusCode::FORBIDDEN.into_response();
+        }
         return match method {
             Method::HEAD => check_blob(state, Path((name.to_string(), digest.to_string()))).await,
             Method::GET => {
@@ -636,6 +651,9 @@ async fn docker_v2_dispatch(
         }
         if validate_docker_name(name).is_err() {
             return (StatusCode::BAD_REQUEST, "Invalid image name").into_response();
+        }
+        if is_write && enforce_namespace_scope(&authority, name).is_err() {
+            return StatusCode::FORBIDDEN.into_response();
         }
         return match method {
             Method::GET | Method::HEAD => {

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -3,6 +3,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
 use crate::registry::docker_auth::DockerAuth;
@@ -10,8 +11,7 @@ use crate::registry::{circuit_open_response, method_not_allowed, ProxyError};
 use crate::secrets::expose_opt;
 use crate::storage::Storage;
 use crate::validation::{
-    ends_with_ci, enforce_namespace_scope, validate_digest, validate_docker_name,
-    validate_docker_reference, NamespaceAuthority,
+    ends_with_ci, validate_digest, validate_docker_name, validate_docker_reference,
 };
 use crate::AppState;
 use axum::{

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -802,6 +802,53 @@ mod tests {
 #[allow(clippy::unwrap_used)]
 mod integration_tests {
     use crate::test_helpers::{body_bytes, create_test_context, send};
+
+    #[tokio::test]
+    async fn test_maven_namespace_scope_enforced() {
+        use crate::auth::NamespaceAuthority;
+        use crate::config::ScopeEnforcement;
+        use axum::body::Bytes;
+        use axum::extract::{Path, State};
+        use axum::http::StatusCode;
+        use axum::Extension;
+
+        let ctx = create_test_context();
+        let scoped = NamespaceAuthority::from_oidc_scope(
+            "ci",
+            &["com/myorg/**".to_string()],
+            ScopeEnforcement::Enforce,
+        );
+
+        // Out of scope (different group) -> 403.
+        let resp = super::upload(
+            State(ctx.state.clone()),
+            Path("com/other/lib/1.0/lib-1.0.jar".to_string()),
+            Extension(scoped.clone()),
+            Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Opaque (unrecognized) path under a real scope -> fail-closed 403.
+        let resp = super::upload(
+            State(ctx.state.clone()),
+            Path("foo".to_string()),
+            Extension(scoped.clone()),
+            Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // In scope -> enforcement passes (not 403).
+        let resp = super::upload(
+            State(ctx.state.clone()),
+            Path("com/myorg/lib/1.0/lib-1.0.jar".to_string()),
+            Extension(scoped),
+            Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    }
     use axum::body::Body;
     use axum::http::{header, Method, StatusCode};
     use sha2::Digest;

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -10,9 +10,10 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::registry::{circuit_open_response, method_not_allowed, proxy_fetch, ProxyError};
 use crate::registry_type::RegistryType;
-use crate::validation::{ends_with_ci, enforce_namespace_scope, NamespaceAuthority};
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     body::Bytes,

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -12,7 +12,7 @@ use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::{circuit_open_response, method_not_allowed, proxy_fetch, ProxyError};
 use crate::registry_type::RegistryType;
-use crate::validation::ends_with_ci;
+use crate::validation::{ends_with_ci, enforce_namespace_scope, NamespaceAuthority};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -20,7 +20,7 @@ use axum::{
     http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
-    Router,
+    Extension, Router,
 };
 use sha2::Digest;
 use std::collections::BTreeSet;
@@ -230,9 +230,29 @@ async fn download(
 // Upload
 // ============================================================================
 
-async fn upload(State(state): State<AppState>, Path(path): Path<String>, body: Bytes) -> Response {
+async fn upload(
+    State(state): State<AppState>,
+    Path(path): Path<String>,
+    Extension(authority): Extension<NamespaceAuthority>,
+    body: Bytes,
+) -> Response {
     if !path.is_ascii() || path.contains("..") || path.contains('\0') || path.starts_with('/') {
         return (StatusCode::BAD_REQUEST, "Invalid path").into_response();
+    }
+
+    // Enforce OIDC namespace_scope on the artifact coordinate (group/artifactId).
+    // An unrecognized (Opaque) path yields an empty coordinate → fail-closed (#583).
+    let maven_namespace = match classify_path(&path) {
+        MavenPathKind::VersionFile(c) => format!("{}/{}", c.group_path, c.artifact_id),
+        MavenPathKind::ArtifactMeta {
+            group_path,
+            artifact_id,
+            ..
+        } => format!("{}/{}", group_path, artifact_id),
+        MavenPathKind::Opaque => String::new(),
+    };
+    if enforce_namespace_scope(&authority, &maven_namespace).is_err() {
+        return StatusCode::FORBIDDEN.into_response();
     }
 
     let key = format!("maven/{}", path);

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -962,6 +962,43 @@ mod tests {
 #[allow(clippy::unwrap_used)]
 mod integration_tests {
     use crate::test_helpers::{body_bytes, create_test_context, send};
+
+    #[tokio::test]
+    async fn test_npm_namespace_scope_enforced() {
+        use crate::auth::NamespaceAuthority;
+        use crate::config::ScopeEnforcement;
+        use axum::body::Bytes;
+        use axum::extract::{Path, State};
+        use axum::http::StatusCode;
+        use axum::Extension;
+
+        let ctx = create_test_context();
+        let scoped = NamespaceAuthority::from_oidc_scope(
+            "ci",
+            &["@myorg/**".to_string()],
+            ScopeEnforcement::Enforce,
+        );
+
+        // Out of scope -> 403, decided before any payload parsing.
+        let resp = super::handle_publish(
+            State(ctx.state.clone()),
+            Path("@other/pkg".to_string()),
+            Extension(scoped.clone()),
+            Bytes::from_static(b"{}"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // In scope -> enforcement passes (then fails payload validation, not 403).
+        let resp = super::handle_publish(
+            State(ctx.state.clone()),
+            Path("@myorg/pkg".to_string()),
+            Extension(scoped),
+            Bytes::from_static(b"{}"),
+        )
+        .await;
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
+    }
     use axum::body::Body;
     use axum::http::{Method, StatusCode};
     use base64::Engine;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -9,6 +9,7 @@ use crate::registry::{
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
+use crate::validation::{enforce_namespace_scope, NamespaceAuthority};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -16,7 +17,7 @@ use axum::{
     http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
-    Router,
+    Extension, Router,
 };
 use base64::Engine;
 use sha2::Digest;
@@ -393,9 +394,15 @@ fn is_valid_attachment_name(name: &str) -> bool {
 async fn handle_publish(
     State(state): State<AppState>,
     Path(path): Path<String>,
+    Extension(authority): Extension<NamespaceAuthority>,
     body: Bytes,
 ) -> Response {
     let package_name = path;
+
+    // Enforce OIDC namespace_scope on the package coordinate (#583).
+    if enforce_namespace_scope(&authority, &package_name).is_err() {
+        return StatusCode::FORBIDDEN.into_response();
+    }
 
     let payload: serde_json::Value = match serde_json::from_slice(&body) {
         Ok(v) => v,

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -3,13 +3,13 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::metrics::METADATA_CORRUPT_TOTAL;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
-use crate::validation::{enforce_namespace_scope, NamespaceAuthority};
 use crate::AppState;
 use axum::{
     body::Bytes,

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -17,14 +17,14 @@ use crate::registry::{
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
 use crate::ui::components::html_escape;
-use crate::validation::ends_with_ci;
+use crate::validation::{ends_with_ci, enforce_namespace_scope, NamespaceAuthority};
 use crate::AppState;
 use axum::{
     extract::{Multipart, Path, State},
     http::{header, HeaderMap, StatusCode},
     response::{Html, IntoResponse, Response},
     routing::get,
-    Router,
+    Extension, Router,
 };
 use sha2::Digest;
 use std::fmt::Write;
@@ -380,7 +380,11 @@ async fn download_file(
 ///   content = the file bytes
 ///   sha256_digest = hex SHA-256 of file (optional)
 ///   metadata_version, summary, etc. (optional metadata)
-async fn upload(State(state): State<AppState>, mut multipart: Multipart) -> Response {
+async fn upload(
+    State(state): State<AppState>,
+    Extension(authority): Extension<NamespaceAuthority>,
+    mut multipart: Multipart,
+) -> Response {
     let mut action = String::new();
     let mut name = String::new();
     let mut version = String::new();
@@ -458,6 +462,11 @@ async fn upload(State(state): State<AppState>, mut multipart: Multipart) -> Resp
 
     // Normalize name and store
     let normalized = normalize_name(&name);
+
+    // Enforce OIDC namespace_scope on the project coordinate (#583).
+    if enforce_namespace_scope(&authority, &normalized).is_err() {
+        return StatusCode::FORBIDDEN.into_response();
+    }
 
     // TOCTOU protection: lock per file to prevent concurrent uploads
     let file_key = format!("pypi/{}/{}", normalized, filename);

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -11,13 +11,14 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_text,
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
 use crate::ui::components::html_escape;
-use crate::validation::{ends_with_ci, enforce_namespace_scope, NamespaceAuthority};
+use crate::validation::ends_with_ci;
 use crate::AppState;
 use axum::{
     extract::{Multipart, Path, State},

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -478,6 +478,63 @@ mod integration_tests {
     };
     use axum::http::{Method, StatusCode};
 
+    fn scoped(mode: crate::config::ScopeEnforcement) -> crate::auth::NamespaceAuthority {
+        crate::auth::NamespaceAuthority::from_oidc_scope("ci", &["myorg/**".to_string()], mode)
+    }
+
+    #[tokio::test]
+    async fn test_raw_namespace_scope_enforced() {
+        use crate::config::ScopeEnforcement;
+        use axum::body::Bytes;
+        use axum::extract::{Path, State};
+        use axum::Extension;
+
+        let ctx = create_test_context();
+
+        // Out of scope -> 403, and nothing is written.
+        let resp = super::upload(
+            State(ctx.state.clone()),
+            Path("other/secret.txt".to_string()),
+            Extension(scoped(ScopeEnforcement::Enforce)),
+            axum::http::HeaderMap::new(),
+            Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(ctx.state.storage.get("raw/other/secret.txt").await.is_err());
+
+        // In scope -> created.
+        let resp = super::upload(
+            State(ctx.state.clone()),
+            Path("myorg/app/file.txt".to_string()),
+            Extension(scoped(ScopeEnforcement::Enforce)),
+            axum::http::HeaderMap::new(),
+            Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        // DELETE out of scope -> 403.
+        let resp = super::delete_file(
+            State(ctx.state.clone()),
+            Path("other/secret.txt".to_string()),
+            Extension(scoped(ScopeEnforcement::Enforce)),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Audit mode allows an out-of-scope write (only logs/counts).
+        let resp = super::upload(
+            State(ctx.state.clone()),
+            Path("elsewhere/a.txt".to_string()),
+            Extension(scoped(ScopeEnforcement::Audit)),
+            axum::http::HeaderMap::new(),
+            Bytes::from_static(b"x"),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
     #[tokio::test]
     async fn test_raw_put_get_roundtrip() {
         let ctx = create_test_context();

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -3,8 +3,9 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
+use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::registry::method_not_allowed;
-use crate::validation::{enforce_namespace_scope, validate_storage_key, NamespaceAuthority};
+use crate::validation::validate_storage_key;
 use crate::AppState;
 use axum::{
     body::Bytes,

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -4,7 +4,7 @@
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
 use crate::registry::method_not_allowed;
-use crate::validation::validate_storage_key;
+use crate::validation::{enforce_namespace_scope, validate_storage_key, NamespaceAuthority};
 use crate::AppState;
 use axum::{
     body::Bytes,
@@ -12,7 +12,7 @@ use axum::{
     http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
-    Router,
+    Extension, Router,
 };
 
 pub fn routes() -> Router<AppState> {
@@ -115,6 +115,7 @@ async fn download(
 async fn upload(
     State(state): State<AppState>,
     Path(path): Path<String>,
+    Extension(authority): Extension<NamespaceAuthority>,
     headers: axum::http::HeaderMap,
     body: Bytes,
 ) -> Response {
@@ -125,6 +126,11 @@ async fn upload(
     let key = format!("raw/{}", path);
     if validate_storage_key(&key).is_err() {
         return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Enforce OIDC namespace_scope on the artifact coordinate (#583).
+    if enforce_namespace_scope(&authority, &path).is_err() {
+        return StatusCode::FORBIDDEN.into_response();
     }
 
     if !path.is_ascii() {
@@ -274,7 +280,11 @@ async fn do_overwrite(state: &AppState, key: &str, path: &str, body: &[u8]) -> R
     }
 }
 
-async fn delete_file(State(state): State<AppState>, Path(path): Path<String>) -> Response {
+async fn delete_file(
+    State(state): State<AppState>,
+    Path(path): Path<String>,
+    Extension(authority): Extension<NamespaceAuthority>,
+) -> Response {
     if !state.config.raw.enabled {
         return StatusCode::NOT_FOUND.into_response();
     }
@@ -282,6 +292,11 @@ async fn delete_file(State(state): State<AppState>, Path(path): Path<String>) ->
     let key = format!("raw/{}", path);
     if validate_storage_key(&key).is_err() {
         return StatusCode::BAD_REQUEST.into_response();
+    }
+
+    // Enforce OIDC namespace_scope on the artifact coordinate (#583).
+    if enforce_namespace_scope(&authority, &path).is_err() {
+        return StatusCode::FORBIDDEN.into_response();
     }
     match state.storage.delete(&key).await {
         Ok(()) => {

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -13,6 +13,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use std::fmt;
+use std::sync::Arc;
 
 /// Validation errors
 #[derive(Debug, Clone, PartialEq)]
@@ -355,6 +356,150 @@ pub async fn reject_null_bytes_middleware(request: Request<Body>, next: Next) ->
     }
 
     next.run(request).await
+}
+
+/// Match an artifact namespace `value` (a slash-separated coordinate such as
+/// `myorg/repo`) against a scope `pattern` using segment-aware glob semantics.
+///
+/// This is used to enforce OIDC `namespace_scope` and is intentionally **not**
+/// the same matcher as the `sub`-claim glob in the OIDC provider: that one is
+/// substring/contains-based and is unsafe for `/`-separated paths (e.g. `org*`
+/// would match `org-evil`). This matcher is anchored at both ends and treats
+/// `/` as a hard segment boundary.
+///
+/// Semantics (wildcards are whole-segment only — they never match across `/`
+/// implicitly):
+/// - the whole pattern `"*"` matches anything — the universal, backward-compatible
+///   no-op used by the default `namespace_scope = ["*"]`.
+/// - a `*` segment matches exactly one segment (`github/*` matches `github/repo`
+///   but not `github/a/b`).
+/// - a `**` segment matches zero or more segments (`github/**` matches `github`,
+///   `github/a`, and `github/a/b`).
+/// - any other segment must match an identical literal segment.
+///
+/// A segment that merely *contains* `*` (e.g. `my*org`) is treated literally and
+/// therefore will not match a real namespace — fail-closed by construction. Only
+/// a segment that is exactly `*` or `**` is a wildcard. Operators should always
+/// include the `/` boundary in scopes (`myorg/**`, not `myorg*`).
+///
+/// # Examples
+/// ```ignore
+/// assert!(namespace_match("*", "anything/at/all"));
+/// assert!(namespace_match("github/*", "github/repo"));
+/// assert!(!namespace_match("github/*", "github-evil/x"));
+/// assert!(!namespace_match("github/*", "github/a/b"));
+/// assert!(namespace_match("github/**", "github/a/b"));
+/// ```
+pub fn namespace_match(pattern: &str, value: &str) -> bool {
+    // Universal no-op: the default scope, and any explicit `*`, matches everything.
+    if pattern == "*" {
+        return true;
+    }
+    let pat: Vec<&str> = pattern.split('/').collect();
+    let val: Vec<&str> = value.split('/').collect();
+    segments_match(&pat, &val)
+}
+
+/// Recursive segment matcher backing [`namespace_match`]. Patterns are operator
+/// config of a handful of segments, so the worst-case branching on `**` is not a
+/// practical concern.
+fn segments_match(pat: &[&str], val: &[&str]) -> bool {
+    match pat.split_first() {
+        // Pattern exhausted: match iff the value is also exhausted (anchored end).
+        None => val.is_empty(),
+        // `**` consumes zero or more value segments.
+        Some((&"**", rest)) => {
+            // Zero consumed:
+            if segments_match(rest, val) {
+                return true;
+            }
+            // One or more consumed (suffixes val[1..], val[2..], …, []):
+            (0..val.len()).any(|i| segments_match(rest, &val[i + 1..]))
+        }
+        // `*` consumes exactly one value segment.
+        Some((&"*", rest)) => !val.is_empty() && segments_match(rest, &val[1..]),
+        // Literal segment must match exactly (anchored start).
+        Some((&lit, rest)) => !val.is_empty() && val[0] == lit && segments_match(rest, &val[1..]),
+    }
+}
+
+/// Per-request namespace authorization, derived from the authenticated identity.
+///
+/// The auth middleware stamps this into the request extensions on **every** path,
+/// so write handlers can extract it without a fallback. It is the vehicle for
+/// enforcing OIDC `namespace_scope` (#583): handlers call
+/// [`enforce_namespace_scope`] with the artifact coordinate they are about to
+/// write, and a `Scoped` authority that does not cover that coordinate yields 403.
+#[derive(Clone, Debug)]
+pub enum NamespaceAuthority {
+    /// No namespace restriction: Basic auth, opaque (`nra_`) tokens, anonymous
+    /// reads, auth disabled, or an OIDC provider scoped to `["*"]`.
+    Unrestricted,
+    /// An OIDC identity restricted to the given scope patterns.
+    Scoped {
+        /// Glob patterns from the provider's `namespace_scope` (segment-aware,
+        /// see [`namespace_match`]).
+        patterns: Arc<[String]>,
+        /// Provider name, included in deny logs (never the token or `sub`).
+        provider: Arc<str>,
+    },
+}
+
+impl NamespaceAuthority {
+    /// Build an authority from an OIDC provider's `namespace_scope`.
+    ///
+    /// A scope containing a bare `*` collapses to [`NamespaceAuthority::Unrestricted`]
+    /// so the default `namespace_scope = ["*"]` is a true no-op. An empty scope
+    /// (`[]`) stays `Scoped` with no patterns and therefore denies every write
+    /// (fail-closed) — a deliberate operator lockout.
+    pub fn from_oidc_scope(provider: &str, scope: &[String]) -> Self {
+        if scope.iter().any(|p| p == "*") {
+            return NamespaceAuthority::Unrestricted;
+        }
+        NamespaceAuthority::Scoped {
+            patterns: Arc::from(scope.to_vec()),
+            provider: Arc::from(provider),
+        }
+    }
+}
+
+/// A write was denied because its artifact coordinate fell outside the
+/// authenticated OIDC identity's `namespace_scope`. Callers must map this to
+/// HTTP 403 and must not touch storage (fail-closed).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceDenied;
+
+/// Enforce an OIDC `namespace_scope` against the artifact `namespace` coordinate
+/// a write handler is about to act on.
+///
+/// `namespace` MUST be the canonical artifact coordinate the handler derived
+/// (e.g. the docker image name `myorg/img`, the npm package `@myorg/pkg`, the raw
+/// path) — never the raw URL path and never the storage key (which carries
+/// transport prefixes/suffixes that would make scoping format-dependent and
+/// bypassable). Returns `Ok(())` for an [`NamespaceAuthority::Unrestricted`]
+/// authority or when `namespace` matches at least one scope pattern; otherwise
+/// returns `Err(NamespaceDenied)` and logs the denial (provider + namespace +
+/// patterns; never the token).
+pub fn enforce_namespace_scope(
+    authority: &NamespaceAuthority,
+    namespace: &str,
+) -> Result<(), NamespaceDenied> {
+    let (patterns, provider) = match authority {
+        NamespaceAuthority::Unrestricted => return Ok(()),
+        NamespaceAuthority::Scoped { patterns, provider } => (patterns, provider),
+    };
+
+    if patterns.iter().any(|p| namespace_match(p, namespace)) {
+        Ok(())
+    } else {
+        tracing::warn!(
+            provider = %provider,
+            namespace = %namespace,
+            patterns = ?patterns,
+            "OIDC namespace_scope denied write outside provider scope"
+        );
+        Err(NamespaceDenied)
+    }
 }
 
 #[cfg(test)]
@@ -704,6 +849,168 @@ mod proptests {
         ) {
             let reference = format!("{}../{}", prefix, suffix);
             prop_assert!(validate_docker_reference(&reference).is_err());
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod namespace_match_tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn star_pattern_is_universal_noop() {
+        // The default `namespace_scope = ["*"]` must match everything.
+        assert!(namespace_match("*", "myorg/repo"));
+        assert!(namespace_match("*", "a/b/c/d"));
+        assert!(namespace_match("*", "single"));
+        assert!(namespace_match("*", ""));
+    }
+
+    #[test]
+    fn single_star_matches_exactly_one_segment() {
+        assert!(namespace_match("github/*", "github/repo"));
+        // …but not zero and not more than one.
+        assert!(!namespace_match("github/*", "github"));
+        assert!(!namespace_match("github/*", "github/a/b"));
+    }
+
+    #[test]
+    fn double_star_matches_zero_or_more_segments() {
+        assert!(namespace_match("github/**", "github")); // zero
+        assert!(namespace_match("github/**", "github/a")); // one
+        assert!(namespace_match("github/**", "github/a/b")); // many
+        assert!(!namespace_match("github/**", "other/a")); // wrong prefix
+    }
+
+    #[test]
+    fn prefix_lookalikes_do_not_match() {
+        // The headline requirement of #583: `github/*` must NOT match `github-evil`.
+        assert!(!namespace_match("github/*", "github-evil/x"));
+        assert!(!namespace_match("github/**", "github-evil/x"));
+        assert!(!namespace_match("github/**", "github_evil/x"));
+        assert!(!namespace_match("github", "github-evil"));
+    }
+
+    #[test]
+    fn matching_is_anchored_not_substring() {
+        // Unlike the sub-claim glob, this matcher does not do `contains`.
+        assert!(!namespace_match("foo", "xfooy"));
+        assert!(!namespace_match("org", "org/sub")); // literal != prefix
+        assert!(!namespace_match("sub", "org/sub")); // literal != suffix
+        assert!(namespace_match("org", "org"));
+    }
+
+    #[test]
+    fn exact_literal_paths() {
+        assert!(namespace_match("myorg/team/repo", "myorg/team/repo"));
+        assert!(!namespace_match("myorg/team/repo", "myorg/team/other"));
+        assert!(!namespace_match("myorg/team", "myorg/team/repo"));
+    }
+
+    #[test]
+    fn intra_segment_star_is_literal_not_wildcard() {
+        // Only a whole-segment `*`/`**` is a wildcard; `my*org` is fail-closed.
+        assert!(!namespace_match("my*org/*", "myXXXorg/repo"));
+        assert!(namespace_match("my*org", "my*org")); // matches only itself, literally
+    }
+
+    fn scope(patterns: &[&str]) -> Vec<String> {
+        patterns.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn default_star_scope_is_unrestricted() {
+        // The default `namespace_scope = ["*"]` collapses to Unrestricted (no-op).
+        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&["*"]));
+        assert!(matches!(auth, NamespaceAuthority::Unrestricted));
+        assert!(enforce_namespace_scope(&auth, "anyorg/whatever").is_ok());
+        // A `*` anywhere in the list is enough to be unrestricted.
+        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&["myorg/**", "*"]));
+        assert!(matches!(auth, NamespaceAuthority::Unrestricted));
+    }
+
+    #[test]
+    fn unrestricted_authority_always_allows() {
+        assert!(enforce_namespace_scope(&NamespaceAuthority::Unrestricted, "").is_ok());
+        assert!(enforce_namespace_scope(&NamespaceAuthority::Unrestricted, "a/b/c").is_ok());
+    }
+
+    #[test]
+    fn scoped_authority_allows_inside_denies_outside() {
+        let auth = NamespaceAuthority::from_oidc_scope("github", &scope(&["myorg/**"]));
+        assert!(enforce_namespace_scope(&auth, "myorg/repo").is_ok());
+        assert!(enforce_namespace_scope(&auth, "myorg/team/repo").is_ok());
+        assert_eq!(
+            enforce_namespace_scope(&auth, "other/repo"),
+            Err(NamespaceDenied)
+        );
+        // The #583 lookalike must be denied, not allowed.
+        assert_eq!(
+            enforce_namespace_scope(&auth, "myorg-evil/repo"),
+            Err(NamespaceDenied)
+        );
+    }
+
+    #[test]
+    fn empty_scope_is_fail_closed() {
+        // `namespace_scope = []` is a deliberate lockout: deny everything.
+        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&[]));
+        assert_eq!(
+            enforce_namespace_scope(&auth, "anything"),
+            Err(NamespaceDenied)
+        );
+    }
+
+    #[test]
+    fn empty_namespace_under_scope_is_denied() {
+        // A handler that fails to derive a coordinate must not fall open.
+        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&["myorg/**"]));
+        assert_eq!(enforce_namespace_scope(&auth, ""), Err(NamespaceDenied));
+    }
+
+    proptest! {
+        // The universal no-op holds for any value.
+        #[test]
+        fn prop_star_matches_anything(s in "[a-zA-Z0-9/@._-]{0,60}") {
+            prop_assert!(namespace_match("*", &s));
+        }
+
+        // Anti prefix-confusion: `org/*` never matches `org<sep>rest/...`.
+        #[test]
+        fn prop_prefix_star_rejects_lookalike(
+            org in "[a-z][a-z0-9]{0,9}",
+            sep in "[-_.]",
+            rest in "[a-z][a-z0-9]{0,7}",
+            tail in "[a-z][a-z0-9]{0,7}",
+        ) {
+            let pattern = format!("{}/*", org);
+            let value = format!("{}{}{}/{}", org, sep, rest, tail);
+            prop_assert!(!namespace_match(&pattern, &value));
+        }
+
+        // Anchoring: a single literal segment never matches a strictly longer
+        // segment that merely contains it.
+        #[test]
+        fn prop_literal_segment_is_anchored(
+            pre in "[a-z]{1,4}",
+            seg in "[a-z]{2,8}",
+            post in "[a-z]{1,4}",
+        ) {
+            let value = format!("{}{}{}", pre, seg, post);
+            prop_assert!(!namespace_match(&seg, &value));
+        }
+
+        // `prefix/**` matches every value under `prefix/`.
+        #[test]
+        fn prop_double_star_matches_all_descendants(
+            prefix in "[a-z][a-z0-9]{0,9}",
+            descendant in "[a-z][a-z0-9/]{0,30}",
+        ) {
+            let pattern = format!("{}/**", prefix);
+            let value = format!("{}/{}", prefix, descendant);
+            prop_assert!(namespace_match(&pattern, &value));
         }
     }
 }

--- a/nora-registry/src/validation.rs
+++ b/nora-registry/src/validation.rs
@@ -13,7 +13,6 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use std::fmt;
-use std::sync::Arc;
 
 /// Validation errors
 #[derive(Debug, Clone, PartialEq)]
@@ -420,85 +419,6 @@ fn segments_match(pat: &[&str], val: &[&str]) -> bool {
         Some((&"*", rest)) => !val.is_empty() && segments_match(rest, &val[1..]),
         // Literal segment must match exactly (anchored start).
         Some((&lit, rest)) => !val.is_empty() && val[0] == lit && segments_match(rest, &val[1..]),
-    }
-}
-
-/// Per-request namespace authorization, derived from the authenticated identity.
-///
-/// The auth middleware stamps this into the request extensions on **every** path,
-/// so write handlers can extract it without a fallback. It is the vehicle for
-/// enforcing OIDC `namespace_scope` (#583): handlers call
-/// [`enforce_namespace_scope`] with the artifact coordinate they are about to
-/// write, and a `Scoped` authority that does not cover that coordinate yields 403.
-#[derive(Clone, Debug)]
-pub enum NamespaceAuthority {
-    /// No namespace restriction: Basic auth, opaque (`nra_`) tokens, anonymous
-    /// reads, auth disabled, or an OIDC provider scoped to `["*"]`.
-    Unrestricted,
-    /// An OIDC identity restricted to the given scope patterns.
-    Scoped {
-        /// Glob patterns from the provider's `namespace_scope` (segment-aware,
-        /// see [`namespace_match`]).
-        patterns: Arc<[String]>,
-        /// Provider name, included in deny logs (never the token or `sub`).
-        provider: Arc<str>,
-    },
-}
-
-impl NamespaceAuthority {
-    /// Build an authority from an OIDC provider's `namespace_scope`.
-    ///
-    /// A scope containing a bare `*` collapses to [`NamespaceAuthority::Unrestricted`]
-    /// so the default `namespace_scope = ["*"]` is a true no-op. An empty scope
-    /// (`[]`) stays `Scoped` with no patterns and therefore denies every write
-    /// (fail-closed) — a deliberate operator lockout.
-    pub fn from_oidc_scope(provider: &str, scope: &[String]) -> Self {
-        if scope.iter().any(|p| p == "*") {
-            return NamespaceAuthority::Unrestricted;
-        }
-        NamespaceAuthority::Scoped {
-            patterns: Arc::from(scope.to_vec()),
-            provider: Arc::from(provider),
-        }
-    }
-}
-
-/// A write was denied because its artifact coordinate fell outside the
-/// authenticated OIDC identity's `namespace_scope`. Callers must map this to
-/// HTTP 403 and must not touch storage (fail-closed).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct NamespaceDenied;
-
-/// Enforce an OIDC `namespace_scope` against the artifact `namespace` coordinate
-/// a write handler is about to act on.
-///
-/// `namespace` MUST be the canonical artifact coordinate the handler derived
-/// (e.g. the docker image name `myorg/img`, the npm package `@myorg/pkg`, the raw
-/// path) — never the raw URL path and never the storage key (which carries
-/// transport prefixes/suffixes that would make scoping format-dependent and
-/// bypassable). Returns `Ok(())` for an [`NamespaceAuthority::Unrestricted`]
-/// authority or when `namespace` matches at least one scope pattern; otherwise
-/// returns `Err(NamespaceDenied)` and logs the denial (provider + namespace +
-/// patterns; never the token).
-pub fn enforce_namespace_scope(
-    authority: &NamespaceAuthority,
-    namespace: &str,
-) -> Result<(), NamespaceDenied> {
-    let (patterns, provider) = match authority {
-        NamespaceAuthority::Unrestricted => return Ok(()),
-        NamespaceAuthority::Scoped { patterns, provider } => (patterns, provider),
-    };
-
-    if patterns.iter().any(|p| namespace_match(p, namespace)) {
-        Ok(())
-    } else {
-        tracing::warn!(
-            provider = %provider,
-            namespace = %namespace,
-            patterns = ?patterns,
-            "OIDC namespace_scope denied write outside provider scope"
-        );
-        Err(NamespaceDenied)
     }
 }
 
@@ -914,60 +834,6 @@ mod namespace_match_tests {
         // Only a whole-segment `*`/`**` is a wildcard; `my*org` is fail-closed.
         assert!(!namespace_match("my*org/*", "myXXXorg/repo"));
         assert!(namespace_match("my*org", "my*org")); // matches only itself, literally
-    }
-
-    fn scope(patterns: &[&str]) -> Vec<String> {
-        patterns.iter().map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn default_star_scope_is_unrestricted() {
-        // The default `namespace_scope = ["*"]` collapses to Unrestricted (no-op).
-        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&["*"]));
-        assert!(matches!(auth, NamespaceAuthority::Unrestricted));
-        assert!(enforce_namespace_scope(&auth, "anyorg/whatever").is_ok());
-        // A `*` anywhere in the list is enough to be unrestricted.
-        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&["myorg/**", "*"]));
-        assert!(matches!(auth, NamespaceAuthority::Unrestricted));
-    }
-
-    #[test]
-    fn unrestricted_authority_always_allows() {
-        assert!(enforce_namespace_scope(&NamespaceAuthority::Unrestricted, "").is_ok());
-        assert!(enforce_namespace_scope(&NamespaceAuthority::Unrestricted, "a/b/c").is_ok());
-    }
-
-    #[test]
-    fn scoped_authority_allows_inside_denies_outside() {
-        let auth = NamespaceAuthority::from_oidc_scope("github", &scope(&["myorg/**"]));
-        assert!(enforce_namespace_scope(&auth, "myorg/repo").is_ok());
-        assert!(enforce_namespace_scope(&auth, "myorg/team/repo").is_ok());
-        assert_eq!(
-            enforce_namespace_scope(&auth, "other/repo"),
-            Err(NamespaceDenied)
-        );
-        // The #583 lookalike must be denied, not allowed.
-        assert_eq!(
-            enforce_namespace_scope(&auth, "myorg-evil/repo"),
-            Err(NamespaceDenied)
-        );
-    }
-
-    #[test]
-    fn empty_scope_is_fail_closed() {
-        // `namespace_scope = []` is a deliberate lockout: deny everything.
-        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&[]));
-        assert_eq!(
-            enforce_namespace_scope(&auth, "anything"),
-            Err(NamespaceDenied)
-        );
-    }
-
-    #[test]
-    fn empty_namespace_under_scope_is_denied() {
-        // A handler that fails to derive a coordinate must not fall open.
-        let auth = NamespaceAuthority::from_oidc_scope("ci", &scope(&["myorg/**"]));
-        assert_eq!(enforce_namespace_scope(&auth, ""), Err(NamespaceDenied));
     }
 
     proptest! {

--- a/scripts/coherence-check.sh
+++ b/scripts/coherence-check.sh
@@ -189,6 +189,32 @@ if [ "$SELECT_MISSING" -eq 0 ]; then
 fi
 echo ""
 
+# ── Namespace scope enforcement coverage (#583) ───────────────────────────
+# Every registry whose routes() mounts a write/any route must call
+# enforce_namespace_scope, so a new write-capable format cannot silently
+# reintroduce the OIDC namespace_scope fail-open.
+
+echo "--- Namespace Scope Enforcement Coverage ---"
+NS_COVERED=0
+NS_MISSING=0
+for ns_file in "$REPO_ROOT"/nora-registry/src/registry/*.rs; do
+    ns_base=$(basename "$ns_file")
+    [ "$ns_base" = "mod.rs" ] && continue
+    ns_routes=$(awk '/pub fn routes\(\)/{flag=1} flag{print} flag&&/^}/{exit}' "$ns_file")
+    if echo "$ns_routes" | grep -qE '\b(put|post|delete|any)\('; then
+        if grep -q 'enforce_namespace_scope' "$ns_file"; then
+            NS_COVERED=$((NS_COVERED + 1))
+        else
+            fail "registry/$ns_base mounts a write/any route but never calls enforce_namespace_scope (#583)"
+            NS_MISSING=$((NS_MISSING + 1))
+        fi
+    fi
+done
+if [ "$NS_MISSING" -eq 0 ]; then
+    ok "All write-capable registries enforce namespace_scope ($NS_COVERED modules)"
+fi
+echo ""
+
 # ── Summary ───────────────────────────────────────────────────────────────
 
 echo "=== Summary ==="


### PR DESCRIPTION
Closes #583.

## Summary
`namespace_scope` was parsed and advertised as a per-provider access control but never read at runtime, so any OIDC identity could publish to any namespace its role allowed (fail-open). This enforces it on writes across all six write-capable registries (docker, raw, npm, maven, pypi, cargo — the rest are read-only proxies).

- **Segment-aware matcher**: `*` matches one path segment, `**` matches zero or more, anchored on `/` boundaries — so `github/*` matches `github/repo` but never `github-evil/...`. The whole pattern `*` (the default `["*"]`) is a universal no-op.
- **Coordinate, not URL/key**: enforcement matches the artifact coordinate each handler parsed (docker image name, npm package, raw path, …), not the raw URL or storage key — avoiding transport-suffix leakage and parser-differential bypasses.
- **Fail-closed**: an empty scope (`[]`) or an underivable coordinate denies; reads are never gated; opaque (`nra_`) and Basic credentials are not scoped.
- **Audit mode**: `namespace_scope_enforcement = "audit"` allows out-of-scope writes but logs and counts them via `nora_auth_namespace_scope_total{provider,decision}`, for staged rollout. Default is `"enforce"`.
- A coherence check requires every write-capable registry to call the enforcement, so a future format can't silently regress.

## ⚠️ Breaking (behavioral)
If a provider's `namespace_scope` is anything other than `["*"]`, out-of-scope writes now return **403**. The default `["*"]` is unchanged (no-op), so deployments that never set the field are unaffected. Operators who set a real scope should review config before upgrading, or set `namespace_scope_enforcement = "audit"` to stage. See CHANGELOG.

## Test plan
- [x] `cargo test` — lib 49 + bin 1242, 0 failed (incl. per-format wiring tests + matcher property tests)
- [x] `cargo clippy -- -D warnings` clean, `cargo fmt --check`
- [x] coherence-check + opsec-check + cargo-deny/audit pass

## Note
User-facing docs (the "Namespace Scoping" section, EN+RU) are prepared for the separate docs site repo and are not part of this PR.