### PR TITLE
fix(cargo): revalidate the sparse index against upstream before serving from cache

### DIFF
--- a/nora-registry/src/cache_ttl.rs
+++ b/nora-registry/src/cache_ttl.rs
@@ -33,6 +33,21 @@ pub fn is_within_ttl(modified_unix: u64, ttl_secs: i64) -> bool {
     }
 }
 
+/// Whether a cached MUTABLE proxy resource (a cargo sparse index, a docker tag, a version
+/// listing, …) may be served WITHOUT revalidating against upstream: only when there is no
+/// upstream to revalidate against (the resource is locally authoritative) or it is still within
+/// a POSITIVE `metadata_ttl` staleness window. A non-positive ttl revalidates every pull, so a
+/// newly published version or yank appears.
+pub fn mutable_ref_fresh(has_upstream: bool, metadata_ttl: i64, modified: Option<u64>) -> bool {
+    if !has_upstream {
+        return true;
+    }
+    metadata_ttl > 0
+        && modified
+            .map(|m| is_within_ttl(m, metadata_ttl))
+            .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,5 +92,22 @@ mod tests {
         assert!(!is_within_ttl(now - 300, 300));
         // One second less — still fresh
         assert!(is_within_ttl(now - 299, 300));
+    }
+
+    #[test]
+    fn mutable_ref_fresh_hosted_and_proxied() {
+        let now = now_secs();
+        // Hosted (no upstream to revalidate against) → always fresh, regardless of ttl.
+        assert!(mutable_ref_fresh(false, -1, Some(now)));
+        assert!(mutable_ref_fresh(false, 0, None));
+        // Proxied + non-positive ttl → revalidate every pull (not fresh) — the fix.
+        assert!(!mutable_ref_fresh(true, -1, Some(now)));
+        assert!(!mutable_ref_fresh(true, 0, Some(now)));
+        // Proxied + positive ttl within the window → fresh (bounded staleness).
+        assert!(mutable_ref_fresh(true, 300, Some(now - 10)));
+        // Proxied + positive ttl beyond the window → revalidate.
+        assert!(!mutable_ref_fresh(true, 300, Some(now - 600)));
+        // Proxied + unknown mtime → revalidate.
+        assert!(!mutable_ref_fresh(true, 300, None));
     }
 }

--- a/nora-registry/src/config/registry/cargo.rs
+++ b/nora-registry/src/config/registry/cargo.rs
@@ -15,6 +15,8 @@ pub struct CargoConfig {
     pub proxy_auth: Option<ProtectedString>,
     #[serde(default = "super::super::default_timeout")]
     pub proxy_timeout: u64,
+    #[serde(default = "super::super::default_metadata_ttl")]
+    pub metadata_ttl: i64,
 }
 
 fn default_cargo_proxy() -> Option<String> {
@@ -28,6 +30,7 @@ impl Default for CargoConfig {
             proxy: default_cargo_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
+            metadata_ttl: 300,
         }
     }
 }
