### PR TITLE
fix(go): revalidate mutable version listings against upstream before serving from cache

### DIFF
--- a/nora-registry/src/config/registry/go.rs
+++ b/nora-registry/src/config/registry/go.rs
@@ -19,6 +19,11 @@ pub struct GoConfig {
     pub proxy_timeout_zip: u64,
     #[serde(default = "default_go_max_zip_size")]
     pub max_zip_size: u64,
+    /// Staleness window (seconds) for the mutable listing endpoints (`@v/list`, `@latest`); a
+    /// non-positive value revalidates every pull. Per-version files (.info/.mod/.zip) are
+    /// content-addressed and always immutable.
+    #[serde(default = "super::super::default_metadata_ttl")]
+    pub metadata_ttl: i64,
 }
 
 fn default_go_proxy() -> Option<String> {
@@ -42,6 +47,7 @@ impl Default for GoConfig {
             proxy_timeout: 30,
             proxy_timeout_zip: 120,
             max_zip_size: 104_857_600,
+            metadata_ttl: 300,
         }
     }
 }
@@ -73,6 +79,9 @@ impl GoConfig {
         }
         if let Ok(val) = env::var("NORA_GO_MAX_ZIP_SIZE") {
             super::super::parse_env_warn("NORA_GO_MAX_ZIP_SIZE", &val, &mut self.max_zip_size);
+        }
+        if let Ok(val) = env::var("NORA_GO_METADATA_TTL") {
+            super::super::parse_env_warn("NORA_GO_METADATA_TTL", &val, &mut self.metadata_ttl);
         }
     }
 }

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -105,30 +105,50 @@ async fn handle(
     // Immutable: .info, .mod, .zip — once cached, never overwrite
     let is_immutable = !is_mutable;
 
-    // 1. Try local cache (for immutable files, this is authoritative)
-    if let Ok(data) = state.storage.get(&storage_key).await {
-        // Curation integrity verification (issue #189)
-        if let Some((ref module_name, ref version)) = go_curation {
-            if let Some(response) = crate::curation::verify_integrity(
-                &state.curation().curation_engine,
-                crate::curation::RegistryType::Go,
-                module_name,
-                version.as_deref(),
-                &data,
-            ) {
-                return response;
+    // 1. Try local cache.
+    //    Immutable files (.info/.mod/.zip) are content-addressed by an exact version and are
+    //    authoritative once cached. The mutable listing endpoints (@v/list, @latest) must be
+    //    revalidated against upstream before serving — otherwise a newly published version never
+    //    appears — unless there is no upstream (locally authoritative) or the cached copy is still
+    //    within the positive `metadata_ttl` window. `cached` is kept for the stale-on-error path.
+    let cached = state.storage.get(&storage_key).await.ok();
+    let modified = if cached.is_some() && is_mutable {
+        state.storage.stat(&storage_key).await.map(|m| m.modified)
+    } else {
+        None
+    };
+    let cache_fresh = cached.is_some()
+        && go_cache_fresh(
+            is_immutable,
+            state.config.go.proxy.is_some(),
+            state.config.go.metadata_ttl,
+            modified,
+        );
+    if let Some(ref data) = cached {
+        if cache_fresh {
+            // Curation integrity verification (issue #189)
+            if let Some((ref module_name, ref version)) = go_curation {
+                if let Some(response) = crate::curation::verify_integrity(
+                    &state.curation().curation_engine,
+                    crate::curation::RegistryType::Go,
+                    module_name,
+                    version.as_deref(),
+                    data,
+                ) {
+                    return response;
+                }
             }
-        }
 
-        state.metrics.record_download("go");
-        state.metrics.record_cache_hit("go");
-        state.activity.push(ActivityEntry::new(
-            ActionType::CacheHit,
-            format_artifact(&module_encoded, &file),
-            "go",
-            "CACHE",
-        ));
-        return with_content_type(data.to_vec(), content_type, is_mutable);
+            state.metrics.record_download("go");
+            state.metrics.record_cache_hit("go");
+            state.activity.push(ActivityEntry::new(
+                ActionType::CacheHit,
+                format_artifact(&module_encoded, &file),
+                "go",
+                "CACHE",
+            ));
+            return with_content_type(data.to_vec(), content_type, is_mutable);
+        }
     }
 
     // 2. Try upstream proxy
@@ -214,16 +234,36 @@ async fn handle(
 
             with_content_type(bytes, content_type, is_mutable)
         }
-        Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
-        Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
         Err(e) => {
-            tracing::debug!(
-                module = module_encoded,
-                file = file,
-                error = ?e,
-                "Go upstream proxy error"
-            );
-            StatusCode::BAD_GATEWAY.into_response()
+            // Upstream unreachable — serve the stale cached copy if we have one (graceful).
+            // Only the mutable listing endpoints reach here with a cached copy; immutable hits
+            // returned above, so this never serves a wrong content-addressed file.
+            if let Some(ref data) = cached {
+                tracing::warn!(
+                    module = module_encoded,
+                    file = file,
+                    "Go upstream failed, serving stale cached copy"
+                );
+                let mut response = with_content_type(data.to_vec(), content_type, is_mutable);
+                response.headers_mut().insert(
+                    axum::http::header::HeaderName::from_static("x-nora-stale"),
+                    axum::http::header::HeaderValue::from_static("true"),
+                );
+                return response;
+            }
+            match e {
+                ProxyError::NotFound => StatusCode::NOT_FOUND.into_response(),
+                ProxyError::CircuitOpen(reg) => circuit_open_response(&reg),
+                _ => {
+                    tracing::debug!(
+                        module = module_encoded,
+                        file = file,
+                        error = ?e,
+                        "Go upstream proxy error"
+                    );
+                    StatusCode::BAD_GATEWAY.into_response()
+                }
+            }
         }
     }
 }
@@ -356,6 +396,22 @@ fn format_artifact(module: &str, file: &str) -> String {
     } else {
         format!("{}/{}", module, file)
     }
+}
+
+/// Whether a cached Go proxy response may be served without revalidating against upstream.
+///
+/// Immutable per-version files (`.info`/`.mod`/`.zip`) are content-addressed by an exact version
+/// and are authoritative once cached. The mutable listing endpoints (`@v/list`, `@latest`) defer
+/// to [`crate::cache_ttl::mutable_ref_fresh`]: a hosted registry (no upstream) is locally
+/// authoritative, a positive `metadata_ttl` allows a bounded staleness window, and otherwise the
+/// listing is revalidated against upstream so a newly published version appears.
+fn go_cache_fresh(
+    is_immutable: bool,
+    has_upstream: bool,
+    metadata_ttl: i64,
+    modified: Option<u64>,
+) -> bool {
+    is_immutable || crate::cache_ttl::mutable_ref_fresh(has_upstream, metadata_ttl, modified)
 }
 
 /// Build response with Content-Type and Cache-Control headers.
