### PR TITLE
perf(storage): instrument buffered get() integrity-verify cost (#602)

### DIFF
--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -198,6 +198,43 @@ pub static UPSTREAM_REQUEST_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| 
     .expect("failed to create UPSTREAM_REQUEST_DURATION metric at startup")
 });
 
+/// Wall-clock time of the integrity-verify step on a buffered `Storage::get()`
+/// — the `spawn_blocking(pins.verify(..))` call. Includes blocking-pool queue
+/// time, so a rising p99 under read load signals pool saturation, not just hash
+/// cost. Recorded whenever a pin store is configured (Local backend); a key
+/// with no pin returns early inside `verify()` and contributes a near-zero
+/// sample. Quantifies the #602 perf question before any change is made (#602).
+pub static STORAGE_VERIFY_DURATION_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        "nora_storage_verify_duration_seconds",
+        "Integrity-verify (SHA-256) wall-clock per buffered get, including blocking-pool queue",
+        &["registry"],
+        vec![0.0001, 0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5]
+    )
+    .expect("failed to create STORAGE_VERIFY_DURATION_SECONDS metric at startup")
+});
+
+/// Size in bytes of bodies served through the buffered `Storage::get()` path.
+/// Shows how much read traffic is large enough for inline hashing to matter —
+/// the data needed to decide whether a size threshold is worthwhile (#602).
+pub static STORAGE_GET_BYTES: LazyLock<HistogramVec> = LazyLock::new(|| {
+    register_histogram_vec!(
+        "nora_storage_get_bytes",
+        "Body size of buffered Storage::get() reads",
+        &["registry"],
+        vec![
+            1024.0,
+            16_384.0,
+            262_144.0,
+            1_048_576.0,
+            8_388_608.0,
+            67_108_864.0,
+            536_870_912.0
+        ]
+    )
+    .expect("failed to create STORAGE_GET_BYTES metric at startup")
+});
+
 /// Total artifact downloads by registry (#431)
 pub static DOWNLOADS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -8,7 +8,7 @@ pub use local::LocalStorage;
 pub use s3::S3Storage;
 
 use crate::hash_pin_store::HashPinStore;
-use crate::metrics::STORAGE_OPERATIONS;
+use crate::metrics::{STORAGE_GET_BYTES, STORAGE_OPERATIONS, STORAGE_VERIFY_DURATION_SECONDS};
 use crate::validation::{validate_storage_key, ValidationError};
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -47,6 +47,22 @@ pub enum StorageError {
 }
 
 pub type Result<T> = std::result::Result<T, StorageError>;
+
+/// Registry prefix of a storage key, for metric labelling only
+/// (`npm/lodash/metadata.json` → `npm`). Storage stays format-agnostic: this
+/// reads the first path segment as an opaque label, with no registry-protocol
+/// knowledge. Cardinality is bounded — an empty, oversized, or non-lowercase
+/// first segment collapses to `other`, so a pathological key cannot explode the
+/// label set.
+fn registry_label(key: &str) -> &str {
+    let segment = key.split('/').next().unwrap_or("");
+    if !segment.is_empty() && segment.len() <= 16 && segment.bytes().all(|b| b.is_ascii_lowercase())
+    {
+        segment
+    } else {
+        "other"
+    }
+}
 
 /// Storage backend trait
 #[async_trait]
