### PR TITLE
feat(docker): support Range requests for blob GET (resumable pulls)

### DIFF
--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -236,6 +236,54 @@ async fn storage_get_reader_with_fallback(
     }
 }
 
+/// Parse a single `Range: bytes=start-end` header against a known object size, returning the
+/// inclusive `(start, end)` clamped to the object, or `None` if it is absent, unparsable,
+/// multipart, or unsatisfiable (the caller then serves the full object). Suffix ranges
+/// (`bytes=-N`, the last N bytes) are supported.
+fn parse_byte_range(value: &str, size: u64) -> Option<(u64, u64)> {
+    let spec = value.strip_prefix("bytes=")?.split(',').next()?.trim();
+    let (s, e) = spec.split_once('-')?;
+    let (start, end) = if s.is_empty() {
+        let n: u64 = e.trim().parse().ok()?;
+        if n == 0 || size == 0 {
+            return None;
+        }
+        (size.saturating_sub(n), size - 1)
+    } else {
+        let start: u64 = s.trim().parse().ok()?;
+        let end = if e.trim().is_empty() {
+            size.saturating_sub(1)
+        } else {
+            e.trim().parse::<u64>().ok()?.min(size.saturating_sub(1))
+        };
+        (start, end)
+    };
+    if size == 0 || start > end || start >= size {
+        return None;
+    }
+    Some((start, end))
+}
+
+async fn storage_get_range_with_fallback(
+    storage: &Storage,
+    ns_key: &str,
+    legacy_key: &str,
+    start: u64,
+    end: u64,
+) -> Result<
+    (
+        u64,
+        std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
+    ),
+    crate::storage::StorageError,
+> {
+    match storage.get_range(ns_key, start, end).await {
+        Ok(r) => Ok(r),
+        Err(_) if ns_key != legacy_key => storage.get_range(legacy_key, start, end).await,
+        Err(e) => Err(e),
+    }
+}
+
 /// An `AsyncRead` wrapper that hashes the bytes it streams and, on a SHA-256
 /// mismatch at EOF, fails the stream instead of letting a tampered blob complete
 /// cleanly. `get_reader` (#580) streams large docker blobs without buffering, so
@@ -936,6 +984,46 @@ async fn download_blob(
             return response;
         }
 
+        // Range request: serve the requested byte range (206 Partial Content). A ranged
+        // response is partial, so the streaming SHA-256 verify (full-GET only) does not
+        // apply — a ranged serve relies on the content-addressed storage key plus the
+        // client's own content-digest check, as Docker/Harbor do. An absent/invalid range
+        // falls through to the full 200 below.
+        if let Some((start, end)) = headers
+            .get(header::RANGE)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| parse_byte_range(v, size))
+        {
+            drop(reader);
+            let ranged = match storage_get_range_with_fallback(
+                &state.storage,
+                &key,
+                &legacy_key,
+                start,
+                end,
+            )
+            .await
+            {
+                Ok((_, r)) => r,
+                Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+            };
+            state.metrics.record_download("docker");
+            state.metrics.record_cache_hit("docker");
+            return Response::builder()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(header::CONTENT_TYPE, "application/octet-stream")
+                .header(header::CONTENT_LENGTH, end - start + 1)
+                .header(
+                    header::CONTENT_RANGE,
+                    format!("bytes {}-{}/{}", start, end, size),
+                )
+                .header(header::ACCEPT_RANGES, "bytes")
+                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+                .header("docker-content-digest", &digest)
+                .body(Body::from_stream(ReaderStream::new(ranged)))
+                .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+        }
+
         state.metrics.record_download("docker");
         state.metrics.record_cache_hit("docker");
         state.activity.push(ActivityEntry::new(
@@ -949,6 +1037,7 @@ async fn download_blob(
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/octet-stream")
             .header(header::CONTENT_LENGTH, size)
+            .header(header::ACCEPT_RANGES, "bytes")
             .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
             .header("docker-content-digest", &digest)
             .body(Body::from_stream(stream))
@@ -3416,6 +3505,64 @@ mod integration_tests {
         assert_eq!(get_resp.status(), StatusCode::OK);
         let body = body_bytes(get_resp).await;
         assert_eq!(body.as_ref(), &blob_data[..]);
+    }
+
+    #[test]
+    fn test_parse_byte_range() {
+        use super::parse_byte_range;
+        assert_eq!(parse_byte_range("bytes=0-3", 10), Some((0, 3)));
+        assert_eq!(parse_byte_range("bytes=5-", 10), Some((5, 9))); // open-ended
+        assert_eq!(parse_byte_range("bytes=-4", 10), Some((6, 9))); // suffix (last 4)
+        assert_eq!(parse_byte_range("bytes=8-100", 10), Some((8, 9))); // clamp end to size
+        assert_eq!(parse_byte_range("bytes=10-12", 10), None); // start past end
+        assert_eq!(parse_byte_range("bytes=5-3", 10), None); // reversed
+        assert_eq!(parse_byte_range("nonsense", 10), None); // unparsable
+        assert_eq!(parse_byte_range("bytes=0-3", 0), None); // empty object
+    }
+
+    #[tokio::test]
+    async fn test_docker_blob_range_request() {
+        use tower::ServiceExt;
+        let ctx = create_test_context();
+        let blob = b"0123456789abcdef";
+        let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(blob)));
+
+        let post = send(
+            &ctx.app,
+            Method::POST,
+            "/v2/rng/blobs/uploads/",
+            Body::empty(),
+        )
+        .await;
+        let loc = post
+            .headers()
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        let uuid = loc.rsplit('/').next().unwrap();
+        let put_url = format!("/v2/rng/blobs/uploads/{}?digest={}", uuid, digest);
+        send(&ctx.app, Method::PUT, &put_url, Body::from(&blob[..])).await;
+
+        let req = axum::http::Request::builder()
+            .method(Method::GET)
+            .uri(format!("/v2/rng/blobs/{}", digest))
+            .header(header::RANGE, "bytes=4-7")
+            .body(Body::empty())
+            .unwrap();
+        let resp = ctx.app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            resp.headers()
+                .get(header::CONTENT_RANGE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            format!("bytes 4-7/{}", blob.len())
+        );
+        let body = body_bytes(resp).await;
+        assert_eq!(body.as_ref(), &blob[4..=7]);
     }
 
     #[tokio::test]

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -275,6 +275,35 @@ impl StorageBackend for LocalStorage {
             .map_err(|e| StorageError::Io(e.to_string()))?;
         Ok((meta.len(), Box::pin(file)))
     }
+
+    async fn get_range(
+        &self,
+        key: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+        let path = self.key_to_path(key);
+        let mut file = fs::File::open(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                StorageError::NotFound
+            } else {
+                StorageError::Io(e.to_string())
+            }
+        })?;
+        let size = file
+            .metadata()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?
+            .len();
+        if start > 0 {
+            file.seek(std::io::SeekFrom::Start(start))
+                .await
+                .map_err(|e| StorageError::Io(e.to_string()))?;
+        }
+        let len = end.saturating_sub(start) + 1;
+        Ok((size, Box::pin(file.take(len))))
+    }
 }
 
 #[cfg(test)]

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -112,6 +112,34 @@ pub trait StorageBackend: Send + Sync {
     /// Local backend: `tokio::fs::File::open` + metadata.
     /// S3 backend: `object_store::get` → byte-stream wrapped in `StreamReader`.
     async fn get_reader(&self, key: &str) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)>;