@@ -565,6 +621,35 @@ mod tests {
     #[test]
     fn test_content_type_list() {
         assert_eq!(content_type_for("@v/list"), "text/plain; charset=utf-8");
+    }
+
+    // ── Cache freshness (revalidation) ────────────────────────────────────
+
+    #[test]
+    fn test_go_cache_fresh_immutable_always() {
+        // Per-version files are content-addressed → always servable from cache, even proxied.
+        assert!(go_cache_fresh(true, true, -1, Some(0)));
+        assert!(go_cache_fresh(true, true, 0, None));
+    }
+
+    #[test]
+    fn test_go_cache_fresh_mutable_hosted() {
+        // Hosted (no upstream) listing is locally authoritative → fresh regardless of ttl.
+        assert!(go_cache_fresh(false, false, 0, None));
+    }
+
+    #[test]
+    fn test_go_cache_fresh_mutable_proxied_revalidates() {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        // Proxied listing with non-positive ttl → revalidate every pull (the fix).
+        assert!(!go_cache_fresh(false, true, 0, Some(now)));
+        // Proxied listing within a positive ttl window → bounded staleness, served from cache.
+        assert!(go_cache_fresh(false, true, 300, Some(now - 10)));
+        // Proxied listing beyond the window → revalidate.
+        assert!(!go_cache_fresh(false, true, 300, Some(now - 600)));
     }
 
     // ── Cache-Control headers ─────────────────────────────────────────────

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -122,6 +122,7 @@ fn build_context(
             proxy_timeout: 5,
             proxy_timeout_zip: 30,
             max_zip_size: 10_485_760,
+            metadata_ttl: 300,
         },
         cargo: CargoConfig {
             enabled: true,


### PR DESCRIPTION
## Summary

Closes #644.

The Go module proxy serves the mutable listing endpoints — `@v/list` and `@latest` — from cache indefinitely (there was no `metadata_ttl` and the cache lookup short-circuits the upstream fetch unconditionally), so a newly published module version never appears once a listing is cached. The per-version files (`.info`/`.mod`/`.zip`) are content-addressed and correctly immutable.

Gate the cache-serve path on mutability: `@v/list` and `@latest` are revalidated against upstream when stale (via the shared `cache_ttl::mutable_ref_fresh` and a new `metadata_ttl`, default 300); immutable per-version files are served from cache as before. On upstream failure the stale cached listing is served (graceful).

Scope: this covers the version-listing endpoints. Non-canonical `@v/<query>.info` resolution (e.g. a branch name) is a separate, narrower case tracked in #645.

## Test plan

- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo build` clean.
- `cargo test -p nora-registry` — 1309 passed, 0 failed.
- Added unit coverage for `go_cache_fresh()` (immutable always / hosted / proxied × `metadata_ttl`).