### PR TITLE
feat(storage): operator re-pin recovery for integrity-failed artifacts (#601)

### DIFF
--- a/MONITORING.md
+++ b/MONITORING.md
@@ -49,7 +49,7 @@ Import `dist/grafana-dashboard.json` into Grafana (Dashboards > Import > Upload 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `nora_storage_bytes` | gauge | registry | Storage size in bytes per registry |
-| `nora_storage_operations_total` | counter | operation, status | Storage operations (put, get, delete) |
+| `nora_storage_operations_total` | counter | operation, status | Storage operations (put, get, delete). `status="integrity_fail"`/`"verify_error"` on `operation="get"` mean a stored artifact failed hash-pin verification and was refused (fail-closed, #582) — see [Integrity recovery](#integrity-recovery). |
 
 ### Circuit Breaker
 
@@ -142,4 +142,36 @@ groups:
         labels: { severity: critical }
         annotations:
           summary: "Upstream URL leak detected in NORA responses"
+
+      - alert: NoraIntegrityFailure
+        expr: increase(nora_storage_operations_total{operation="get",status=~"integrity_fail|verify_error"}[5m]) > 0
+        for: 0m
+        labels: { severity: critical }
+        annotations:
+          summary: "NORA refusing to serve an artifact (hash-pin integrity failure)"
 ```
+
+A ready-to-load version of these rules ships at [`deploy/prometheus-rules.yml`](deploy/prometheus-rules.yml); point Prometheus at it via `rule_files:`.
+
+## Integrity recovery
+
+When `nora_storage_operations_total{operation="get",status="integrity_fail"}`
+fires, a stored artifact's bytes no longer match its hash pin (bit rot or
+tampering) and `Storage::get()` returns 5xx on every read (fail-closed, #582).
+The offending key is in the `integrity violation` error log line.
+
+- **Cache/proxy artifacts** self-heal: the next request treats the failure as a
+  cache miss, re-fetches from upstream, and re-pins.
+- **Locally-authored artifacts** (e.g. uploaded `raw` blobs) have no upstream.
+  Verify the on-disk bytes against a hash you trust, then:
+
+  ```sh
+  # Dry run — shows old → new pin without writing:
+  nora re-pin raw/myorg/app-1.0.0.bin --expected <sha256>
+  # Apply once you've confirmed:
+  nora re-pin raw/myorg/app-1.0.0.bin --expected <sha256> --yes
+  ```
+
+  `--expected` is **mandatory**: re-pin updates the pin only if the on-disk
+  bytes already hash to it. If they do not, the disk is genuinely corrupt — the
+  command refuses (re-pin cannot heal corruption); restore from backup first.

--- a/deploy/prometheus-rules.yml
+++ b/deploy/prometheus-rules.yml
@@ -1,0 +1,31 @@
+# Prometheus alerting rules for NORA.
+#
+# Load alongside your scrape config:
+#
+#   # prometheus.yml
+#   rule_files:
+#     - /etc/prometheus/prometheus-rules.yml
+#
+# These rules surface the fail-closed integrity path (#582/#601): when a stored
+# artifact's bytes no longer match its hash pin, `Storage::get()` returns 5xx on
+# every read. Without an alert that silently becomes "service down on a hot key"
+# with no diagnosis.
+groups:
+  - name: nora-integrity
+    rules:
+      - alert: NoraIntegrityFailure
+        # `status` (not `result`) is the metric's label; matches
+        # nora_storage_operations_total{operation="get",status="integrity_fail"}
+        # and "verify_error" emitted by storage::Storage::get().
+        expr: increase(nora_storage_operations_total{operation="get",status=~"integrity_fail|verify_error"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+        annotations:
+          summary: "NORA is refusing to serve an artifact (hash-pin integrity failure)"
+          description: >-
+            Storage get() failed closed on a hash-pin mismatch (bit rot or
+            tampering); the artifact returns 5xx on every read. Find the key in
+            the `integrity violation` error log, verify the on-disk bytes, then
+            recover with `nora re-pin <key> --expected <sha256> --yes` (or
+            restore from backup if the disk is genuinely corrupt).

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -136,6 +136,22 @@ enum Commands {
         #[arg(long, default_value = "false")]
         dry_run: bool,
     },
+    /// Recover an artifact whose hash pin no longer matches its bytes (#601).
+    ///
+    /// Updates the pin to `--expected` only if the on-disk bytes already hash
+    /// to it. If the disk is genuinely corrupt (does not match), it refuses —
+    /// re-pin cannot heal corruption; restore from backup first.
+    RePin {
+        /// Storage key, e.g. `raw/myorg/app-1.0.0.bin`
+        key: String,
+        /// The SHA-256 (64-char hex) the operator knows to be canonical for
+        /// this key — from a CI manifest, upstream checksum, or lockfile.
+        #[arg(long)]
+        expected: String,
+        /// Apply the change. Without this, prints what would change (dry run).
+        #[arg(long)]
+        yes: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -631,6 +647,53 @@ async fn main() {
                 }
                 Err(e) => {
                     error!("Docker key migration failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
+        }
+        Some(Commands::RePin { key, expected, yes }) => {
+            let expected = expected.to_ascii_lowercase();
+            if expected.len() != 64 || !expected.bytes().all(|b| b.is_ascii_hexdigit()) {
+                error!("--expected must be a 64-character hex SHA-256");
+                std::process::exit(2);
+            }
+            match storage.repin(&key, &expected, yes).await {
+                Ok(storage::RepinOutcome::NoPinStore) => {
+                    println!("Backend has no pin store (S3) — nothing to re-pin.");
+                }
+                Ok(storage::RepinOutcome::DiskMismatch { disk, expected }) => {
+                    error!(
+                        key = %key,
+                        on_disk = %disk,
+                        expected = %expected,
+                        "re-pin refused: on-disk bytes do not match --expected — the artifact is corrupt. Restore it from backup, then re-pin."
+                    );
+                    std::process::exit(1);
+                }
+                Ok(storage::RepinOutcome::AlreadyPinned { hash }) => {
+                    println!("Pin already matches {hash} — nothing to do.");
+                }
+                Ok(storage::RepinOutcome::WouldUpdate { old, new }) => {
+                    println!(
+                        "Would re-pin {key}:\n  old: {}\n  new: {new}\nRe-run with --yes to apply.",
+                        old.as_deref().unwrap_or("(none)")
+                    );
+                }
+                Ok(storage::RepinOutcome::Updated { old, new }) => {
+                    // Loud audit trail — re-pin is a privileged integrity override.
+                    warn!(
+                        key = %key,
+                        old = ?old,
+                        new = %new,
+                        "INTEGRITY RE-PIN: hash pin updated by operator (#601)"
+                    );
+                    println!(
+                        "Re-pinned {key}:\n  old: {}\n  new: {new}",
+                        old.as_deref().unwrap_or("(none)")
+                    );
+                }
+                Err(e) => {
+                    error!(key = %key, "re-pin failed: {}", e);
                     std::process::exit(1);
                 }
             }

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -12,6 +12,7 @@ use crate::metrics::{STORAGE_GET_BYTES, STORAGE_OPERATIONS, STORAGE_VERIFY_DURAT
 use crate::validation::{validate_storage_key, ValidationError};
 use async_trait::async_trait;
 use axum::body::Bytes;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -62,6 +63,24 @@ fn registry_label(key: &str) -> &str {
     } else {
         "other"
     }
+}
+
+/// Outcome of [`Storage::repin`] — an operator integrity-recovery action (#601).
+#[derive(Debug, PartialEq, Eq)]
+pub enum RepinOutcome {
+    /// The disk matched `expected` and the pin was updated from `old` to `new`.
+    Updated { old: Option<String>, new: String },
+    /// Dry run: the disk matched `expected` and the pin would change.
+    WouldUpdate { old: Option<String>, new: String },
+    /// The disk already matched `expected` and the pin already equalled it —
+    /// nothing to do.
+    AlreadyPinned { hash: String },
+    /// Refused: the on-disk bytes hash to `disk`, not `expected`. The artifact
+    /// is genuinely corrupt/tampered — re-pin cannot heal it; restore from
+    /// backup. The pin is left unchanged.
+    DiskMismatch { disk: String, expected: String },
+    /// This backend has no pin store (S3) — there is nothing to re-pin.
+    NoPinStore,
 }
 
 /// Storage backend trait
@@ -311,6 +330,51 @@ impl Storage {
     /// Look up the pinned SHA-256 hash for a storage key (None if pin store is disabled or key is unknown).
     pub fn get_pin_hash(&self, key: &str) -> Option<String> {
         self.pin_store.as_ref().and_then(|p| p.get(key))
+    }
+
+    /// Operator recovery for an artifact whose hash pin no longer matches its
+    /// stored bytes (#601). Reads the raw bytes *bypassing* verification — the
+    /// whole point, since [`Storage::get`] fails closed on the very mismatch we
+    /// are recovering from — and updates the pin to `expected` **only if the
+    /// on-disk bytes already hash to `expected`**.
+    ///
+    /// `expected` is the SHA-256 the operator independently knows to be
+    /// canonical for this key (from a CI manifest, upstream checksum, lockfile,
+    /// …). Requiring it is the security guard that keeps this from becoming an
+    /// integrity bypass: a plain "recompute the hash from disk" would let
+    /// corrupted or tampered bytes silently re-bless themselves, re-opening the
+    /// hole #582 closed. By demanding `disk == expected`, re-pin can only ever
+    /// set the pin to a hash the disk *already* has **and** the operator has
+    /// vouched for. If the disk is genuinely corrupt (`disk != expected`) it
+    /// refuses — re-pin cannot heal corruption; the operator must restore from
+    /// backup first.
+    ///
+    /// `apply == false` is a dry run (computes and compares, writes nothing).
+    /// Local backend only — S3 has no pin store.
+    pub async fn repin(&self, key: &str, expected: &str, apply: bool) -> Result<RepinOutcome> {
+        validate_storage_key(key)?;
+        let Some(ref pins) = self.pin_store else {
+            return Ok(RepinOutcome::NoPinStore);
+        };
+        let expected = expected.to_ascii_lowercase();
+        // Raw read — deliberately bypasses `Storage::get()`'s verification,
+        // which would fail closed on the mismatch we are recovering from.
+        let data = self.inner.get(key).await?;
+        let disk = hex::encode(Sha256::digest(&data));
+        if disk != expected {
+            // The bytes on disk are not the ones the operator vouched for —
+            // genuine corruption/tampering. Re-pin must NOT bless them.
+            return Ok(RepinOutcome::DiskMismatch { disk, expected });
+        }
+        let old = pins.get(key);
+        if old.as_deref() == Some(expected.as_str()) {
+            return Ok(RepinOutcome::AlreadyPinned { hash: expected });
+        }
+        if !apply {
+            return Ok(RepinOutcome::WouldUpdate { old, new: expected });
+        }
+        pins.record_hash(key, &expected);
+        Ok(RepinOutcome::Updated { old, new: expected })
     }
 
     /// Number of pinned hashes (0 if pin store is disabled).
@@ -571,5 +635,105 @@ mod tests {
         let unpinned = "raw/ok/unpinned.bin";
         std::fs::write(dir.path().join(unpinned), b"no-pin").unwrap();
         assert_eq!(&storage.get(unpinned).await.unwrap()[..], b"no-pin");
+    }
+
+    fn sha_hex(data: &[u8]) -> String {
+        hex::encode(Sha256::digest(data))
+    }
+
+    /// #601 happy path: an artifact legitimately replaced out-of-band (disk now
+    /// holds new canonical bytes, pin still references the old ones) fails
+    /// closed, then `re-pin --expected <hash-of-new>` restores service because
+    /// the disk already matches `expected`. Exercises the real `repin()` +
+    /// `get()` call path (PM-4).
+    #[tokio::test]
+    async fn repin_fixes_stale_pin_when_disk_matches_expected() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+        let key = "raw/app/release.bin";
+
+        storage.put(key, b"v1-bytes").await.unwrap();
+        await_pin(&storage, key).await;
+
+        // Operator replaces the file out-of-band with new canonical bytes.
+        std::fs::write(dir.path().join(key), b"v2-canonical").unwrap();
+        // Now the pin (hash of v1) no longer matches the disk → fail-closed.
+        assert!(matches!(
+            storage.get(key).await,
+            Err(StorageError::IntegrityViolation)
+        ));
+
+        let expected = sha_hex(b"v2-canonical");
+
+        // Dry run reports the change without writing.
+        assert_eq!(
+            storage.repin(key, &expected, false).await.unwrap(),
+            RepinOutcome::WouldUpdate {
+                old: Some(sha_hex(b"v1-bytes")),
+                new: expected.clone(),
+            }
+        );
+        // ...and the pin is untouched, so it still fails closed.
+        assert!(storage.get(key).await.is_err());
+
+        // Apply: the disk matches `expected`, so the pin is updated.
+        assert_eq!(
+            storage.repin(key, &expected, true).await.unwrap(),
+            RepinOutcome::Updated {
+                old: Some(sha_hex(b"v1-bytes")),
+                new: expected,
+            }
+        );
+        // Service restored — the new canonical bytes are served.
+        assert_eq!(&storage.get(key).await.unwrap()[..], b"v2-canonical");
+    }
+
+    /// #601 security guard: re-pin must NOT bless corrupt/tampered bytes. When
+    /// the disk does not match `--expected`, it refuses and leaves the pin
+    /// unchanged, so the artifact keeps failing closed (no integrity bypass).
+    #[tokio::test]
+    async fn repin_refuses_when_disk_does_not_match_expected() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+        let key = "raw/app/payload.bin";
+
+        storage.put(key, b"genuine").await.unwrap();
+        await_pin(&storage, key).await;
+
+        // Disk is tampered; operator (correctly) supplies the genuine hash.
+        std::fs::write(dir.path().join(key), b"TAMPERED").unwrap();
+        let genuine = sha_hex(b"genuine");
+
+        // disk (hash of TAMPERED) != expected (hash of genuine) → refuse.
+        assert_eq!(
+            storage.repin(key, &genuine, true).await.unwrap(),
+            RepinOutcome::DiskMismatch {
+                disk: sha_hex(b"TAMPERED"),
+                expected: genuine.clone(),
+            }
+        );
+        // The pin was not changed to the tampered bytes — still fails closed.
+        assert!(matches!(
+            storage.get(key).await,
+            Err(StorageError::IntegrityViolation)
+        ));
+        assert_eq!(storage.get_pin_hash(key).as_deref(), Some(genuine.as_str()));
+    }
+
+    /// Re-pinning a key whose pin already equals `expected` is a no-op.
+    #[tokio::test]
+    async fn repin_already_pinned_is_noop() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+        let key = "raw/app/ok.bin";
+        storage.put(key, b"stable").await.unwrap();
+        await_pin(&storage, key).await;
+
+        assert_eq!(
+            storage.repin(key, &sha_hex(b"stable"), true).await.unwrap(),
+            RepinOutcome::AlreadyPinned {
+                hash: sha_hex(b"stable")
+            }
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #601.

After #582, a stored artifact whose bytes no longer match its hash pin (bit rot or tampering) fails closed — 5xx on every read. Cache/proxy artifacts self-heal (failed read → cache miss → re-fetch → re-pin), but **locally-authored** artifacts (uploaded `raw` blobs) had no recovery short of `delete`, which loses the data. This adds an operator recovery path plus the missing alert.

## `nora re-pin <key> --expected <sha256> [--yes]`

`--expected` is **mandatory by design** — this is the security guard that keeps recovery from becoming an integrity bypass:

- re-pin reads the raw bytes **bypassing** verification (otherwise the failing artifact couldn't be read at all), computes their hash, and updates the pin to `--expected` **only if `sha256(disk) == expected`**.
- If the disk does **not** match, it **refuses** (`DiskMismatch`) and leaves the pin untouched — the artifact is genuinely corrupt; re-pin cannot heal corruption, restore from backup first.

A plain "recompute the hash from disk" (the issue's literal proposal) would let corrupted/tampered bytes silently re-bless themselves, re-opening the hole #582 closed. Requiring the disk to already match an independently-known canonical hash means re-pin can only ever set the pin to bytes the operator has vouched for.

Guardrails: **CLI-only** (no network surface — re-pin is a write into the trust boundary), dry-run by default (`--yes` to apply), loud `warn!` audit log of the old→new pin, S3 explicitly reports "no pin store" rather than faking success.

## Alert + runbook

- `deploy/prometheus-rules.yml` — `NoraIntegrityFailure` firing on `nora_storage_operations_total{operation="get",status=~"integrity_fail|verify_error"}` (the metric label is `status`, not `result` as the issue sketched). Without it, a fail-closed artifact silently becomes "service down on a hot key" with no diagnosis.
- `MONITORING.md` — Integrity-recovery runbook + alert wiring.

## Scope

Per design review, `repair` (re-pull from upstream) is **out of scope** — proxy artifacts already self-heal, and locally-authored artifacts have no upstream to re-pull from, so it has no valid domain. Batch/fsck-style scanning is a separate concern.

## Test plan

All through the real `repin()` + `get()` call path:
- **Security guard:** disk tampered, operator supplies the genuine hash → `DiskMismatch`, pin unchanged, `get()` still fails closed (no bypass).
- **Happy path:** artifact replaced out-of-band, operator supplies hash of new bytes → dry-run previews, `--yes` updates pin, service restored.
- **No-op:** pin already equals expected → `AlreadyPinned`.
- End-to-end CLI smoke (malformed `--expected` → exit 2; dry-run; apply with audit log).
- `cargo fmt`, `clippy -D warnings`, full suite (1286 passed), semgrep/cargo-deny/cargo-audit clean.