### PR TITLE
feat(proxy): revalidate npm metadata with If-None-Match on TTL expiry (#596)

### DIFF
--- a/nora-registry/src/config/registry/npm.rs
+++ b/nora-registry/src/config/registry/npm.rs
@@ -19,6 +19,11 @@ pub struct NpmConfig {
     pub metadata_ttl: i64,
     #[serde(default = "super::super::default_true")]
     pub serve_stale: bool,
+    /// Revalidate stale metadata with a conditional request (`If-None-Match`)
+    /// instead of always re-downloading the full body (#596). Fail-open: any
+    /// error falls back to a full fetch.
+    #[serde(default = "super::super::default_true")]
+    pub revalidate: bool,
 }
 
 impl Default for NpmConfig {
@@ -30,6 +35,7 @@ impl Default for NpmConfig {
             proxy_timeout: 30,
             metadata_ttl: 300,
             serve_stale: true,
+            revalidate: true,
         }
     }
 }
@@ -57,6 +63,9 @@ impl NpmConfig {
         }
         if let Ok(val) = env::var("NORA_NPM_SERVE_STALE") {
             self.serve_stale = !matches!(val.as_str(), "false" | "0");
+        }
+        if let Ok(val) = env::var("NORA_NPM_REVALIDATE") {
+            self.revalidate = !matches!(val.as_str(), "false" | "0");
         }
     }
 }

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -391,6 +391,26 @@ fn primary_key_for_checksum(key: &str) -> Option<&str> {
     None
 }
 
+/// Revalidation validator sidecars (`<key>.meta`, #596) are produced ONLY for
+/// npm metadata, so the orphan rule is scoped to the npm prefix — otherwise a
+/// Maven artifact that legitimately ends in `.meta` could be false-deleted.
+fn is_meta_sidecar(key: &str) -> bool {
+    key.starts_with("npm/") && ends_with_ci(key, ".meta")
+}
+
+/// True for any sidecar whose orphan rule is "primary artifact absent".
+fn is_orphanable_sidecar(key: &str) -> bool {
+    is_checksum_sidecar(key) || is_meta_sidecar(key)
+}
+
+/// Primary artifact key a sidecar belongs to (checksum or `.meta`).
+fn primary_key_for_sidecar(key: &str) -> Option<&str> {
+    if is_meta_sidecar(key) {
+        return key.strip_suffix(".meta");
+    }
+    primary_key_for_checksum(key)
+}
+
 async fn detect_checksum_orphans(storage: &Storage) -> DetectionResult {
     let mut checksums: Vec<String> = Vec::new();
 
@@ -401,7 +421,7 @@ async fn detect_checksum_orphans(storage: &Storage) -> DetectionResult {
             Vec::new()
         });
         for key in keys {
-            if is_checksum_sidecar(&key) {
+            if is_orphanable_sidecar(&key) {
                 checksums.push(key);
             }
         }
@@ -411,7 +431,7 @@ async fn detect_checksum_orphans(storage: &Storage) -> DetectionResult {
     let mut orphans = Vec::new();
 
     for checksum_key in &checksums {
-        if let Some(primary) = primary_key_for_checksum(checksum_key) {
+        if let Some(primary) = primary_key_for_sidecar(checksum_key) {
             // If the primary artifact doesn't exist, the checksum is orphaned
             if storage.stat(primary).await.is_none() {
                 orphans.push(checksum_key.clone());
@@ -1066,6 +1086,52 @@ mod tests {
         );
         assert_eq!(result.skipped_recent, 1);
         assert!(storage.get(key).await.is_ok());
+    }
+
+    /// #596: a `.meta` validator sidecar is reaped when its npm metadata body is
+    /// gone (orphan), kept when the body is present, and — crucially — a Maven
+    /// artifact ending in `.meta` is NOT treated as a sidecar (no false delete).
+    #[tokio::test]
+    async fn test_gc_meta_sidecar_orphan_rule_is_npm_scoped() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // Orphan npm .meta (no primary body) → reaped.
+        storage
+            .put("npm/orphan/metadata.json.meta", br#"{"etag":"v1"}"#)
+            .await
+            .unwrap();
+        // npm .meta WITH its primary body → kept.
+        storage
+            .put("npm/live/metadata.json", b"body")
+            .await
+            .unwrap();
+        storage
+            .put("npm/live/metadata.json.meta", br#"{"etag":"v2"}"#)
+            .await
+            .unwrap();
+        // Maven artifact literally ending in .meta, no primary → must NOT be a
+        // sidecar candidate (false-delete guard).
+        storage
+            .put("maven/com/x/1.0/thing.meta", b"real-artifact")
+            .await
+            .unwrap();
+
+        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        assert!(result.deleted >= 1);
+
+        assert!(
+            storage.get("npm/orphan/metadata.json.meta").await.is_err(),
+            "orphan npm .meta must be reaped"
+        );
+        assert!(
+            storage.get("npm/live/metadata.json.meta").await.is_ok(),
+            "npm .meta with a live body must be kept"
+        );
+        assert!(
+            storage.get("maven/com/x/1.0/thing.meta").await.is_ok(),
+            "a Maven .meta artifact must never be treated as a sidecar"
+        );
     }
 
     #[tokio::test]

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -31,6 +31,40 @@ pub static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("failed to create HTTP_REQUESTS_TOTAL metric at startup")
 });
 
+/// Conditional revalidations where upstream answered 304 Not Modified — the
+/// cached body was reused and no body bytes were downloaded (#596).
+pub static PROXY_UPSTREAM_304_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_proxy_upstream_304_total",
+        "Upstream 304 Not Modified responses on revalidation",
+        &["registry"]
+    )
+    .expect("failed to create PROXY_UPSTREAM_304_TOTAL metric at startup")
+});
+
+/// Body bytes saved by revalidation (size of the cached body that did NOT have
+/// to be re-downloaded because upstream returned 304) (#596).
+pub static PROXY_REVALIDATION_BYTES_SAVED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_proxy_revalidation_bytes_saved_total",
+        "Body bytes not re-downloaded thanks to a 304 revalidation",
+        &["registry"]
+    )
+    .expect("failed to create PROXY_REVALIDATION_BYTES_SAVED_TOTAL metric at startup")
+});
+
+/// Revalidation attempts that failed (conditional request error, corrupt
+/// validator sidecar, missing cached body) and fell back to a full fetch.
+/// Nonzero signals the feature is silently degrading (#596).
+pub static PROXY_REVALIDATION_ERRORS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_proxy_revalidation_errors_total",
+        "Revalidation attempts that fell back to a full fetch",
+        &["registry"]
+    )
+    .expect("failed to create PROXY_REVALIDATION_ERRORS_TOTAL metric at startup")
+});
+
 /// HTTP request duration histogram
 pub static HTTP_REQUEST_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -213,6 +213,143 @@ pub(crate) async fn proxy_fetch_text(
     .await
 }
 