+
+    /// Stream the inclusive byte range `[start, end]` of an object, returning the object's
+    /// total size and a reader over exactly those bytes. The default reads from the start and
+    /// discards the prefix; backends override with an efficient seek / ranged GET.
+    async fn get_range(
+        &self,
+        key: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        use tokio::io::AsyncReadExt;
+        let (size, mut reader) = self.get_reader(key).await?;
+        let mut to_skip = start;
+        let mut buf = [0u8; 64 * 1024];
+        while to_skip > 0 {
+            let want = to_skip.min(buf.len() as u64) as usize;
+            let n = reader
+                .read(&mut buf[..want])
+                .await
+                .map_err(|e| StorageError::Io(e.to_string()))?;
+            if n == 0 {
+                break;
+            }
+            to_skip -= n as u64;
+        }
+        let len = end.saturating_sub(start) + 1;
+        Ok((size, Box::pin(reader.take(len))))
+    }
 }
 
 /// Storage wrapper for dynamic dispatch with integrity verification.
@@ -504,6 +532,30 @@ impl Storage {
             Err(e) => {
                 STORAGE_OPERATIONS
                     .with_label_values(&["get_reader", "error"])
+                    .inc();
+                Err(e)
+            }
+        }
+    }
+
+    /// Stream the inclusive byte range `[start, end]` of an object (see the trait method).
+    pub async fn get_range(
+        &self,
+        key: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        validate_storage_key(key)?;
+        match self.inner.get_range(key, start, end).await {
+            Ok(r) => {
+                STORAGE_OPERATIONS
+                    .with_label_values(&["get_range", "ok"])
+                    .inc();
+                Ok(r)
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS
+                    .with_label_values(&["get_range", "error"])
                     .inc();
                 Err(e)
             }

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -256,6 +256,34 @@ impl StorageBackend for S3Storage {
         let reader = tokio_util::io::StreamReader::new(stream);
         Ok((size as u64, Box::pin(reader)))
     }
+
+    async fn get_range(
+        &self,
+        key: &str,
+        start: u64,
+        end: u64,
+    ) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
+        let make_opts = || object_store::GetOptions {
+            range: Some(object_store::GetRange::Bounded(start..(end + 1))),
+            ..Default::default()
+        };
+        let path = Path::from(encode_s3_key(key));
+        let result = match self.store.get_opts(&path, make_opts()).await {
+            Ok(r) => r,
+            Err(object_store::Error::NotFound { .. }) if key.contains('@') => {
+                let legacy_path = Path::from(encode_s3_key_legacy(key));
+                self.store
+                    .get_opts(&legacy_path, make_opts())
+                    .await
+                    .map_err(map_err)?
+            }
+            Err(e) => return Err(map_err(e)),
+        };
+        let size = result.meta.size;
+        let stream = result.into_stream().map_err(std::io::Error::other);
+        let reader = tokio_util::io::StreamReader::new(stream);
+        Ok((size as u64, Box::pin(reader)))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds Range support to docker blob GET so clients can resume interrupted pulls of large layers.

- Blob GET now honours `Range: bytes=start-end` and serves `206 Partial Content` with `Content-Range`; the full GET advertises `Accept-Ranges: bytes`. An absent or unsatisfiable range falls through to a full `200`.
- A new `StorageBackend::get_range` streams the requested byte range — the local backend seeks, the S3 backend issues a ranged GET (`object_store` `GetRange`), and a default reads-and-skips for other backends.
- A ranged response is partial, so it cannot be re-hashed against the full digest; like Docker/Harbor it relies on the content-addressed storage key plus the client's own content-digest check (the streaming SHA-256 verify still runs on full GETs).

Tests: `parse_byte_range` unit cases (open/suffix/clamp/unsatisfiable) and an HTTP `206` test asserting the returned bytes and `Content-Range`.

Closes #654