@@ -166,6 +182,10 @@ impl Storage {
         match self.inner.get(key).await {
             Ok(data) => {
                 STORAGE_OPERATIONS.with_label_values(&["get", "ok"]).inc();
+                let label = registry_label(key);
+                STORAGE_GET_BYTES
+                    .with_label_values(&[label])
+                    .observe(data.len() as f64);
                 if let Some(ref pins) = self.pin_store {
                     let pins = Arc::clone(pins);
                     let key_owned = key.to_string();
@@ -175,9 +195,23 @@ impl Storage {
                     // hashing it inline would stall the async worker for the
                     // hash duration, so we keep the blocking pool. The panic
                     // path is handled fail-closed below — see #582.
-                    match tokio::task::spawn_blocking(move || pins.verify(&key_owned, &data_ref))
-                        .await
-                    {
+                    //
+                    // INVARIANT (#582): a *positive* verify result is NEVER
+                    // cached — the hash is recomputed on every read. Caching
+                    // "verified" by mtime/size would re-open the bypass #582
+                    // closed (bit-rot does not bump mtime; an on-disk tamperer
+                    // can forge it via `utimes`). The recompute is the
+                    // deliberate cost of fail-closed delivery; #602 instruments
+                    // that cost via STORAGE_VERIFY_DURATION_SECONDS rather than
+                    // weakening the guarantee.
+                    let verify_start = std::time::Instant::now();
+                    let outcome =
+                        tokio::task::spawn_blocking(move || pins.verify(&key_owned, &data_ref))
+                            .await;
+                    STORAGE_VERIFY_DURATION_SECONDS
+                        .with_label_values(&[label])
+                        .observe(verify_start.elapsed().as_secs_f64());
+                    match outcome {
                         // Genuine hash mismatch — tampering or on-disk corruption.
                         // Fail-closed: never serve the tampered bytes (#582).
                         Ok(false) => {
@@ -399,6 +433,65 @@ mod tests {
         );
         // And the recorded pin must match the bytes (a subsequent get verifies).
         assert_eq!(&storage.get("raw/x/app.bin").await.unwrap()[..], b"payload");
+    }
+
+    #[test]
+    fn registry_label_extracts_prefix_and_bounds_cardinality() {
+        assert_eq!(registry_label("npm/lodash/metadata.json"), "npm");
+        assert_eq!(
+            registry_label("docker/library/nginx/blobs/sha256:ab"),
+            "docker"
+        );
+        assert_eq!(registry_label("raw/x/app.bin"), "raw");
+        // Defensive collapses to "other" — never an unbounded label.
+        assert_eq!(registry_label(""), "other");
+        assert_eq!(registry_label("/leading-slash"), "other");
+        assert_eq!(registry_label("UPPER/x"), "other");
+        assert_eq!(registry_label("averylongsegmentname/x"), "other"); // >16 chars
+                                                                       // Filter is strictly [a-z] — digits/hyphens collapse to "other" so a
+                                                                       // future "allow [a-z0-9]" change can't silently explode cardinality.
+        assert_eq!(registry_label("v2/x"), "other");
+        assert_eq!(registry_label("a-b/x"), "other");
+        assert_eq!(registry_label("npm"), "npm"); // no slash, whole key is prefix
+    }
+
+    /// #602: a buffered `get()` of a pinned artifact records both the body-size
+    /// and the verify-duration histograms (the data that decides whether the
+    /// hash-on-read cost warrants a fix). Exercises the real `Storage::get()`.
+    #[tokio::test]
+    async fn get_observes_size_and_verify_duration_metrics() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+        let key = "raw/metrics/app.bin";
+        storage.put(key, b"observe-me").await.unwrap();
+
+        let bytes_before = STORAGE_GET_BYTES
+            .with_label_values(&["raw"])
+            .get_sample_count();
+        let verify_before = STORAGE_VERIFY_DURATION_SECONDS
+            .with_label_values(&["raw"])
+            .get_sample_count();
+
+        let data = storage.get(key).await.unwrap();
+        assert_eq!(&data[..], b"observe-me");
+
+        // `>=` not `==`: these are global metrics and other tests share the
+        // `raw` label under parallel execution; our get() contributes at least
+        // one observation to each.
+        assert!(
+            STORAGE_GET_BYTES
+                .with_label_values(&["raw"])
+                .get_sample_count()
+                >= bytes_before + 1,
+            "get() must observe the body size"
+        );
+        assert!(
+            STORAGE_VERIFY_DURATION_SECONDS
+                .with_label_values(&["raw"])
+                .get_sample_count()
+                >= verify_before + 1,
+            "get() of a pinned key must observe the verify duration"
+        );
     }
 
     /// Regression for #604: the streaming write path `put_from_path()` must also


### PR DESCRIPTION
## Summary

Refs #602.

`Storage::get()` recomputes a full SHA-256 over the body on every read of a pinned artifact — the load-bearing fail-closed integrity check from #582. #602 asks whether that cost is hot enough to warrant a size threshold / verify-on-write+scrub / negative-cache.

**Before changing anything, instrument it.** Two facts make the cost likely overstated and any fix premature without data:
- The genuinely-large artifacts (docker blobs) already stream through `get_reader()` **without any hashing** — so the buffered `get()` carries metadata, manifests, npm tarballs, raw artifacts.
- There is **no latency/size telemetry** on the storage path today (only a bare op counter).

## What this adds

- **`nora_storage_verify_duration_seconds{registry}`** — wraps the `spawn_blocking(verify)` call, capturing hash time **and** blocking-pool queue time, so a rising p99 distinguishes "hash is expensive" from "pool is saturated under read concurrency."
- **`nora_storage_get_bytes{registry}`** — body-size distribution of buffered reads; the data needed to judge whether (and where) a size threshold pays off.
- **`registry_label()`** — derives the metric label from the key's first path segment with bounded cardinality (`[a-z]{1,16}`, else `other`); storage stays format-agnostic (no registry-protocol knowledge).
- Documents the **#582 invariant** at the verify site: a *positive* verify result is **never** cached. Caching "verified" by mtime/size would re-open the bypass #582 closed — bit-rot does not bump mtime, and an on-disk tamperer can forge it via `utimes`.

## What this deliberately does NOT do

- **No background scrub** — a periodic walker is a sidecar subsystem against ADR-1/ADR-2 (single-binary, filesystem-as-DB), and "scrub verified it N minutes ago" is exactly the integrity bypass #582 closed.
- **No positive / mtime verify-cache** — re-opens the #582 bit-rot + tamper bypass.
- **No size threshold yet** — deferred until the histograms show a real large-buffered tail with pool queueing; shipping a blind threshold would drop inline verification for large npm/raw artifacts with no compensation.

No behaviour change; fail-closed semantics (#582) are untouched.

## Test plan

- `get()` of a pinned key observes both histograms (real `Storage::get()` path).
- `registry_label()` extraction + cardinality-bound cases (digits/hyphens/uppercase/oversized/empty → `other`).
- `cargo fmt`, `clippy -D warnings`, full suite (1285 passed), semgrep/cargo-deny/cargo-audit clean.

## Follow-up

With one week of prod histograms: if the large-buffered tail is a fraction of a percent and verify p99 stays single-digit ms → close #602 as "measured, within budget." If a real tail with pool queueing appears → a size-threshold + verify-on-write (via the existing `record_hash` path) PR, sized from the data.