@@ -49,6 +52,9 @@ impl CargoConfig {
         }
         if let Ok(val) = env::var("NORA_CARGO_PROXY_TIMEOUT") {
             super::super::parse_env_warn("NORA_CARGO_PROXY_TIMEOUT", &val, &mut self.proxy_timeout);
+        }
+        if let Ok(val) = env::var("NORA_CARGO_METADATA_TTL") {
+            super::super::parse_env_warn("NORA_CARGO_METADATA_TTL", &val, &mut self.metadata_ttl);
         }
     }
 }

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -105,24 +105,45 @@ async fn sparse_index(
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    // Try local index first
     let index_key = format!("cargo/index/{}/{}", expected_prefix, crate_name);
-    if let Ok(data) = state.storage.get(&index_key).await {
-        state.metrics.record_download("cargo");
-        state.metrics.record_cache_hit("cargo");
-        state.activity.push(ActivityEntry::new(
-            ActionType::CacheHit,
-            crate_name.to_string(),
-            "cargo",
-            "CACHE",
-        ));
-        return sparse_index_conditional(data.to_vec(), &headers);
+
+    // Read the cached index eagerly — kept for the freshness check and the stale-on-error fallback.
+    let cached = state.storage.get(&index_key).await.ok();
+
+    // The sparse index is MUTABLE (new versions append and `yanked` flips at any time), so a
+    // proxied index must be revalidated against upstream before it is served — otherwise newly
+    // published versions / yanks never appear. A hosted index (no upstream) is locally
+    // authoritative, and a positive `metadata_ttl` re-introduces a bounded staleness window.
+    if let Some(ref data) = cached {
+        let modified = state.storage.stat(&index_key).await.map(|m| m.modified);
+        if crate::cache_ttl::mutable_ref_fresh(
+            state.config.cargo.proxy.is_some(),
+            state.config.cargo.metadata_ttl,
+            modified,
+        ) {
+            state.metrics.record_download("cargo");
+            state.metrics.record_cache_hit("cargo");
+            state.activity.push(ActivityEntry::new(
+                ActionType::CacheHit,
+                crate_name.to_string(),
+                "cargo",
+                "CACHE",
+            ));
+            return sparse_index_conditional(data.to_vec(), &headers);
+        }
     }
 
-    // Try upstream sparse index (sparse+https://index.crates.io/)
+    // Revalidate / fetch from upstream (no cache, or the cached index is stale).
     let proxy_url = match &state.config.cargo.proxy {
         Some(url) => url.clone(),
-        None => return StatusCode::NOT_FOUND.into_response(),
+        None => {
+            // Hosted (no upstream): a cached index is locally authoritative.
+            if let Some(ref data) = cached {
+                state.metrics.record_cache_hit("cargo");
+                return sparse_index_conditional(data.to_vec(), &headers);
+            }
+            return StatusCode::NOT_FOUND.into_response();
+        }
     };
 
     // crates.io sparse index lives at index.crates.io
@@ -166,15 +187,32 @@ async fn sparse_index(
 
             sparse_index_conditional(data, &headers)
         }
-        Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
-        Err(crate::registry::ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
         Err(e) => {
-            tracing::debug!(
-                crate_name = crate_name,
-                error = ?e,
-                "Cargo sparse index upstream error"
-            );
-            StatusCode::NOT_FOUND.into_response()
+            // Upstream unreachable — serve the stale cached index if we have one (graceful).
+            if let Some(ref data) = cached {
+                tracing::warn!(
+                    crate_name = crate_name,
+                    "Cargo upstream failed, serving stale cached index"
+                );
+                let mut response = sparse_index_conditional(data.to_vec(), &headers);
+                response.headers_mut().insert(
+                    axum::http::header::HeaderName::from_static("x-nora-stale"),
+                    axum::http::header::HeaderValue::from_static("true"),
+                );
+                return response;
+            }
+            match e {
+                ProxyError::CircuitOpen(reg) => circuit_open_response(&reg),
+                ProxyError::NotFound => StatusCode::NOT_FOUND.into_response(),
+                _ => {
+                    tracing::debug!(
+                        crate_name = crate_name,
+                        error = ?e,
+                        "Cargo sparse index upstream error"
+                    );
+                    StatusCode::NOT_FOUND.into_response()
+                }
+            }
         }
     }
 }

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -128,6 +128,7 @@ fn build_context(
             proxy: None,
             proxy_auth: None,
             proxy_timeout: 5,
+            metadata_ttl: 300,
         },
         docker: DockerConfig {
             enabled: true,


### PR DESCRIPTION
## Summary

Closes #640.

The Cargo sparse index is mutable — new versions append and the `yanked` flag may change — but the proxy served the cached index indefinitely (there was no `metadata_ttl`, and the ETag/304 path is client-to-NORA only), so newly published versions and yanks never appeared.

Add a `metadata_ttl` to the cargo config (default 300, matching the other proxied metadata) and revalidate the cached index against upstream when stale: a hosted index (no upstream) stays authoritative, a proxied index within the ttl window is served from cache, otherwise it is refetched. On upstream failure the stale cached index is served (graceful). The freshness decision is a shared `cache_ttl::mutable_ref_fresh()` helper.

## Test plan

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build` clean.
- `cargo test -p nora-registry` — 1304 passed, 0 failed.
- Added unit coverage for `mutable_ref_fresh()` (hosted / proxied × `metadata_ttl`).
