### PR TITLE
refactor(config): centralize client base URL construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **Docker pull command in the UI** — the package detail view built `docker pull` from `public_url` verbatim, so a configured `public_url` with a scheme produced an invalid `docker pull https://host/image`. The pull command now uses the bare host authority.
+- **IPv6 fallback base URL** — when `public_url` is unset and the bind host is an IPv6 literal, the advertised base URL now brackets the address (`http://[::1]:4000`), matching the listen address format.
+
+### Internal
+- Client-facing URL construction (service index rewriting, UI install commands, docker pull) is now centralized in `ServerConfig::public_base_url()` / `public_host()`, replacing three divergent inline copies.
+
 ### Security
 - **OIDC `namespace_scope` is now enforced on writes** — it was previously parsed and documented as a per-provider access control but never applied at runtime (fail-open, #583). A provider's `namespace_scope` now restricts which artifact namespaces its tokens may publish to, across docker, raw, npm, maven, pypi and cargo. Matching is segment-aware (`myorg/*` matches `myorg/repo` but never `myorg-evil/...`; use `myorg/**` for everything under `myorg/`).
   - **BREAKING (behavioral):** if a provider's `namespace_scope` is set to anything other than `["*"]`, out-of-scope writes from that issuer now return `403`. The default `["*"]` is unchanged and remains a no-op, so deployments that never set the field are unaffected. **Check your OIDC config before upgrading.**

--- a/nora-registry/src/config/server.rs
+++ b/nora-registry/src/config/server.rs
@@ -43,6 +43,45 @@ impl ServerConfig {
         }
     }
 
