### PR TITLE
feat(metrics): export nora_curation_decisions_total{decision}

### DIFF
--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -155,6 +155,22 @@ impl CurationEngine {
     /// - **Enforce**: Block decisions are final.
     /// - All Skip → Allow.
     pub fn evaluate(&self, request: &FilterRequest) -> EvaluationResult {
+        let result = self.evaluate_inner(request);
+        // Expose the effective curation decision in Prometheus — previously only
+        // internal counters existed, so allow/block was invisible in telemetry.
+        let decision = match &result.decision {
+            Decision::Allow => "allow",
+            Decision::Block { .. } if result.audited => "audit",
+            Decision::Block { .. } => "block",
+            Decision::Skip => "skip",
+        };
+        crate::metrics::CURATION_DECISIONS_TOTAL
+            .with_label_values(&[decision])
+            .inc();
+        result
+    }
+
+    fn evaluate_inner(&self, request: &FilterRequest) -> EvaluationResult {
         // Namespace isolation: ALWAYS active, even in Off mode.
         // Prevents dependency confusion regardless of curation config.
         if let Some(ref ns_filter) = self.namespace_filter {

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -31,6 +31,20 @@ pub static HTTP_REQUESTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     .expect("failed to create HTTP_REQUESTS_TOTAL metric at startup")
 });
 
+/// Curation engine decisions, by effective outcome. Makes allow/deny visible in
+/// telemetry — previously curation only kept internal counters, so an operator
+/// could not see from Prometheus how often curation allowed vs blocked.
+/// Labels: `decision` ∈ {allow, block, audit (would-block, allowed in audit
+/// mode), skip}.
+pub static CURATION_DECISIONS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_curation_decisions_total",
+        "Curation engine decisions by effective outcome",
+        &["decision"]
+    )
+    .expect("failed to create CURATION_DECISIONS_TOTAL metric at startup")
+});
+
 /// Conditional revalidations where upstream answered 304 Not Modified — the
 /// cached body was reused and no body bytes were downloaded (#596).
 pub static PROXY_UPSTREAM_304_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {


### PR DESCRIPTION
## Summary

Closes #631.

Curation kept internal allow/block counters but exported no Prometheus metric. This adds `nora_curation_decisions_total{decision}` (`allow` | `block` | `audit` | `skip`), incremented once per `evaluate()` by the effective outcome (a thin wrapper over the existing logic; the decisions themselves are unchanged). Same internal-counter → Prometheus pattern as #446, scoped to curation.

## Test plan

- `cargo test -p nora-registry` (curation + metrics modules) green — existing behavior unchanged (metric is additive, no new unit test).
- Manual: exercise allow and block paths → `nora_curation_decisions_total{decision="allow"}` and `{decision="block"}` increment on `/metrics`.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.
