### PR TITLE
feat(proxy): coalesce concurrent upstream fetches on cache miss (single-flight)

### DIFF
--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -1189,6 +1189,7 @@ Jd74nq6dNCjpWG4drIsyhqX+
             circuit_breaker: Arc::new(crate::circuit_breaker::CircuitBreakerRegistry::new(
                 ctx.state.config.circuit_breaker.clone(),
             )),
+            proxy_coalesce: crate::proxy_coalesce::InflightMap::new(),
             digest_store: ctx.state.digest_store.clone(),
             leak_finders: ctx.state.leak_finders.clone(),
         };

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -806,6 +806,7 @@ impl Default for Config {
                 port: 4000,
                 public_url: None,
                 body_limit_mb: 2048,
+                proxy_coalesce: true,
             },
             storage: StorageConfig {
                 mode: StorageMode::Local,

--- a/nora-registry/src/config/server.rs
+++ b/nora-registry/src/config/server.rs
@@ -16,10 +16,19 @@ pub struct ServerConfig {
     /// Maximum request body size in MB (default: 2048 = 2GB)
     #[serde(default = "default_body_limit_mb")]
     pub body_limit_mb: usize,
+    /// Coalesce concurrent upstream fetches for the same key on a cache miss
+    /// (single-flight, #595). Default `true`; set `false` to disable and let
+    /// every concurrent request fetch independently (kill-switch).
+    #[serde(default = "default_proxy_coalesce")]
+    pub proxy_coalesce: bool,
 }
 
 pub(super) fn default_body_limit_mb() -> usize {
     2048 // 2GB - enough for any Docker image
+}
+
+pub(super) fn default_proxy_coalesce() -> bool {
+    true
 }
 
 /// TLS configuration for outbound connections to upstream registries.
@@ -109,6 +118,7 @@ mod tests {
             port,
             public_url: None,
             body_limit_mb: 2048,
+            proxy_coalesce: true,
         }
     }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -21,6 +21,7 @@ mod metrics;
 mod migrate;
 mod mirror;
 mod openapi;
+mod proxy_coalesce;
 mod rate_limit;
 mod registry;
 mod registry_type;
@@ -202,6 +203,10 @@ pub struct AppState {
     /// OIDC validator for workload identity (CI/CD)
     pub oidc: Option<Arc<auth::OidcValidator>>,
     pub(crate) circuit_breaker: Arc<circuit_breaker::CircuitBreakerRegistry>,
+    /// Single-flight coalescer for the proxy cache-miss path: collapses a
+    /// thundering herd of concurrent requests for the same key into one
+    /// upstream fetch (#595). In-memory and rebuildable (empty after restart).
+    pub(crate) proxy_coalesce: proxy_coalesce::InflightMap<Bytes>,
     pub digest_store: Arc<digest_quarantine::DigestStore>,
     /// Pre-compiled upstream hostname searchers for leak detection (#386)
     pub leak_finders: metrics::LeakFinders,
@@ -1176,6 +1181,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         auth_failures: Arc::new(auth::AuthFailureTracker::new(5, 900)),
         oidc: oidc_validator.map(Arc::new),
         circuit_breaker: Arc::new(circuit_breaker::CircuitBreakerRegistry::new(cb_config)),
+        proxy_coalesce: proxy_coalesce::InflightMap::new(),
         digest_store,
         leak_finders,
     };

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -65,6 +65,44 @@ pub static PROXY_REVALIDATION_ERRORS_TOTAL: LazyLock<IntCounterVec> = LazyLock::
     .expect("failed to create PROXY_REVALIDATION_ERRORS_TOTAL metric at startup")
 });
 
