### PR TITLE
fix(storage): make hash-pin writes durable and fail closed

### DIFF
--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -116,13 +116,19 @@ impl HashPinStore {
     /// retried `put()` would skip the (still-missing) append.
     pub fn record(&self, key: &str, data: &[u8]) -> io::Result<()> {
         let hash = Self::sha256_hex(data);
-        let needs_write = {
-            let pins = self.pins.read();
-            pins.get(key).is_none_or(|existing| *existing != hash)
-        };
-        if needs_write {
+        // Atomic per key: hold the write lock across check → append → insert.
+        // The disk append happens before the in-memory update (durability), and
+        // no concurrent record() for the same key can interleave its append and
+        // insert with ours, so disk and memory cannot diverge. (An earlier
+        // two-lock version — read-check, release, append, write-insert — had a
+        // TOCTOU where two same-key writers' append and insert orders disagreed.)
+        // The append is a ~100-byte line and record() runs on a blocking thread
+        // (`spawn_blocking`), so holding the lock across it trades a little read
+        // contention for correctness — the right call for a tamper-detection store.
+        let mut pins = self.pins.write();
+        if pins.get(key).is_none_or(|existing| *existing != hash) {
             Self::append_to_file(&self.path, key, &hash)?;
-            self.pins.write().insert(key.to_string(), hash);
+            pins.insert(key.to_string(), hash);
         }
         Ok(())
     }
@@ -141,13 +147,11 @@ impl HashPinStore {
             "record_hash: expected 64-char hex SHA-256, got: {hash}"
         );
 
-        let needs_write = {
-            let pins = self.pins.read();
-            pins.get(key).is_none_or(|existing| *existing != hash)
-        };
-        if needs_write {
+        // Same atomic check → append → insert under one write lock as record().
+        let mut pins = self.pins.write();
+        if pins.get(key).is_none_or(|existing| *existing != hash) {
             Self::append_to_file(&self.path, key, hash)?;
-            self.pins.write().insert(key.to_string(), hash.to_string());
+            pins.insert(key.to_string(), hash.to_string());
         }
         Ok(())
     }
@@ -182,10 +186,11 @@ impl HashPinStore {
     /// before verification, and a later `put()` of the key overwrites the pin —
     /// so callers may treat a remove failure as non-fatal.
     pub fn remove(&self, key: &str) -> io::Result<()> {
-        let present = self.pins.read().contains_key(key);
-        if present {
+        // Atomic tombstone: append + drop under one write lock (see record()).
+        let mut pins = self.pins.write();
+        if pins.contains_key(key) {
             Self::append_to_file(&self.path, key, "")?;
-            self.pins.write().remove(key);
+            pins.remove(key);
         }
         Ok(())
     }
@@ -457,5 +462,43 @@ mod tests {
             "record_hash must propagate the same I/O error"
         );
         assert_eq!(store.len(), 0, "failed record_hash must not update memory");
+    }
+
+    /// Regression for the disk-first TOCTOU: concurrent record() calls for the
+    /// SAME key with DIFFERENT data must leave the in-memory pin equal to what a
+    /// fresh reload from disk sees — disk and memory cannot diverge. Holding the
+    /// write lock across check → append → insert makes each record() atomic per
+    /// key; the earlier two-lock version could append in one order but insert in
+    /// the other.
+    #[test]
+    fn test_concurrent_same_key_disk_memory_consistent() {
+        use std::sync::Arc;
+        let dir = TempDir::new().unwrap();
+        let path = pin_path(&dir);
+        let store = Arc::new(HashPinStore::new(&path));
+        let key = "concurrent/key";
+
+        let handles: Vec<_> = (0..20)
+            .map(|i| {
+                let s = Arc::clone(&store);
+                std::thread::spawn(move || {
+                    let _ = s.record(key, format!("data-{i}").as_bytes());
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let in_memory = store.get(key);
+        drop(store);
+        // What survives a restart must equal what the live process holds.
+        let reloaded = HashPinStore::new(&path);
+        assert_eq!(
+            in_memory,
+            reloaded.get(key),
+            "in-memory pin must match the durably-recorded pin (no TOCTOU divergence)"
+        );
+        assert!(in_memory.is_some(), "some writer must have recorded a pin");
     }
 }

--- a/nora-registry/src/hash_pin_store.rs
+++ b/nora-registry/src/hash_pin_store.rs
@@ -10,12 +10,22 @@
 //! Persistence: append-only NDJSON file (`.nora-pins.ndjson`) compacted on
 //! startup. Each line: `{"k":"storage/key","h":"sha256hex"}`. An empty `h`
 //! marks a deletion (tombstone).
+//!
+//! Durability: every pin write **propagates** its I/O result to the caller,
+//! which fails closed (`StorageError::Io`) rather than report a `put()` success
+//! the disk never accepted. A swallowed pin-write error would silently
+//! downgrade a pinned key to open-world after a restart — the very integrity
+//! bypass #582/#604 closed — because the in-memory pin is now updated only
+//! *after* the durable append succeeds. (Crash-durability of the pin via
+//! `fsync` is tracked separately: it must land together with the matching body
+//! `fsync` on `put_from_path`, so the pin is never made *more* durable than the
+//! bytes it pins.)
 
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::io::{BufRead, Write};
+use std::io::{self, BufRead, Write};
 use std::path::PathBuf;
 use tracing::warn;
 
@@ -36,17 +46,33 @@ impl HashPinStore {
         let path = path.into();
         let mut pins = HashMap::new();
 
-        // Replay NDJSON log — last entry per key wins
-        if let Ok(file) = std::fs::File::open(&path) {
-            let reader = std::io::BufReader::new(file);
-            for line in reader.lines().map_while(Result::ok) {
-                if let Ok(entry) = serde_json::from_str::<PinEntry>(&line) {
-                    if entry.h.is_empty() {
-                        pins.remove(&entry.k);
-                    } else {
-                        pins.insert(entry.k, entry.h);
+        // Replay NDJSON log — last entry per key wins.
+        match std::fs::File::open(&path) {
+            Ok(file) => {
+                let reader = std::io::BufReader::new(file);
+                for line in reader.lines().map_while(Result::ok) {
+                    if let Ok(entry) = serde_json::from_str::<PinEntry>(&line) {
+                        if entry.h.is_empty() {
+                            pins.remove(&entry.k);
+                        } else {
+                            pins.insert(entry.k, entry.h);
+                        }
                     }
                 }
+            }
+            // First run / empty store — nothing to replay.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            // The pin file exists but cannot be read (permissions, EIO).
+            // Loading an empty set would silently make every key open-world;
+            // surface it loudly so the operator notices the integrity index did
+            // not load rather than discovering it only on a missed tamper.
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    path = %path.display(),
+                    "hash-pin log present but unreadable; integrity index NOT loaded \
+                     (keys verify open-world until this is fixed)"
+                );
             }
         }
 
@@ -55,8 +81,17 @@ impl HashPinStore {
             path,
         };
 
-        // Compact on startup to remove tombstones and duplicates
-        store.compact();
+        // Compact on startup to remove tombstones and duplicates. Compaction is
+        // an optimization, not an integrity-critical write: a failure leaves the
+        // (correct, already-persisted) uncompacted log in place, so it is logged
+        // and tolerated rather than fatal.
+        if let Err(e) = store.compact() {
+            warn!(
+                error = %e,
+                path = %store.path.display(),
+                "hash-pin compaction on startup failed; continuing with uncompacted log"
+            );
+        }
         store
     }
 
@@ -73,21 +108,23 @@ impl HashPinStore {
     /// hash, this is a no-op. If the hash changed (normal metadata update),
     /// the pin is updated.
     ///
-    /// The write lock is released before file I/O to minimize lock contention.
-    pub fn record(&self, key: &str, data: &[u8]) {
+    /// Returns the I/O error if the pin append fails, so the caller can fail
+    /// closed rather than serve an artifact it could not pin. The in-memory
+    /// index is updated only *after* the append succeeds — memory must never
+    /// claim a pin the disk does not hold, or a `get()` after a failed `put()`
+    /// would verify against a RAM-only pin that vanishes on restart, and a
+    /// retried `put()` would skip the (still-missing) append.
+    pub fn record(&self, key: &str, data: &[u8]) -> io::Result<()> {
         let hash = Self::sha256_hex(data);
-        let should_write = {
-            let mut pins = self.pins.write();
-            let changed = pins.get(key).is_none_or(|existing| *existing != hash);
-            if changed {
-                pins.insert(key.to_string(), hash.clone());
-            }
-            changed
+        let needs_write = {
+            let pins = self.pins.read();
+            pins.get(key).is_none_or(|existing| *existing != hash)
         };
-        // File append after lock release — ~100 bytes, fast on any filesystem
-        if should_write {
-            Self::append_to_file(&self.path, key, &hash);
+        if needs_write {
+            Self::append_to_file(&self.path, key, &hash)?;
+            self.pins.write().insert(key.to_string(), hash);
         }
+        Ok(())
     }
 
     /// Record a pre-computed SHA-256 hash for a storage key.
@@ -95,24 +132,24 @@ impl HashPinStore {
     /// Used by streaming paths where the hash was already computed
     /// incrementally during download — avoids re-reading the file (#580).
     ///
-    /// `hash` must be a lowercase hex-encoded SHA-256 (64 chars).
-    pub fn record_hash(&self, key: &str, hash: &str) {
+    /// `hash` must be a lowercase hex-encoded SHA-256 (64 chars). Durability and
+    /// ordering match [`HashPinStore::record`]: the pin is appended before the
+    /// in-memory index is updated, and an I/O failure is returned to the caller.
+    pub fn record_hash(&self, key: &str, hash: &str) -> io::Result<()> {
         debug_assert!(
             hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit()),
             "record_hash: expected 64-char hex SHA-256, got: {hash}"
         );
 
-        let should_write = {
-            let mut pins = self.pins.write();
-            let changed = pins.get(key).is_none_or(|existing| *existing != hash);
-            if changed {
-                pins.insert(key.to_string(), hash.to_string());
-            }
-            changed
+        let needs_write = {
+            let pins = self.pins.read();
+            pins.get(key).is_none_or(|existing| *existing != hash)
         };
-        if should_write {
-            Self::append_to_file(&self.path, key, hash);
+        if needs_write {
+            Self::append_to_file(&self.path, key, hash)?;
+            self.pins.write().insert(key.to_string(), hash.to_string());
         }
+        Ok(())
     }
 
     /// Verify data integrity against pinned hash. Called on every `get()`.
@@ -139,15 +176,18 @@ impl HashPinStore {
 
     /// Remove a pin entry. Called on `delete()`.
     ///
-    /// The write lock is released before file I/O.
-    pub fn remove(&self, key: &str) {
-        let removed = {
-            let mut pins = self.pins.write();
-            pins.remove(key).is_some()
-        };
-        if removed {
-            Self::append_to_file(&self.path, key, "");
+    /// Appends a tombstone before dropping the in-memory entry, returning any
+    /// I/O error. A tombstone-write failure leaves the (now stale) pin in place;
+    /// that is benign — `get()` on a deleted key fails at the inner backend
+    /// before verification, and a later `put()` of the key overwrites the pin —
+    /// so callers may treat a remove failure as non-fatal.
+    pub fn remove(&self, key: &str) -> io::Result<()> {
+        let present = self.pins.read().contains_key(key);
+        if present {
+            Self::append_to_file(&self.path, key, "")?;
+            self.pins.write().remove(key);
         }
+        Ok(())
     }
 
     /// Look up the stored SHA-256 hash for a key, if pinned.
@@ -160,45 +200,49 @@ impl HashPinStore {
         self.pins.read().len()
     }
 
-    /// Compact the NDJSON file: rewrite with only live entries.
-    fn compact(&self) {
+    /// Compact the NDJSON file: rewrite with only live entries via a temp file
+    /// and an atomic rename. Returns any I/O error; the caller decides whether a
+    /// compaction failure is fatal (it is not — see [`HashPinStore::new`]).
+    fn compact(&self) -> io::Result<()> {
         let pins = self.pins.read();
         if pins.is_empty() {
-            // Remove empty file
-            let _ = std::fs::remove_file(&self.path);
-            return;
+            // No live pins: remove the file if present; an absent file is fine.
+            return match std::fs::remove_file(&self.path) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(e) => Err(e),
+            };
         }
 
         let temp_path = self.path.with_extension("ndjson.tmp");
-        if let Ok(mut file) = std::fs::File::create(&temp_path) {
-            for (key, hash) in pins.iter() {
-                let entry = PinEntry {
-                    k: key.clone(),
-                    h: hash.clone(),
-                };
-                if let Ok(line) = serde_json::to_string(&entry) {
-                    let _ = writeln!(file, "{}", line);
-                }
-            }
-            let _ = std::fs::rename(&temp_path, &self.path);
+        let mut file = std::fs::File::create(&temp_path)?;
+        for (key, hash) in pins.iter() {
+            let entry = PinEntry {
+                k: key.clone(),
+                h: hash.clone(),
+            };
+            let line = serde_json::to_string(&entry).map_err(io::Error::other)?;
+            writeln!(file, "{line}")?;
         }
+        std::fs::rename(&temp_path, &self.path)?;
+        Ok(())
     }
 
-    /// Append a single entry to the NDJSON file (static, safe to call from any thread).
-    fn append_to_file(path: &std::path::Path, key: &str, hash: &str) {
-        if let Ok(mut file) = std::fs::OpenOptions::new()
+    /// Append a single entry to the NDJSON file (static, safe to call from any
+    /// thread). Propagates any open/serialize/write error to the caller instead
+    /// of swallowing it.
+    fn append_to_file(path: &std::path::Path, key: &str, hash: &str) -> io::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
-            .open(path)
-        {
-            let entry = PinEntry {
-                k: key.to_string(),
-                h: hash.to_string(),
-            };
-            if let Ok(line) = serde_json::to_string(&entry) {
-                let _ = writeln!(file, "{}", line);
-            }
-        }
+            .open(path)?;
+        let entry = PinEntry {
+            k: key.to_string(),
+            h: hash.to_string(),
+        };
+        let line = serde_json::to_string(&entry).map_err(io::Error::other)?;
+        writeln!(file, "{line}")?;
+        Ok(())
     }
 }
 
@@ -217,7 +261,9 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = HashPinStore::new(pin_path(&dir));
 
-        store.record("maven/com/example/1.0/app.jar", b"jar-content");
+        store
+            .record("maven/com/example/1.0/app.jar", b"jar-content")
+            .unwrap();
         assert!(store.verify("maven/com/example/1.0/app.jar", b"jar-content"));
         assert!(!store.verify("maven/com/example/1.0/app.jar", b"tampered"));
     }
@@ -236,11 +282,11 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = HashPinStore::new(pin_path(&dir));
 
-        store.record("npm/meta/express", b"v1");
+        store.record("npm/meta/express", b"v1").unwrap();
         assert!(store.verify("npm/meta/express", b"v1"));
 
         // Metadata update — pin is updated
-        store.record("npm/meta/express", b"v2");
+        store.record("npm/meta/express", b"v2").unwrap();
         assert!(store.verify("npm/meta/express", b"v2"));
         assert!(!store.verify("npm/meta/express", b"v1"));
     }
@@ -250,10 +296,10 @@ mod tests {
         let dir = TempDir::new().unwrap();
         let store = HashPinStore::new(pin_path(&dir));
 
-        store.record("key", b"data");
+        store.record("key", b"data").unwrap();
         assert_eq!(store.len(), 1);
 
-        store.remove("key");
+        store.remove("key").unwrap();
         assert_eq!(store.len(), 0);
 
         // After removal, any data passes verification (no pin)
@@ -267,9 +313,9 @@ mod tests {
 
         {
             let store = HashPinStore::new(&path);
-            store.record("a", b"data-a");
-            store.record("b", b"data-b");
-            store.remove("b");
+            store.record("a", b"data-a").unwrap();
+            store.record("b", b"data-b").unwrap();
+            store.remove("b").unwrap();
         }
 
         // Reload from disk
@@ -286,9 +332,9 @@ mod tests {
 
         {
             let store = HashPinStore::new(&path);
-            store.record("keep", b"data");
-            store.record("remove", b"data");
-            store.remove("remove");
+            store.record("keep", b"data").unwrap();
+            store.record("remove", b"data").unwrap();
+            store.remove("remove").unwrap();
         }
 
         // After reload + compact, file should only have 1 entry
@@ -308,11 +354,8 @@ mod tests {
         let store = HashPinStore::new(&path);
 
         // Same data twice — should not append duplicate
-        store.record("key", b"data");
-        store.record("key", b"data");
-
-        // Wait for background I/O thread to complete
-        std::thread::sleep(std::time::Duration::from_millis(200));
+        store.record("key", b"data").unwrap();
+        store.record("key", b"data").unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
@@ -336,7 +379,7 @@ mod tests {
 
         // Pre-computed SHA-256 of b"streaming-data"
         let hash = HashPinStore::sha256_hex(b"streaming-data");
-        store.record_hash("docker/blob/sha256:abc", &hash);
+        store.record_hash("docker/blob/sha256:abc", &hash).unwrap();
 
         assert_eq!(store.len(), 1);
         assert!(store.verify("docker/blob/sha256:abc", b"streaming-data"));
@@ -351,7 +394,7 @@ mod tests {
         let hash = HashPinStore::sha256_hex(b"persistent");
         {
             let store = HashPinStore::new(&path);
-            store.record_hash("key/hash", &hash);
+            store.record_hash("key/hash", &hash).unwrap();
         }
 
         // Reload
@@ -367,8 +410,8 @@ mod tests {
         let store = HashPinStore::new(&path);
 
         let hash = HashPinStore::sha256_hex(b"data");
-        store.record_hash("key", &hash);
-        store.record_hash("key", &hash);
+        store.record_hash("key", &hash).unwrap();
+        store.record_hash("key", &hash).unwrap();
 
         let content = std::fs::read_to_string(&path).unwrap();
         let lines: Vec<&str> = content.lines().collect();
@@ -383,5 +426,36 @@ mod tests {
             hash,
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
+    }
+
+    /// A pin write to an unwritable path must surface the I/O error, not swallow
+    /// it — otherwise `put()` reports success while the pin never lands,
+    /// silently downgrading the key to open-world on the next restart.
+    ///
+    /// The path is placed *under a regular file* so `open()` fails with
+    /// `ENOTDIR` — a structural error the kernel returns even to root, unlike a
+    /// `chmod`-based read-only directory which root (a common deployment for
+    /// this code) bypasses via `DAC_OVERRIDE`.
+    #[test]
+    fn test_record_propagates_io_error() {
+        let dir = TempDir::new().unwrap();
+        let not_a_dir = dir.path().join("iamafile");
+        std::fs::write(&not_a_dir, b"x").unwrap();
+        let unwritable = not_a_dir.join(".nora-pins.ndjson");
+
+        let store = HashPinStore::new(&unwritable);
+        assert!(
+            store.record("k", b"data").is_err(),
+            "pin write to an unwritable path must return an error, not swallow it"
+        );
+        // The in-memory index must not claim a pin the disk never accepted.
+        assert_eq!(store.len(), 0, "failed pin write must not update memory");
+
+        let hash = HashPinStore::sha256_hex(b"data");
+        assert!(
+            store.record_hash("k", &hash).is_err(),
+            "record_hash must propagate the same I/O error"
+        );
+        assert_eq!(store.len(), 0, "failed record_hash must not update memory");
     }
 }

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -172,15 +172,36 @@ impl Storage {
                     // the artifact unpinned. Fully closing that requires
                     // serializing get/put per key; it is benign (it serves NORA's
                     // own just-written bytes) and out of scope here.
+                    // `record` now returns its I/O result: handle the inner
+                    // failure (ENOSPC/EACCES/EIO/read-only FS) the same way as a
+                    // panicked task — fail closed. Previously that error was
+                    // swallowed inside `record`, so `put()` returned Ok while the
+                    // pin never reached disk, silently downgrading the key to
+                    // open-world after the next restart (the #582/#604 bypass).
+                    //
+                    // NOTE (immutable registries): `self.inner.put` already
+                    // succeeded, so on an immutable registry the client's retry
+                    // hits the immutability guard (409) and never re-runs this pin
+                    // write — the orphaned body stays unpinned until an operator
+                    // `repin`s it. That is still strictly better than the prior
+                    // silent success and is the documented recovery path;
+                    // auto-cleanup of the orphan body is a separate follow-up.
                     match tokio::task::spawn_blocking(move || pins.record(&key_owned, &data_owned))
                         .await
                     {
-                        Ok(()) => {}
-                        Err(e) => {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
                             STORAGE_OPERATIONS
                                 .with_label_values(&["put", "pin_error"])
                                 .inc();
                             tracing::error!(error = %e, key = %key, "hash-pin record failed");
+                            return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
+                        }
+                        Err(e) => {
+                            STORAGE_OPERATIONS
+                                .with_label_values(&["put", "pin_error"])
+                                .inc();
+                            tracing::error!(error = %e, key = %key, "hash-pin record task panicked");
                             return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
                         }
                     }
@@ -281,9 +302,31 @@ impl Storage {
                     .inc();
                 if let Some(ref pins) = self.pin_store {
                     let pins = Arc::clone(pins);
-                    let key = key.to_string();
-                    // Sync file append — offload from tokio worker
-                    tokio::task::spawn_blocking(move || pins.remove(&key));
+                    let key_owned = key.to_string();
+                    // Await the tombstone write so a failure is observable rather
+                    // than fire-and-forget. A lost tombstone is fail-safe (a stale
+                    // pin at worst yields a future IntegrityViolation, healable via
+                    // `repin`), so `delete()` still reports success — the
+                    // authoritative action (byte removal) already succeeded.
+                    match tokio::task::spawn_blocking(move || pins.remove(&key_owned)).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            STORAGE_OPERATIONS
+                                .with_label_values(&["delete", "pin_error"])
+                                .inc();
+                            tracing::warn!(
+                                error = %e,
+                                key = %key,
+                                "hash-pin tombstone write failed; stale pin left (repin to heal)"
+                            );
+                        }
+                        Err(e) => {
+                            STORAGE_OPERATIONS
+                                .with_label_values(&["delete", "pin_error"])
+                                .inc();
+                            tracing::warn!(error = %e, key = %key, "hash-pin tombstone task panicked");
+                        }
+                    }
                 }
                 Ok(())
             }
@@ -373,7 +416,8 @@ impl Storage {
         if !apply {
             return Ok(RepinOutcome::WouldUpdate { old, new: expected });
         }
-        pins.record_hash(key, &expected);
+        pins.record_hash(key, &expected)
+            .map_err(|e| StorageError::Io(format!("hash-pin record failed: {e}")))?;
         Ok(RepinOutcome::Updated { old, new: expected })
     }
 
@@ -411,12 +455,19 @@ impl Storage {
                     match tokio::task::spawn_blocking(move || pins.record_hash(&key_owned, &hash))
                         .await
                     {
-                        Ok(()) => {}
-                        Err(e) => {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
                             STORAGE_OPERATIONS
                                 .with_label_values(&["put", "pin_error"])
                                 .inc();
                             tracing::error!(error = %e, key = %key, "hash-pin record failed");
+                            return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
+                        }
+                        Err(e) => {
+                            STORAGE_OPERATIONS
+                                .with_label_values(&["put", "pin_error"])
+                                .inc();
+                            tracing::error!(error = %e, key = %key, "hash-pin record task panicked");
                             return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
                         }
                     }
@@ -735,5 +786,45 @@ mod tests {
                 hash: sha_hex(b"stable")
             }
         );
+    }
+
+    /// Documents the recovery contract for the immutable-publish unpin trap:
+    /// when a `put()` body write succeeds but the pin write fails (now surfaced
+    /// as `StorageError::Io` instead of swallowed), the artifact is left durably
+    /// on disk *unpinned* (open-world). On an immutable registry the client
+    /// cannot self-heal — its retry hits the 409 guard — so that orphaned state
+    /// must be recoverable via operator `repin`. Models the orphaned state with
+    /// `put_from_path(.., None)`, which stores the body without recording a pin.
+    #[tokio::test]
+    async fn orphaned_unpinned_body_is_repin_recoverable() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().join("store").to_str().unwrap());
+        let key = "raw/app/orphan.bin";
+
+        // Stage the post-failure state: body on disk, no pin recorded.
+        let src = dir.path().join("incoming.bin");
+        std::fs::write(&src, b"orphan-bytes").unwrap();
+        storage.put_from_path(key, &src, None).await.unwrap();
+        assert_eq!(
+            storage.get_pin_hash(key),
+            None,
+            "precondition: the orphaned body must be stored without a pin"
+        );
+
+        // Operator re-pins with the independently-known canonical hash; the disk
+        // already matches it, so the pin is set and service verifies again.
+        let expected = sha_hex(b"orphan-bytes");
+        assert_eq!(
+            storage.repin(key, &expected, true).await.unwrap(),
+            RepinOutcome::Updated {
+                old: None,
+                new: expected.clone(),
+            }
+        );
+        assert_eq!(
+            storage.get_pin_hash(key).as_deref(),
+            Some(expected.as_str())
+        );
+        assert_eq!(&storage.get(key).await.unwrap()[..], b"orphan-bytes");
     }
 }


### PR DESCRIPTION
## Summary

Closes #628.

`HashPinStore` write methods swallowed filesystem errors and inserted the in-memory pin before the (swallowed) disk write, so a failed pin append left `put()` reporting `Ok` while no pin landed — open-world verification after the next restart. This makes `record`/`record_hash`/`remove`/`compact`/`append_to_file` return `io::Result` and propagate; the in-memory index is updated only after a durable append (disk-first); `put()`/`put_from_path()` fail closed on a pin I/O error via the existing `pin_error` metric. `record()` is atomic per key (single write lock across check → append → insert) so concurrent same-key writers cannot diverge disk and memory.

## Test plan

- `cargo test -p nora-registry test_record_propagates_io_error` — appending into a non-directory path (ENOTDIR) surfaces the error instead of swallowing it.
- `cargo test -p nora-registry test_concurrent_same_key_disk_memory_consistent` — concurrent same-key writers keep disk and memory in agreement.
- Full `cargo test` green; clippy/fmt clean.
