### PR TITLE
feat(metrics): per-registry artifact and storage gauges + process uptime

### DIFF
--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1407,11 +1407,18 @@ async fn run_server(mut config: Config, storage: Storage) {
                 metrics::STORAGE_BYTES
                     .with_label_values(&["total"])
                     .set(metrics_state.storage.total_size().await as i64);
-                // Per-registry artifact counts + process uptime (#446)
+                // Per-registry artifact counts + logical bytes from the cached index,
+                // plus process uptime (#446). The "total" storage_bytes label above is
+                // the full physical footprint; per-registry is summed artifact size.
                 for (rt, count) in metrics_state.repo_index.counts() {
                     metrics::ARTIFACTS_TOTAL
                         .with_label_values(&[rt.as_str()])
                         .set(count as i64);
+                }
+                for (rt, bytes) in metrics_state.repo_index.sizes() {
+                    metrics::STORAGE_BYTES
+                        .with_label_values(&[rt.as_str()])
+                        .set(bytes as i64);
                 }
                 metrics::UPTIME_SECONDS.set(metrics_state.start_time.elapsed().as_secs() as i64);
             }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1407,6 +1407,13 @@ async fn run_server(mut config: Config, storage: Storage) {
                 metrics::STORAGE_BYTES
                     .with_label_values(&["total"])
                     .set(metrics_state.storage.total_size().await as i64);
+                // Per-registry artifact counts + process uptime (#446)
+                for (rt, count) in metrics_state.repo_index.counts() {
+                    metrics::ARTIFACTS_TOTAL
+                        .with_label_values(&[rt.as_str()])
+                        .set(count as i64);
+                }
+                metrics::UPTIME_SECONDS.set(metrics_state.start_time.elapsed().as_secs() as i64);
             }
 
             // Every 5 minutes (tick_count % 10 == 0): evict unused publish locks

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -160,12 +160,11 @@ pub static NAMESPACE_SCOPE_DECISIONS: LazyLock<IntCounterVec> = LazyLock::new(||
     .expect("failed to create NAMESPACE_SCOPE_DECISIONS metric at startup")
 });
 
-/// Artifacts count by registry
-#[allow(dead_code)]
-pub static ARTIFACTS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
-    register_int_counter_vec!(
+/// Current number of artifacts by registry (gauge — rises and falls with GC)
+pub static ARTIFACTS_TOTAL: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
         "nora_artifacts_total",
-        "Total artifacts stored",
+        "Current number of artifacts by registry",
         &["registry"]
     )
     .expect("failed to create ARTIFACTS_TOTAL metric at startup")
@@ -277,6 +276,12 @@ pub static STORAGE_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
         &["registry"]
     )
     .expect("failed to create STORAGE_BYTES metric at startup")
+});
+
+/// Process uptime in seconds (gauge)
+pub static UPTIME_SECONDS: LazyLock<IntGauge> = LazyLock::new(|| {
+    register_int_gauge!("nora_uptime_seconds", "Process uptime in seconds")
+        .expect("failed to create UPTIME_SECONDS metric at startup")
 });
 
 /// Cache write errors by registry and operation (#500)

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -272,7 +272,7 @@ pub static UPLOADS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
 pub static STORAGE_BYTES: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     register_int_gauge_vec!(
         "nora_storage_bytes",
-        "Storage size in bytes by registry",
+        "Stored artifact bytes per registry (label \"total\" = full storage footprint incl. metadata)",
         &["registry"]
     )
     .expect("failed to create STORAGE_BYTES metric at startup")

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -70,6 +70,11 @@ impl RegistryIndex {
     pub fn count(&self) -> usize {
         self.data.read().len()
     }
+
+    /// Sum of artifact bytes in this registry's cached index (no rebuild).
+    pub fn total_size(&self) -> u64 {
+        self.data.read().iter().map(|r| r.size).sum()
+    }
 }
 
 impl Default for RegistryIndex {
@@ -161,6 +166,14 @@ impl RepoIndex {
         self.indexes
             .iter()
             .map(|(rt, idx)| (*rt, idx.count()))
+            .collect()
+    }
+
+    /// Get total artifact bytes per registry from the cached index (no rebuild).
+    pub fn sizes(&self) -> HashMap<RegistryType, u64> {
+        self.indexes
+            .iter()
+            .map(|(rt, idx)| (*rt, idx.total_size()))
             .collect()
     }
 }


### PR DESCRIPTION
## Summary

Closes #446.

Bridges the remaining UI-dashboard counters to Prometheus so Grafana / VictoriaMetrics can replicate every dashboard card from `/metrics` alone:

- **`nora_artifacts_total`** is now an `IntGaugeVec` (count rises and falls with GC), emitted **per registry** from `repo_index.counts()` in the periodic loop. It was previously `#[allow(dead_code)]`, never emitted, and typed as a counter.
- **`nora_storage_bytes`** is now emitted **per registry** (`RepoIndex::sizes()` = sum of `RepoInfo.size`, matching the dashboard); the `{registry="total"}` label remains the full physical storage footprint.
- **`nora_uptime_seconds`** gauge added, set from `start_time.elapsed()`.

downloads / uploads / cache were already wired.

## Test plan

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build` clean.
- `cargo test -p nora-registry` — **1303 passed, 0 failed**. The per-registry label is bounded by `registry_label`/`RegistryType::as_str` (≤16 ascii-lowercase or `other`) — no cardinality blow-up.
- **Runtime A/B (before github/main vs after):** before — neither `nora_artifacts_total` nor `nora_uptime_seconds` present; after — both present, `# TYPE … gauge`.
- **Runtime math-truth across all 13 registries:** uploaded 7 raw artifacts (2800 B); scraped `/metrics` cross-checked against on-disk reality:
  - `artifacts_total{raw}` = 7 == disk files == uploaded ✅
  - `storage_bytes{raw}` = 2800 == uploaded payload bytes ✅
  - `storage_bytes{total}` = 5157 == sum of file bytes on disk ✅
  - 13/13 registries carry both a count and a bytes series; all values non-negative.