+/// Concurrent upstream fetches collapsed into one by the single-flight
+/// coalescer: a follower served the leader's in-memory result without making
+/// its own upstream round-trip (#595).
+pub static PROXY_COALESCED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_proxy_coalesced_total",
+        "Follower requests served from the single-flight leader without an upstream fetch",
+        &["registry"]
+    )
+    .expect("failed to create PROXY_COALESCED_TOTAL metric at startup")
+});
+
+/// Current number of in-flight single-flight leaders (distinct keys being
+/// fetched right now). A flat zero under load means coalescing is not engaging;
+/// a monotonic climb signals a guard leak (#595).
+pub static PROXY_INFLIGHT: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "nora_proxy_inflight",
+        "Distinct keys currently being fetched under single-flight coalescing",
+        &["registry"]
+    )
+    .expect("failed to create PROXY_INFLIGHT metric at startup")
+});
+
+/// Followers that did NOT get the leader's result and fell through to their own
+/// upstream fetch — because the leader failed/cancelled (`leader`) or the wait
+/// budget elapsed while the leader was still fetching (`budget`). A `budget`
+/// rate rivalling `PROXY_COALESCED_TOTAL` means a slow upstream is re-stampeding
+/// past the coalescer; without this it degrades silently (#595).
+pub static PROXY_COALESCE_FALLTHROUGH_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_proxy_coalesce_fallthrough_total",
+        "Followers that fell through to their own fetch instead of coalescing",
+        &["registry", "reason"]
+    )
+    .expect("failed to create PROXY_COALESCE_FALLTHROUGH_TOTAL metric at startup")
+});
+
 /// HTTP request duration histogram
 pub static HTTP_REQUEST_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(

--- a/nora-registry/src/proxy_coalesce.rs
+++ b/nora-registry/src/proxy_coalesce.rs
@@ -1,0 +1,458 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+
+//! In-memory single-flight coalescing for the proxy cache-miss path (#595).
+//!
+//! When `M` concurrent clients ask for the same expired or missing artifact,
+//! the naive path sends `M` independent upstream fetches and `M` redundant
+//! storage writes for one logical refresh — a classic thundering herd /
+//! cache stampede. This module collapses that to **one** upstream fetch: the
+//! first caller for a key ("leader") performs the fetch; concurrent callers
+//! ("followers") wait for the leader's in-memory result and serve a clone of
+//! it without touching the upstream or the cache.
+//!
+//! ## Why in-memory, not "followers re-read storage"
+//!
+//! NORA's registries cache proxied bytes with a fire-and-forget
+//! `tokio::spawn(storage.put(..))` *after* the response is returned (e.g.
+//! `registry/npm.rs`). A follower that polled storage would race that detached
+//! task — the object may not be written yet. So the leader publishes its
+//! finished serve-bytes into a shared [`Slot`] and followers read *that*; the
+//! background cache write stays exactly as it was (leader does it once).
+//!
+//! ## Correctness & cancel-safety
+//!
+//! - Leader election is a single `Entry::Vacant`/`Occupied` decision under the
+//!   map mutex (never `Arc::strong_count`, which races) — exactly one leader.
+//! - The map mutex (`parking_lot`) is never held across an `.await`; its guard
+//!   is `!Send`, so the compiler rejects accidental holds on the multi-thread
+//!   runtime. `parking_lot` also does not poison, so a leader panic still runs
+//!   the guard's `Drop`.
+//! - [`FetchGuard`] removes the key (ABA-safe via `Arc::ptr_eq`) and wakes
+//!   waiters **on `Drop`**, so a cancelled leader (client disconnect) frees the
+//!   slot instead of poisoning the key. The slot is never left dangling.
+//! - A follower registers its `Notified` *before* the fast-path result check,
+//!   so it cannot miss a `notify_waiters()` that fires in the gap (tokio
+//!   guarantees a `Notified` receives `notify_waiters` wakeups from the moment
+//!   it is created, not first poll).
+//! - State is purely in-memory and rebuildable — an empty map after restart is
+//!   correct (matches the "in-memory indexes are rebuildable from disk"
+//!   invariant). No storage-format change.
+
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::sync::Notify;
+
+/// One in-flight key's shared state: the leader's published result plus a
+/// notifier woken when the leader resolves (success, failure, or cancel).
+struct Slot<T> {
+    /// `Some` once the leader has a value to share; followers clone it.
+    result: Mutex<Option<T>>,
+    /// Notified when the leader finishes or its slot is released.
+    ready: Notify,
+}
+
+impl<T> Slot<T> {
+    fn new() -> Self {
+        Slot {
+            result: Mutex::new(None),
+            ready: Notify::new(),
+        }
+    }
+}
+
+type SlotMap<T> = Arc<Mutex<HashMap<String, Arc<Slot<T>>>>>;
+
+/// Per-key single-flight coordinator. Cheap to clone (shares one map).
+///
+/// `T` is the value followers receive — for the proxy path this is the
+/// ready-to-serve response body (`axum::body::Bytes`, an `Arc`-backed buffer
+/// whose clone is O(1)).
+#[derive(Clone)]
+pub struct InflightMap<T> {
+    map: SlotMap<T>,
+}
+
+impl<T> Default for InflightMap<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> InflightMap<T> {
+    /// Create an empty coordinator.
+    pub fn new() -> Self {
+        InflightMap {
+            map: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+/// RAII slot lease held by the leader for the duration of its fetch.
+///
+/// On `Drop` — whether from a normal return, a panic unwind, or the future
+/// being cancelled mid-fetch — it removes its own slot from the map and wakes
+/// every waiter, then decrements the in-flight gauge. Removal is ABA-safe: if
+/// the key was already reused by a newer leader, `Arc::ptr_eq` prevents this
+/// guard from evicting that newer slot.
+struct FetchGuard<T> {
+    map: SlotMap<T>,
+    key: String,
+    slot: Arc<Slot<T>>,
+    registry: &'static str,
+}
+
+impl<T> Drop for FetchGuard<T> {
+    fn drop(&mut self) {
+        {
+            let mut map = self.map.lock();
+            if let Entry::Occupied(occ) = map.entry(self.key.clone()) {
+                // Only evict our own slot — a newer leader may have re-inserted
+                // the same key after we removed/before this drop (ABA).
+                if Arc::ptr_eq(occ.get(), &self.slot) {
+                    occ.remove();
+                }
+            }
+        } // map lock released before notifying
+          // Wake followers. Those that already observed `result` ignore it; the
+          // rest re-check `result` (None on leader failure/cancel) and fall
+          // through to their own fetch.
+        self.slot.ready.notify_waiters();
+        crate::metrics::PROXY_INFLIGHT
+            .with_label_values(&[self.registry])
+            .dec();
+    }
+}
+
+impl<T> InflightMap<T>
+where
+    T: Clone,
+{
+    /// Run `fetch` under single-flight for `key`.
+    ///
+    /// Exactly one concurrent caller per key (the leader) executes `fetch`;
+    /// the rest (followers) wait up to `budget` for the leader's published
+    /// value and return a clone of it, incrementing
+    /// [`PROXY_COALESCED_TOTAL`](crate::metrics::PROXY_COALESCED_TOTAL). If the
+    /// leader fails (`None`), is cancelled, or `budget` elapses, the follower
+    /// falls through to its **own** `fetch` (fail-open — a request never hangs
+    /// on a dead leader, and a transient leader failure never fails followers).
+    ///
+    /// `budget` should comfortably exceed the leader's worst-case wall-clock
+    /// (upstream timeout + retry) so followers wake on the leader's
+    /// notification rather than on the budget ceiling; the ceiling is only a
+    /// safety net against a leader that never notifies.
+    ///
+    /// `registry` is the metric label for the in-flight gauge and coalesced
+    /// counter.
+    pub async fn coalesced<F, Fut>(
+        &self,
+        key: &str,
+        registry: &'static str,
+        budget: Duration,
+        fetch: F,
+    ) -> Option<T>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Option<T>>,
+    {
+        // --- PRECONDITIONS ---
+        debug_assert!(!key.is_empty(), "coalesce key must not be empty");
+
+        // Leader election: one decision under the lock, zero awaits.
+        let role = {
+            let mut map = self.map.lock();
+            match map.entry(key.to_string()) {
+                Entry::Vacant(v) => {
+                    let slot = Arc::new(Slot::new());
+                    v.insert(Arc::clone(&slot));
+                    Role::Leader(slot)
+                }
+                Entry::Occupied(o) => Role::Follower(Arc::clone(o.get())),
+            }
+        }; // map lock dropped here — before any `.await`
+
+        match role {
+            Role::Leader(slot) => {
+                crate::metrics::PROXY_INFLIGHT
+                    .with_label_values(&[registry])
+                    .inc();
+                // Guard frees the slot + notifies waiters on every exit path,
+                // including cancellation of `fetch().await` below.
+                // CANCEL-SAFETY: slot release happens in `FetchGuard::drop`,
+                // not after the await point.
+                let _guard = FetchGuard {
+                    map: Arc::clone(&self.map),
+                    key: key.to_string(),
+                    slot: Arc::clone(&slot),
+                    registry,
+                };
+                let out = fetch().await;
+                // Publish BEFORE the guard drops so a follower woken by the
+                // guard's `notify_waiters()` always observes the final value.
+                if let Some(ref value) = out {
+                    *slot.result.lock() = Some(value.clone());
+                }
+                out
+                // `_guard` drops here: removes key (ptr_eq) + notify_waiters.
+            }
+            Role::Follower(slot) => {
+                // Register interest BEFORE checking `result`: a `Notified`
+                // created now is guaranteed to receive a `notify_waiters()`
+                // that fires before we await. If the leader already published,
+                // the fast-path check below sees it regardless.
+                let notified = slot.ready.notified();
+                tokio::pin!(notified);
+
+                if let Some(value) = slot.result.lock().clone() {
+                    return Some(Self::record_follower(registry, value));
+                }
+
+                let reason = match tokio::time::timeout(budget, &mut notified).await {
+                    Ok(()) => {
+                        if let Some(value) = slot.result.lock().clone() {
+                            return Some(Self::record_follower(registry, value));
+                        }
+                        // Leader resolved without a value (failure/cancel) —
+                        // fall through to our own fetch.
+                        "leader"
+                    }
+                    Err(_) => {
+                        // Budget elapsed while the leader was still fetching —
+                        // fall through. A rising `budget` rate means a slow
+                        // upstream is re-stampeding past the coalescer.
+                        "budget"
+                    }
+                };
+                crate::metrics::PROXY_COALESCE_FALLTHROUGH_TOTAL
+                    .with_label_values(&[registry, reason])
+                    .inc();
+                fetch().await
+            }
+        }
+    }
+
+    fn record_follower(registry: &'static str, value: T) -> T {
+        crate::metrics::PROXY_COALESCED_TOTAL
+            .with_label_values(&[registry])
+            .inc();
+        value
+    }
+}
+
+enum Role<T> {
+    Leader(Arc<Slot<T>>),
+    Follower(Arc<Slot<T>>),
+}
+
+/// Follower wait budget for a registry whose upstream timeout is `proxy_timeout`
+/// seconds. Sized above the leader's worst-case wall-clock with headroom: the
+/// npm metadata path wired today uses the no-retry `proxy_fetch_conditional`
+/// (leader ≈ `proxy_timeout`), but `proxy_fetch_core` (binary/tarball fetches)
+/// retries once with a 1 s back-off (≈ `2 * proxy_timeout + 1 s`). We size for
+/// the latter so the budget stays correct if coalescing is later wired onto a
+/// retrying path. The leader notifies followers the instant it resolves, so
+/// this is only a ceiling, not the expected wait — a follower that hits it is
+/// counted under `PROXY_COALESCE_FALLTHROUGH_TOTAL{reason="budget"}`.
+pub fn follower_budget(proxy_timeout_secs: u64) -> Duration {
+    Duration::from_secs(2 * proxy_timeout_secs + 3)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Barrier;
+
+    fn budget() -> Duration {
+        Duration::from_secs(5)
+    }
+
+    /// M concurrent callers on the same key → `fetch` runs exactly once; the
+    /// other M-1 receive the leader's value. (Acceptance: M→1 fetch.)
+    #[tokio::test]
+    async fn coalesces_concurrent_callers_to_single_fetch() {
+        let map: InflightMap<u64> = InflightMap::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        const M: usize = 32;
+        // Barrier ensures all tasks reach election before the leader finishes,
+        // so they genuinely contend (otherwise a fast leader could complete
+        // before followers arrive).
+        let gate = Arc::new(Barrier::new(M));
+
+        let mut handles = Vec::new();
+        for _ in 0..M {
+            let map = map.clone();
+            let calls = Arc::clone(&calls);
+            let gate = Arc::clone(&gate);
+            handles.push(tokio::spawn(async move {
+                gate.wait().await;
+                map.coalesced("pkg", "test", budget(), || async {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    // Hold the slot so followers pile up behind the leader.
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Some(7u64)
+                })
+                .await
+            }));
+        }
+
+        let results: Vec<_> = futures::future::join_all(handles).await;
+        for r in results {
+            assert_eq!(r.unwrap(), Some(7u64), "every caller gets the value");
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "exactly one upstream fetch for M concurrent callers"
+        );
+        assert!(
+            map.map.lock().is_empty(),
+            "slot is removed after the leader finishes"
+        );
+    }
+
+    /// Distinct keys never block each other — two keys fetched concurrently
+    /// each run their own fetch. (Acceptance: distinct keys independent.)
+    #[tokio::test]
+    async fn distinct_keys_do_not_block() {
+        let map: InflightMap<u64> = InflightMap::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let a = {
+            let map = map.clone();
+            let calls = Arc::clone(&calls);
+            tokio::spawn(async move {
+                map.coalesced("a", "test", budget(), || async {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Some(1u64)
+                })
+                .await
+            })
+        };
+        let b = {
+            let map = map.clone();
+            let calls = Arc::clone(&calls);
+            tokio::spawn(async move {
+                map.coalesced("b", "test", budget(), || async {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Some(2u64)
+                })
+                .await
+            })
+        };
+
+        assert_eq!(a.await.unwrap(), Some(1));
+        assert_eq!(b.await.unwrap(), Some(2));
+        assert_eq!(calls.load(Ordering::SeqCst), 2, "each distinct key fetched");
+    }
+
+    /// Leader failure (`None`) does not fail followers — they fall through to
+    /// their own fetch. (Acceptance: leader failure doesn't fail followers.)
+    #[tokio::test]
+    async fn leader_failure_falls_through_to_followers() {
+        let map: InflightMap<u64> = InflightMap::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        const M: usize = 8;
+        let gate = Arc::new(Barrier::new(M));
+
+        let mut handles = Vec::new();
+        for _ in 0..M {
+            let map = map.clone();
+            let calls = Arc::clone(&calls);
+            let gate = Arc::clone(&gate);
+            handles.push(tokio::spawn(async move {
+                gate.wait().await;
+                map.coalesced("pkg", "test", budget(), || async {
+                    let n = calls.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(30)).await;
+                    // First caller (leader) "fails"; later callers succeed.
+                    if n == 0 {
+                        None
+                    } else {
+                        Some(99u64)
+                    }
+                })
+                .await
+            }));
+        }
+
+        let results: Vec<_> = futures::future::join_all(handles).await;
+        let successes = results
+            .iter()
+            .filter(|r| r.as_ref().unwrap() == &Some(99))
+            .count();
+        assert!(
+            successes >= 1,
+            "followers fall through and fetch after the leader fails"
+        );
+        // Leader called fetch once; followers fell through and each fetched —
+        // so more than one call, and no caller hung.
+        assert!(
+            calls.load(Ordering::SeqCst) >= 2,
+            "leader failure forces followers to their own fetch"
+        );
+    }
+
+    /// Leader cancellation (its future dropped mid-fetch) releases the key, so
+    /// a subsequent request fetches cleanly with no permanent stall.
+    /// (Acceptance: cancellation releases the key.)
+    #[tokio::test]
+    async fn leader_cancellation_releases_key() {
+        let map: InflightMap<u64> = InflightMap::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        // Spawn a leader that sleeps long, then cancel it mid-fetch.
+        let leader = {
+            let map = map.clone();
+            let calls = Arc::clone(&calls);
+            tokio::spawn(async move {
+                map.coalesced("pkg", "test", budget(), || async {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_secs(60)).await;
+                    Some(1u64)
+                })
+                .await
+            })
+        };
+
+        // Let the leader register and start fetching, then cancel it.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(!map.map.lock().is_empty(), "leader registered its slot");
+        leader.abort();
+        // Give the abort time to run the guard's Drop.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            map.map.lock().is_empty(),
+            "cancelled leader's slot is released on drop"
+        );
+
+        // A fresh request becomes the new leader and fetches cleanly.
+        let fresh = map
+            .coalesced("pkg", "test", budget(), || async {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Some(2u64)
+            })
+            .await;
+        assert_eq!(fresh, Some(2), "subsequent request fetches with no stall");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            2,
+            "cancelled leader + one clean refetch"
+        );
+    }
+
+    #[test]
+    fn budget_scales_with_timeout() {
+        // 2 * timeout + 3s margin.
+        assert_eq!(follower_budget(30), Duration::from_secs(63));
+        assert_eq!(follower_budget(0), Duration::from_secs(3));
+    }
+}

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -169,8 +169,23 @@ async fn handle_request(
             let ttl = state.config.npm.metadata_ttl;
             if let Some(meta) = state.storage.stat(&key).await {
                 if !crate::cache_ttl::is_within_ttl(meta.modified, ttl) {
-                    if let Some(fresh) = refetch_metadata(&state, &path, &key).await {
-                        return with_content_type(false, fresh.into()).into_response();
+                    // Single-flight: when a popular packument expires and a CI
+                    // fleet stampedes the same key, one request revalidates
+                    // upstream and the rest serve its in-memory result (#595).
+                    let fresh = if state.config.server.proxy_coalesce {
+                        let budget =
+                            crate::proxy_coalesce::follower_budget(state.config.npm.proxy_timeout);
+                        state
+                            .proxy_coalesce
+                            .coalesced(&key, "npm", budget, || async {
+                                refetch_metadata(&state, &path, &key).await.map(Bytes::from)
+                            })
+                            .await
+                    } else {
+                        refetch_metadata(&state, &path, &key).await.map(Bytes::from)
+                    };
+                    if let Some(fresh) = fresh {
+                        return with_content_type(false, fresh).into_response();
                     }
                     // Upstream failed — serve stale if configured, otherwise 502
                     if state.config.npm.serve_stale {
@@ -1527,5 +1542,139 @@ mod spec_conformance_tests {
             .with_label_values(&["npm"])
             .get();
         assert!(after > before, "a 304 revalidation must be recorded");
+    }
+
+    /// #595: a thundering herd of concurrent requests for the same expired
+    /// metadata key must collapse to a SINGLE upstream fetch. M clients race
+    /// `GET /npm/testpkg` while the key is stale; a counting mock upstream
+    /// (delayed so followers pile up) must observe exactly one request, and
+    /// every client must receive the leader's body.
+    #[tokio::test]
+    async fn test_npm_concurrent_metadata_miss_coalesces_to_one_upstream_fetch() {
+        use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+        use axum::http::{Method, StatusCode};
+        use std::sync::Arc;
+        use std::time::Duration;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        // Delay the response so all followers reach the single-flight election
+        // while the leader is still fetching. Body is not valid JSON, so the
+        // handler's byte-level URL rewrite passes it through unchanged.
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("FRESH-PACKUMENT")
+                    .set_delay(Duration::from_millis(400)),
+            )
+            .mount(&upstream)
+            .await;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.npm.proxy = Some(upstream.uri());
+            cfg.npm.metadata_ttl = 0; // always stale → always refetch
+            cfg.npm.revalidate = false; // plain 200, no conditional headers
+            cfg.npm.serve_stale = false;
+            // proxy_coalesce defaults to true.
+        });
+
+        // Pre-seed a stale cached body so the stale-metadata refetch path runs.
+        let key = "npm/testpkg/metadata.json";
+        ctx.state.storage.put(key, b"STALE").await.unwrap();
+
+        let before = crate::metrics::PROXY_COALESCED_TOTAL
+            .with_label_values(&["npm"])
+            .get();
+
+        const M: usize = 16;
+        let app = Arc::new(ctx.app.clone());
+        let mut handles = Vec::new();
+        for _ in 0..M {
+            let app = Arc::clone(&app);
+            handles.push(tokio::spawn(async move {
+                let resp = send(&app, Method::GET, "/npm/testpkg", "").await;
+                let status = resp.status();
+                let body = body_bytes(resp).await;
+                (status, body)
+            }));
+        }
+
+        for h in handles {
+            let (status, body) = h.await.unwrap();
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(&body[..], b"FRESH-PACKUMENT", "every client gets the body");
+        }
+
+        let upstream_hits = upstream.received_requests().await.unwrap().len();
+        assert_eq!(
+            upstream_hits, 1,
+            "M concurrent requests for one key must hit upstream exactly once"
+        );
+
+        let after = crate::metrics::PROXY_COALESCED_TOTAL
+            .with_label_values(&["npm"])
+            .get();
+        assert_eq!(
+            after - before,
+            (M - 1) as u64,
+            "M-1 followers must be served without their own upstream fetch"
+        );
+    }
+
+    /// #595 kill-switch: with `server.proxy_coalesce = false`, the coalescer is
+    /// bypassed and every concurrent request fetches independently — so the
+    /// counting upstream observes one hit per client (proves the gate works).
+    #[tokio::test]
+    async fn test_npm_coalesce_disabled_lets_every_request_fetch() {
+        use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+        use axum::http::{Method, StatusCode};
+        use std::sync::Arc;
+        use std::time::Duration;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string("FRESH-PACKUMENT")
+                    .set_delay(Duration::from_millis(200)),
+            )
+            .mount(&upstream)
+            .await;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.npm.proxy = Some(upstream.uri());
+            cfg.npm.metadata_ttl = 0;
+            cfg.npm.revalidate = false;
+            cfg.npm.serve_stale = false;
+            cfg.server.proxy_coalesce = false; // kill-switch off
+        });
+
+        let key = "npm/testpkg/metadata.json";
+        ctx.state.storage.put(key, b"STALE").await.unwrap();
+
+        const M: usize = 8;
+        let app = Arc::new(ctx.app.clone());
+        let mut handles = Vec::new();
+        for _ in 0..M {
+            let app = Arc::clone(&app);
+            handles.push(tokio::spawn(async move {
+                let resp = send(&app, Method::GET, "/npm/testpkg", "").await;
+                let status = resp.status();
+                let _ = body_bytes(resp).await;
+                status
+            }));
+        }
+        for h in handles {
+            assert_eq!(h.await.unwrap(), StatusCode::OK);
+        }
+
+        let upstream_hits = upstream.received_requests().await.unwrap().len();
+        assert_eq!(
+            upstream_hits, M,
+            "with coalescing disabled every request fetches independently"
+        );
     }
 }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -82,6 +82,7 @@ fn build_context(
             port: 0,
             public_url: None,
             body_limit_mb: 2048,
+            proxy_coalesce: true,
         },
         storage: StorageConfig {
             mode: StorageMode::Local,
@@ -252,6 +253,7 @@ fn build_context(
         circuit_breaker: Arc::new(crate::circuit_breaker::CircuitBreakerRegistry::new(
             cb_config,
         )),
+        proxy_coalesce: crate::proxy_coalesce::InflightMap::new(),
         digest_store: Arc::new(crate::digest_quarantine::DigestStore::empty(&storage_path)),
         leak_finders,
     };


### PR DESCRIPTION
## Summary

Closes #595.

On a cache miss — a first-time proxy request or right after `cache_ttl::is_within_ttl()` returns `false` — every concurrent client requesting the same key independently fetches upstream and independently writes storage. For a popular metadata index (npm packument, PyPI simple index, crates sparse-index line, `maven-metadata.xml`) that expires under a CI fleet, that's N upstream round-trips and N redundant cache writes for one logical refresh — a classic thundering herd.

This adds an in-memory **single-flight** coordinator (`src/proxy_coalesce.rs`) and wires it into the npm metadata revalidation path: for a given key, exactly one task (leader) performs the upstream fetch + store; concurrent tasks (followers) wait for the leader's result and serve it without their own upstream hit.

## Design

- **In-memory result sharing, not storage re-read.** Registries cache proxied bytes with a fire-and-forget `tokio::spawn(storage.put(..))` *after* the response returns, so a follower polling storage would race that detached task. Instead the leader publishes its finished serve-bytes into a shared slot and followers clone *that*; the background cache write is unchanged (leader does it once).
- **Leader election** is a single `Entry::Vacant`/`Occupied` decision under a `parking_lot` mutex (never `Arc::strong_count`); the map lock is never held across an `.await`.
- **Cancel-safety:** a RAII `FetchGuard` releases the slot and wakes waiters on `Drop` — including client-disconnect cancellation and panic unwind — with ABA-safe removal via `Arc::ptr_eq`, so a key is never poisoned or leaked.
- **Lost-wakeup closed:** followers register their `Notify` interest before the fast-path result check.
- **Fail-open:** on leader failure, cancellation, or budget elapse, a follower falls through to its own fetch — a request never hangs on a dead leader.
- State is purely in-memory and rebuildable (empty after restart is correct). No storage-format change.

## Config & metrics

- `server.proxy_coalesce` (bool, default `true`) — kill-switch.
- `nora_proxy_coalesced_total{registry}` — followers served without an upstream hit.
- `nora_proxy_inflight{registry}` — gauge of distinct keys being fetched now (flat-zero under load ⇒ not engaging; monotonic climb ⇒ guard leak).
- `nora_proxy_coalesce_fallthrough_total{registry,reason}` — followers that fell through (`leader` failure/cancel vs `budget` elapsed); a rising `budget` rate signals a slow upstream re-stampeding past the coalescer.

## Scope

This lands the mechanism plus the npm metadata wiring (the dominant herd case). Rolling the coordinator onto the pypi/cargo/maven metadata paths is a mechanical follow-up — the primitive is registry-agnostic.

## Test plan

- Unit (concurrency): M concurrent callers → exactly one `fetch` execution with all callers getting the value; leader failure → followers fall through; leader cancellation → key released, subsequent request fetches cleanly; distinct keys never block each other.
- Integration (wiremock counting upstream): M concurrent `GET /npm/<pkg>` for an expired key → upstream observes **exactly 1** request, every client receives the body; kill-switch off → every request fetches independently (M hits).
- `cargo fmt`, `cargo clippy -D warnings`, full suite (1283 passed), semgrep/cargo-deny/cargo-audit clean.

## Out of scope

- Cross-process / multi-replica coordination (single-binary; in-memory is the right scope).
- Stale-while-revalidate (tracked separately).