+// ============================================================================
+// Conditional revalidation (#596)
+// ============================================================================
+
+/// Upstream cache validators persisted next to a cached object so a later
+/// revalidation can send `If-None-Match` / `If-Modified-Since`. Stored as a
+/// `<key>.meta` JSON sidecar — filesystem-first, survives restarts (ADR-2).
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub(crate) struct Validators {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub etag: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
+}
+
+impl Validators {
+    /// True if at least one validator is present to drive a conditional request.
+    pub fn is_some(&self) -> bool {
+        self.etag.is_some() || self.last_modified.is_some()
+    }
+}
+
+/// Outcome of a conditional upstream request.
+pub(crate) enum Revalidation {
+    /// Upstream answered `304 Not Modified` — the cached body is still valid.
+    NotModified,
+    /// Upstream answered `200` with a (possibly) new body and fresh validators.
+    Modified {
+        body: Vec<u8>,
+        validators: Validators,
+    },
+}
+
+/// Storage key of the validator sidecar for a cached object.
+pub(crate) fn validators_key(key: &str) -> String {
+    format!("{key}.meta")
+}
+
+/// Read the stored upstream validators for `key`, if any. Fail-open: any
+/// read/parse error yields `None` (caller does a full fetch).
+pub(crate) async fn read_validators(storage: &crate::Storage, key: &str) -> Option<Validators> {
+    let data = storage.get(&validators_key(key)).await.ok()?;
+    serde_json::from_slice::<Validators>(&data).ok()
+}
+
+/// Persist upstream validators next to `key`. Written AFTER the body so a
+/// sidecar never advertises freshness for a body that is not there. A no-op
+/// when there is nothing to store.
+pub(crate) async fn write_validators(storage: &crate::Storage, key: &str, v: &Validators) {
+    if !v.is_some() {
+        return;
+    }
+    if let Ok(data) = serde_json::to_vec(v) {
+        if let Err(e) = storage.put(&validators_key(key), &data).await {
+            tracing::warn!(key = %key, error = ?e, "failed to write validator sidecar");
+        }
+    }
+}
+
+fn header_string(resp: &reqwest::Response, name: reqwest::header::HeaderName) -> Option<String> {
+    resp.headers()
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_owned)
+}
+
+/// Conditional upstream fetch (#596). Sends `If-None-Match`/`If-Modified-Since`
+/// from `validators`; returns `NotModified` on 304 (no body downloaded) or
+/// `Modified { body, validators }` on 200. With empty `validators` it sends no
+/// conditional headers, so it always yields `Modified` — that is how the full
+/// fetch path captures validators for the first time.
+///
+/// Circuit breaker: 304/200 record success; transport/5xx record failure; 4xx
+/// returns `NotFound` (matching `proxy_fetch_core`). No retry — revalidation is
+/// a lightweight check and the caller falls back to a full fetch on error.
+pub(crate) async fn proxy_fetch_conditional(
+    client: &reqwest::Client,
+    url: &str,
+    timeout: Duration,
+    auth: Option<&str>,
+    validators: &Validators,
+    cb: &CircuitBreakerRegistry,
+    registry: RegistryType,
+) -> Result<Revalidation, ProxyError> {
+    let registry_str = registry.as_str();
+    cb.check(registry_str)?;
+
+    let mut request = client.get(url).timeout(timeout);
+    if let Some(credentials) = auth {
+        request = request.header(header::AUTHORIZATION, basic_auth_header(credentials));
+    }
+    if let Some(ref etag) = validators.etag {
+        request = request.header(header::IF_NONE_MATCH, etag);
+    }
+    if let Some(ref lm) = validators.last_modified {
+        request = request.header(header::IF_MODIFIED_SINCE, lm);
+    }
+
+    match request.send().await {
+        Ok(response) => {
+            let status = response.status();
+            if status == reqwest::StatusCode::NOT_MODIFIED {
+                cb.record_success(registry_str);
+                return Ok(Revalidation::NotModified);
+            }
+            if status.is_success() {
+                let new_validators = Validators {
+                    etag: header_string(&response, header::ETAG),
+                    last_modified: header_string(&response, header::LAST_MODIFIED),
+                };
+                let body = response
+                    .bytes()
+                    .await
+                    .map_err(|e| ProxyError::Network(e.to_string()))?;
+                cb.record_success(registry_str);
+                return Ok(Revalidation::Modified {
+                    body: body.to_vec(),
+                    validators: new_validators,
+                });
+            }
+            let code = status.as_u16();
+            if (400..500).contains(&code) {
+                // 4xx — upstream alive; recover the breaker without clearing a
+                // real failure tally, consistent with proxy_fetch_core (#606).
+                cb.record_alive(registry_str);
+                return Err(ProxyError::NotFound);
+            }
+            cb.record_failure(registry_str);
+            Err(ProxyError::Upstream(code))
+        }
+        Err(e) => {
+            cb.record_failure(registry_str);
+            Err(ProxyError::Network(e.to_string()))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -233,5 +370,121 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Err(ProxyError::Network(_))));
+    }
+
+    // --- Conditional revalidation (#596) ---
+
+    fn noop_cb() -> CircuitBreakerRegistry {
+        CircuitBreakerRegistry::new(crate::config::CircuitBreakerConfig::default())
+    }
+
+    /// With no stored validators, the conditional fetch sends no `If-None-Match`,
+    /// always gets a 200, and captures the upstream validators (this is also the
+    /// full-fetch path that seeds the sidecar for next time).
+    #[tokio::test]
+    async fn conditional_200_captures_validators() {
+        use wiremock::matchers::any;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"v1\"")
+                    .set_body_string("BODY-V1"),
+            )
+            .mount(&upstream)
+            .await;
+
+        let cb = noop_cb();
+        let out = proxy_fetch_conditional(
+            &reqwest::Client::new(),
+            &upstream.uri(),
+            Duration::from_secs(5),
+            None,
+            &Validators::default(),
+            &cb,
+            RegistryType::Npm,
+        )
+        .await
+        .unwrap();
+
+        match out {
+            Revalidation::Modified { body, validators } => {
+                assert_eq!(body, b"BODY-V1");
+                assert_eq!(validators.etag.as_deref(), Some("\"v1\""));
+            }
+            Revalidation::NotModified => panic!("expected Modified"),
+        }
+    }
+
+    /// When validators are present they are sent as `If-None-Match`, and a 304
+    /// yields `NotModified` with NO body download. The mock only answers 304 when
+    /// the header is present, so a pass proves the header was sent.
+    #[tokio::test]
+    async fn conditional_304_sends_if_none_match_and_returns_not_modified() {
+        use wiremock::matchers::{header_exists, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(header_exists("if-none-match"))
+            .respond_with(ResponseTemplate::new(304))
+            .mount(&upstream)
+            .await;
+
+        let validators = Validators {
+            etag: Some("\"v1\"".to_string()),
+            last_modified: None,
+        };
+        let cb = noop_cb();
+        let out = proxy_fetch_conditional(
+            &reqwest::Client::new(),
+            &upstream.uri(),
+            Duration::from_secs(5),
+            None,
+            &validators,
+            &cb,
+            RegistryType::Npm,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(out, Revalidation::NotModified));
+    }
+
+    /// Validators round-trip through storage (the sidecar lives on disk, so they
+    /// survive a restart) — acceptance criterion for #596.
+    #[tokio::test]
+    async fn validators_sidecar_roundtrips_through_storage() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let storage = crate::Storage::new_local(dir.path().to_str().unwrap());
+
+        // No body yet, but the sidecar is just another key — write then read.
+        let key = "npm/pkg/metadata.json";
+        let v = Validators {
+            etag: Some("\"abc\"".to_string()),
+            last_modified: Some("Wed, 21 Oct 2026 07:28:00 GMT".to_string()),
+        };
+        write_validators(&storage, key, &v).await;
+
+        // Fresh Storage over the same dir = "after restart".
+        let reloaded = crate::Storage::new_local(dir.path().to_str().unwrap());
+        let got = read_validators(&reloaded, key)
+            .await
+            .expect("sidecar persists");
+        assert_eq!(got, v);
+        assert_eq!(validators_key(key), "npm/pkg/metadata.json.meta");
+    }
+
+    /// An empty validator set writes no sidecar (nothing to persist).
+    #[tokio::test]
+    async fn empty_validators_write_no_sidecar() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let storage = crate::Storage::new_local(dir.path().to_str().unwrap());
+        write_validators(&storage, "npm/x/metadata.json", &Validators::default()).await;
+        assert!(read_validators(&storage, "npm/x/metadata.json")
+            .await
+            .is_none());
     }
 }

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -6,7 +6,8 @@ use crate::audit::AuditEntry;
 use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
 use crate::metrics::METADATA_CORRUPT_TOTAL;
 use crate::registry::{
-    circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, ProxyError,
+    circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_conditional,
+    read_validators, write_validators, ProxyError, Revalidation, Validators,
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
@@ -341,38 +342,90 @@ async fn refetch_metadata(state: &AppState, path: &str, key: &str) -> Option<Vec
     let proxy_url = state.config.npm.proxy.as_ref()?;
     let url = format!("{}/{}", proxy_url.trim_end_matches('/'), path);
 
-    let data = proxy_fetch(
+    // Revalidate with a conditional request when enabled and we have stored
+    // validators. Empty validators ⇒ no conditional headers ⇒ always a 200,
+    // which is also how the first fetch captures validators for next time (#596).
+    let validators = if state.config.npm.revalidate {
+        read_validators(&state.storage, key)
+            .await
+            .unwrap_or_default()
+    } else {
+        Validators::default()
+    };
+    let had_validators = validators.is_some();
+
+    match proxy_fetch_conditional(
         &state.http_client,
         &url,
         Duration::from_secs(state.config.npm.proxy_timeout),
         expose_opt(&state.config.npm.proxy_auth),
+        &validators,
         &state.circuit_breaker,
         RegistryType::Npm,
     )
     .await
-    .ok()?;
-
-    let nora_base = nora_base_url(state);
-    let rewritten = rewrite_tarball_urls(&data, &nora_base, proxy_url).unwrap_or_else(|()| {
-        tracing::warn!(
-            path = %path,
-            "npm metadata refetch: JSON parse failed, using byte-level URL rewrite"
-        );
-        let upstream_trimmed = proxy_url.trim_end_matches('/');
-        let nora_npm_base = format!("{}/npm", nora_base.trim_end_matches('/'));
-        replace_upstream_bytes(&data, upstream_trimmed, &nora_npm_base)
-    });
-
-    let storage = state.storage.clone();
-    let key_clone = key.to_string();
-    let cache_data = rewritten.clone();
-    tokio::spawn(async move {
-        if let Err(e) = storage.put(&key_clone, &cache_data).await {
-            tracing::warn!(key = %key_clone, error = ?e, "npm proxy: failed to cache metadata");
+    {
+        // Upstream unchanged — serve the cached (already-rewritten) body and
+        // refresh its freshness so we don't revalidate again until the next TTL
+        // window. No body was downloaded.
+        Ok(Revalidation::NotModified) => {
+            let cached = state.storage.get(key).await.ok()?; // body gone → fail-open
+            crate::metrics::PROXY_UPSTREAM_304_TOTAL
+                .with_label_values(&["npm"])
+                .inc();
+            crate::metrics::PROXY_REVALIDATION_BYTES_SAVED_TOTAL
+                .with_label_values(&["npm"])
+                .inc_by(cached.len() as u64);
+            // Re-put bumps the file mtime (the freshness source) without an
+            // upstream download.
+            let storage = state.storage.clone();
+            let key_clone = key.to_string();
+            let body = cached.clone();
+            tokio::spawn(async move {
+                let _ = storage.put(&key_clone, &body).await;
+            });
+            Some(cached.to_vec())
         }
-    });
+        // New body — rewrite, cache it, then persist the fresh validators.
+        Ok(Revalidation::Modified { body, validators }) => {
+            let nora_base = nora_base_url(state);
+            let rewritten =
+                rewrite_tarball_urls(&body, &nora_base, proxy_url).unwrap_or_else(|()| {
+                    tracing::warn!(
+                        path = %path,
+                        "npm metadata refetch: JSON parse failed, using byte-level URL rewrite"
+                    );
+                    let upstream_trimmed = proxy_url.trim_end_matches('/');
+                    let nora_npm_base = format!("{}/npm", nora_base.trim_end_matches('/'));
+                    replace_upstream_bytes(&body, upstream_trimmed, &nora_npm_base)
+                });
 
-    Some(rewritten)
+            let storage = state.storage.clone();
+            let key_clone = key.to_string();
+            let cache_data = rewritten.clone();
+            tokio::spawn(async move {
+                // Body first; the validator sidecar must never advertise
+                // freshness for a body that isn't there (#596).
+                if let Err(e) = storage.put(&key_clone, &cache_data).await {
+                    tracing::warn!(key = %key_clone, error = ?e, "npm proxy: failed to cache metadata");
+                    return;
+                }
+                write_validators(&storage, &key_clone, &validators).await;
+            });
+
+            Some(rewritten)
+        }
+        // Upstream unavailable / error — fall back to the caller's serve_stale /
+        // 502 path exactly as before.
+        Err(_) => {
+            if had_validators {
+                crate::metrics::PROXY_REVALIDATION_ERRORS_TOTAL
+                    .with_label_values(&["npm"])
+                    .inc();
+            }
+            None
+        }
+    }
 }
 
 // ============================================================================
@@ -1414,5 +1467,65 @@ mod spec_conformance_tests {
             json["homepage"].as_str().unwrap(),
             "https://pkg.example.com"
         );
+    }
+
+    /// #596 acceptance: with a cached metadata body + stored validators, a stale
+    /// request revalidates with `If-None-Match`; on upstream 304 the cached body
+    /// is served and NO 200-with-body is ever fetched. Drives the real handler.
+    #[tokio::test]
+    async fn test_npm_revalidation_304_serves_cache_no_body_download() {
+        use crate::registry::{write_validators, Validators};
+        use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+        use axum::http::{Method, StatusCode};
+        use wiremock::matchers::{header_exists, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        // Conditional request (has If-None-Match) → 304. A request WITHOUT it
+        // would 404 here (no mount), so any full fetch would visibly fail —
+        // proving the 304 path served from cache.
+        Mock::given(method("GET"))
+            .and(header_exists("if-none-match"))
+            .respond_with(ResponseTemplate::new(304))
+            .mount(&upstream)
+            .await;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.npm.proxy = Some(upstream.uri());
+            cfg.npm.metadata_ttl = 0; // always stale → always revalidate
+            cfg.npm.revalidate = true;
+            cfg.npm.serve_stale = false;
+        });
+
+        // Pre-seed the cache body + validator sidecar (as a prior 200 would have).
+        let key = "npm/testpkg/metadata.json";
+        ctx.state
+            .storage
+            .put(key, b"CACHED-PACKUMENT")
+            .await
+            .unwrap();
+        write_validators(
+            &ctx.state.storage,
+            key,
+            &Validators {
+                etag: Some("\"v1\"".to_string()),
+                last_modified: None,
+            },
+        )
+        .await;
+
+        let before = crate::metrics::PROXY_UPSTREAM_304_TOTAL
+            .with_label_values(&["npm"])
+            .get();
+
+        let resp = send(&ctx.app, Method::GET, "/npm/testpkg", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        assert_eq!(&body[..], b"CACHED-PACKUMENT", "must serve the cached body");
+
+        let after = crate::metrics::PROXY_UPSTREAM_304_TOTAL
+            .with_label_values(&["npm"])
+            .get();
+        assert!(after > before, "a 304 revalidation must be recorded");
     }
 }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -106,6 +106,7 @@ fn build_context(
             proxy_timeout: 5,
             metadata_ttl: -1,
             serve_stale: true,
+            revalidate: true,
         },
         pypi: PypiConfig {
             enabled: true,


### PR DESCRIPTION
## Summary

Fixes #596 (P0). On TTL expiry the proxy re-downloaded the **entire** metadata body even when the upstream object was byte-for-byte unchanged. Now it **revalidates**: it sends a conditional request and, on **304 Not Modified**, serves the cached body and refreshes its freshness — **zero body bytes downloaded**.

## Changes

- **`proxy_fetch_conditional`** — a sibling of `proxy_fetch_core` (the 39 existing call-sites are untouched). Sends `If-None-Match` / `If-Modified-Since` from stored validators; returns `NotModified` (304) or `Modified { body, validators }` (200). Breaker: 304/200 → success, 4xx → `record_alive` (#606), 5xx/transport → failure. Validators are stored **verbatim** (weak `W/"…"` ETags included).
- **Validator sidecar** `<key>.meta` JSON — filesystem-first, **survives restart** (ADR-2). Written **after** the body so it never advertises freshness for a missing body. GC reaps an orphan `.meta` once its npm body is gone, **scoped to the `npm/` prefix** so a Maven artifact literally ending in `.meta` is never false-deleted.
- **npm `refetch_metadata`** revalidates when `npm.revalidate` is on (default; env `NORA_NPM_REVALIDATE`). 304 → serve cached + re-put to bump mtime (freshness); 200 → rewrite + cache + store validators; any error → the **existing** `serve_stale` / 502 fallback. **Fail-open throughout** — revalidation never returns a client error the old path would not have.
- **Metrics**: `nora_proxy_upstream_304_total`, `nora_proxy_revalidation_bytes_saved_total`, `nora_proxy_revalidation_errors_total` (all by `registry`).

## Scope

npm only; the shared helper makes PyPI / Cargo / Maven mechanical follow-ups (the issue lists them). Composes with #595 (single-flight) — once that lands, the leader does the cheap 304.

## Test plan

wiremock tests through the **real** code paths:
- **304 path** via the npm handler — cached body served, the full-fetch mock is never hit, `304_total` increments.
- 200 captures upstream ETag into the sidecar; `If-None-Match` is actually emitted; sidecar **round-trips through a fresh `Storage`** (restart); empty validators write no sidecar.
- GC `.meta` reaping is npm-scoped (orphan reaped, live kept, Maven `.meta` untouched).

Full suite 1267/0; `fmt`, `clippy -D warnings`, semgrep (0 errors), `cargo-audit`/`cargo-deny`, typos pass.

## Design notes (3-expert review + isolated review)

`proxy_fetch_core` deliberately not changed (blast radius). Freshness stays mtime-based (304 re-puts the cached body — a local write, the upstream download is what's saved). The isolated review caught a MEDIUM — `.meta` in the shared checksum-sidecar list could false-delete a Maven `.meta` artifact — now scoped to `npm/`.

## Acceptance (from #596)

- [x] Unchanged upstream on expiry → 304 round-trip, zero body bytes
- [x] Changed upstream → 200, new body + new ETag stored
- [x] Missing/legacy sidecar → full refetch (no regression)
- [x] Validators round-trip through restart (on disk)
- [x] `nora_proxy_upstream_304_total` + `nora_proxy_revalidation_bytes_saved_total`