### PR TITLE
docs(compat): note the overlay2 graph-driver registry-mirror limitation

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -31,6 +31,7 @@ This document describes which parts of each registry protocol are implemented in
 - Max 2-level image path: `org/image:tag` works, `org/sub/path/image:tag` returns 404
 - Large monolithic blob PUT (>~500MB) may fail even with high body limit
 - No cross-repository blob mounting
+- Registry-mirror caching requires Docker's containerd image store. On hosts using the legacy `overlay2` graph driver, Docker's built-in registry client does not send the mirror's `?ns=` parameter or follow its Bearer-token challenge, so pulls silently fall back to the upstream and nothing is cached. Enable the containerd image store (`{"features": {"containerd-snapshotter": true}}` in `daemon.json`) to use NORA as a pull-through mirror (#578).
 
 ## npm
 


### PR DESCRIPTION
Documents why a registry-mirror configured against NORA silently fails to cache on hosts using Docker's legacy `overlay2` graph driver (reported in #578): the daemon's built-in registry client does not send the `?ns=` parameter or follow the mirror's Bearer-token challenge, so it gives up on the 401 and pulls from the upstream — pulls succeed, but nothing is cached.

Adds a Known Limitations entry under the Docker section of `COMPAT.md` with the workaround (enable the containerd image store via `{"features": {"containerd-snapshotter": true}}` in `daemon.json`).

Root cause is the Docker daemon's legacy graph driver, not NORA — hence a documentation entry rather than a code change.

Refs #578