+    /// Build the base URL advertised to clients (npm/docker/nuget service
+    /// index, UI install commands). Single source of truth for client-facing
+    /// URLs — handlers and UI must not reconstruct it inline.
+    ///
+    /// Returns `public_url` (trailing slash trimmed) if set, otherwise falls
+    /// back to `http://{host}:{port}`. The fallback only makes sense for a
+    /// routable bind address; `validate()` rejects a wildcard bind without a
+    /// public_url and warns on a loopback public_url (#510, #590), so a broken
+    /// URL never silently ships.
+    pub fn public_base_url(&self) -> String {
+        let base = self
+            .public_url
+            .as_deref()
+            .map(|u| u.trim_end_matches('/').to_string())
+            // Reuse bind_addr() so IPv6 literals get bracket notation
+            // (`http://[::1]:4000`) — keeping the authority format consistent
+            // with the listen address and avoiding drift.
+            .unwrap_or_else(|| format!("http://{}", self.bind_addr()));
+        debug_assert!(
+            base.starts_with("http://") || base.starts_with("https://"),
+            "public_base_url must carry an http(s) scheme: {base}"
+        );
+        base
+    }
+
+    /// Host authority (`host[:port]`) advertised to clients, without scheme.
+    ///
+    /// For registry references that take no URL scheme — e.g.
+    /// `docker pull {host}/repo:tag`. Derived from [`Self::public_base_url`]
+    /// so it shares the single source of truth.
+    pub fn public_host(&self) -> String {
+        let base = self.public_base_url();
+        base.strip_prefix("https://")
+            .or_else(|| base.strip_prefix("http://"))
+            .unwrap_or(&base)
+            .trim_end_matches('/')
+            .to_string()
+    }
+
     /// Apply environment variable overrides for server config.
     pub(super) fn apply_env_overrides(&mut self) {
         if let Ok(val) = env::var("NORA_HOST") {
@@ -96,6 +135,52 @@ mod tests {
             server("registry.example.com", 443).bind_addr(),
             "registry.example.com:443"
         );
+    }
+
+    #[test]
+    fn public_base_url_falls_back_to_host_port() {
+        // No public_url → http://{host}:{port}.
+        assert_eq!(
+            server("127.0.0.1", 4000).public_base_url(),
+            "http://127.0.0.1:4000"
+        );
+    }
+
+    #[test]
+    fn public_base_url_brackets_ipv6_fallback() {
+        // IPv6 literal host without public_url must be bracketed, matching
+        // bind_addr() — otherwise the authority is ambiguous/malformed.
+        assert_eq!(
+            server("2001:db8::1", 4000).public_base_url(),
+            "http://[2001:db8::1]:4000"
+        );
+        assert_eq!(server("::1", 4000).public_host(), "[::1]:4000");
+    }
+
+    #[test]
+    fn public_base_url_uses_public_url_and_trims_slash() {
+        let mut cfg = server("0.0.0.0", 4000);
+        cfg.public_url = Some("https://registry.example.com/".to_string());
+        // public_url wins over the bind address; trailing slash trimmed.
+        assert_eq!(cfg.public_base_url(), "https://registry.example.com");
+    }
+
+    #[test]
+    fn public_host_strips_scheme_for_docker_pull() {
+        // Fallback case: scheme stripped, host:port kept.
+        assert_eq!(
+            server("registry.example.com", 4000).public_host(),
+            "registry.example.com:4000"
+        );
+
+        // public_url case: scheme and trailing slash stripped — `docker pull`
+        // takes a bare host, not a URL.
+        let mut cfg = server("0.0.0.0", 4000);
+        cfg.public_url = Some("https://nora.example.com/".to_string());
+        assert_eq!(cfg.public_host(), "nora.example.com");
+
+        cfg.public_url = Some("http://nora.example.com:8080".to_string());
+        assert_eq!(cfg.public_host(), "nora.example.com:8080");
     }
 }
 

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -48,21 +48,10 @@ pub(crate) fn method_not_allowed(allow: &'static str) -> Response {
 
 /// Build NORA base URL from config (for URL rewriting).
 ///
-/// Returns `public_url` (trimmed trailing slash) if set,
-/// otherwise constructs `http://host:port`.
+/// Thin wrapper over [`ServerConfig::public_base_url`] — the single source of
+/// truth for client-facing URLs.
 pub(crate) fn nora_base_url(state: &AppState) -> String {
-    state
-        .config
-        .server
-        .public_url
-        .as_deref()
-        .map(|u| u.trim_end_matches('/').to_string())
-        .unwrap_or_else(|| {
-            format!(
-                "http://{}:{}",
-                state.config.server.host, state.config.server.port
-            )
-        })
+    state.config.server.public_base_url()
 }
 
 #[derive(Debug)]

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -371,11 +371,8 @@ pub async fn get_docker_detail(state: &AppState, name: &str) -> DockerDetail {
     keys.sort();
     keys.dedup();
 
-    // Build public URL for pull commands
-    let registry_host =
-        state.config.server.public_url.clone().unwrap_or_else(|| {
-            format!("{}:{}", state.config.server.host, state.config.server.port)
-        });
+    // Scheme-less host authority for `docker pull` commands.
+    let registry_host = state.config.server.public_host();
 
     let mut tags = Vec::new();
     for key in &keys {

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -24,20 +24,11 @@ use i18n::Lang;
 use templates::*;
 
 /// Returns base URL for UI install commands.
-/// Uses public_url if set (trimming trailing slash), otherwise http://host:port.
+///
+/// Thin wrapper over [`ServerConfig::public_base_url`] — the single source of
+/// truth for client-facing URLs.
 fn resolve_base_url(state: &AppState) -> String {
-    state
-        .config
-        .server
-        .public_url
-        .as_deref()
-        .map(|u| u.trim_end_matches('/').to_string())
-        .unwrap_or_else(|| {
-            format!(
-                "http://{}:{}",
-                state.config.server.host, state.config.server.port
-            )
-        })
+    state.config.server.public_base_url()
 }
 
 #[derive(Debug, serde::Deserialize)]


### PR DESCRIPTION
## Summary

Consolidates three divergent inline builders for client-facing URLs (registry service-index rewriting, UI install commands, UI `docker pull`) into `ServerConfig::public_base_url()` and `public_host()` — a single source of truth.

Surfaces and fixes two latent bugs:
- **UI `docker pull` command** built the reference from `public_url` verbatim, producing an invalid `docker pull https://host/image` when `public_url` carried a scheme. It now uses the bare host authority.
- **IPv6 fallback** base URL was not bracketed; it now reuses `bind_addr()` so the advertised URL matches the listen address (`http://[::1]:4000`).

No behavioral change to existing valid configs; no new config surface.

## Test plan
- [x] New unit tests: `public_base_url` fallback + public_url trimming + IPv6 bracketing; `public_host` scheme/slash stripping (incl. IPv6).
- [x] Existing wildcard / loopback-warning / package-detail URL tests unchanged and green.
- [x] `cargo test -p nora-registry --lib --bin nora` — 1246 passed.
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo-deny`, `cargo-audit` clean.