### PR TITLE
test(raw): make test_raw_head_returns_etag deterministic (#603)

### DIFF
--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -708,6 +708,17 @@ mod integration_tests {
         let ctx = create_test_context();
         send(&ctx.app, Method::PUT, "/raw/etag.txt", b"hello".to_vec()).await;
 
+        // The ETag is the hash-pin, recorded fire-and-forget after PUT. Wait for
+        // it to land so HEAD deterministically sees the ETag — otherwise the
+        // pin task can be starved under a full parallel suite and the header is
+        // absent (#603). Polls (fast path = immediate), no fixed sleep.
+        for _ in 0..200 {
+            if ctx.state.storage.get_pin_hash("raw/etag.txt").is_some() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
         let head = send(&ctx.app, Method::HEAD, "/raw/etag.txt", "").await;
         assert_eq!(head.status(), StatusCode::OK);
         let etag = head.headers().get("etag").expect("HEAD must return ETag");


### PR DESCRIPTION
## Summary

Fixes #603. `test_raw_head_returns_etag` did `PUT` then immediately `HEAD` and asserted the ETag header, but the ETag is the hash-pin, which `put()` records **fire-and-forget** via `spawn_blocking`. Under a full parallel suite the pin task gets starved, `HEAD` reads no pin, the ETag header is absent, and `.expect("HEAD must return ETag")` panics (~1 in 4 full-suite runs — observed during the #585 gate).

## Change

Wait for the pin to land (poll `get_pin_hash`, fast path immediate, 2s cap) before issuing `HEAD`, so the assertion observes the deterministic post-pin state. **Test only — no production change.**

## Test plan

Verified green across **4 consecutive full-suite runs** (1256/0 each) — the flake reproduced before the change and is gone after. `fmt`, `clippy -D warnings`, semgrep (0 errors), typos pass.