### PR TITLE
test(docker): formally verify parse_byte_range bounds-safety (Kani) + CI

### DIFF
--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -1,0 +1,47 @@
+name: Kani
+
+# Bounded model checking (Kani / CBMC) proves the `#[kani::proof]` harnesses —
+# e.g. `byte_range_core` is total and bounds-safe for ALL u64 inputs. This is a
+# SEPARATE workflow from CI: Kani installs its own toolchain and runs CBMC, which
+# is far heavier than the unit suite, so it is path-scoped and manually
+# dispatchable rather than run on every push. Harnesses are `#[cfg(kani)]` —
+# invisible to the normal build, clippy, and tests.
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'nora-registry/src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/kani.yml'
+
+permissions: read-all
+
+concurrency:
+  group: kani-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kani:
+    name: Kani proofs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@42dc69e1aa15d09112580998cf2ef0119e2e91ae # v2
+
+      # Install Kani via cargo (pinned version) rather than a third-party action,
+      # to keep the supply chain pinned the same way the rest of CI pins action
+      # SHAs. `cargo kani setup` fetches the Kani toolchain + CBMC backend.
+      - name: Install Kani
+        run: |
+          cargo install --locked --version 0.67.0 kani-verifier
+          cargo kani setup
+
+      - name: Run Kani proofs
+        run: cargo kani --package nora-registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,9 @@ large_types_passed_by_value = "deny"
 assigning_clones = "deny"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = [] }
+# `cfg(kani)` is set only by the Kani verifier (`cargo kani`); declare it so the
+# `#[cfg(kani)]` proof harnesses don't trip `unexpected_cfgs` under `-D warnings`.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
 
 [profile.release]
 debug = false

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@
 #        make test    — unit tests only
 #        make build   — release build
 #        make release — tagged release (runs checks first)
+#        make kani    — run Kani bounded-model-checking proofs (needs `cargo kani`)
 
 CARGO := cargo
 
-.PHONY: check test build release fmt clippy coherence lock-audit version-check install-hooks verify-changelog
+.PHONY: check test build release fmt clippy coherence lock-audit version-check install-hooks verify-changelog kani
 
 check: version-check fmt clippy test coherence lock-audit verify-changelog
 	@echo ""
@@ -29,6 +30,13 @@ lock-audit:
 
 verify-changelog:
 	@if [ -x scripts/verify-changelog.sh ]; then scripts/verify-changelog.sh; fi
+
+# Kani proofs are NOT part of `check`: they need the Kani toolchain (`cargo kani`)
+# and run CBMC, which is far heavier than the unit suite. Run on demand / in the
+# dedicated `kani` CI workflow. Harnesses are `#[cfg(kani)]` — invisible to the
+# normal build, clippy, and tests.
+kani:
+	$(CARGO) kani --package nora-registry
 
 build:
 	$(CARGO) build --release

--- a/nora-registry/src/auth/namespace.rs
+++ b/nora-registry/src/auth/namespace.rs
@@ -86,6 +86,11 @@ pub fn enforce_namespace_scope(
             mode,
         } => (patterns, provider, *mode),
     };
+    // Use `provider` as `&str` for the metric label slices below. The mixed
+    // `&[&Arc<str>, &'static str]` array relied on element LUB coercion, which the
+    // Kani verifier's pinned rustc rejects (E0308) where stable accepts it — this
+    // explicit deref makes both elements `&str` and compiles under both toolchains.
+    let provider: &str = provider;
 
     if patterns.iter().any(|p| namespace_match(p, namespace)) {
         NAMESPACE_SCOPE_DECISIONS

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -296,12 +296,11 @@ fn byte_range_core(
 /// `(suffix, start_in, end_empty, end_in, size)` over the full `u64` space it
 /// never panics or overflows, and any `Some((start, end))` is well-formed:
 /// `start <= end < size` — the whole "out-of-bounds / inverted Range" bug-class
-/// discharged at verification time, not at runtime. (Verified GREEN standalone
-/// in ~0.35s, 17/17 checks; the in-crate `cargo kani` run currently needs a
-/// prometheus/Kani-toolchain dependency alignment to compile the full crate.)
+/// discharged at verification time, not at runtime. (Verified GREEN in-crate,
+/// 17/17 checks in ~0.3s.)
 ///
-/// Run: `cargo kani -p nora-registry --harness byte_range_core_is_bounds_safe`
-/// (compiled only under `--cfg kani`; invisible to the normal build/clippy/test).
+/// Run: `make kani`, or `cargo kani -p nora-registry` (CI: `.github/workflows/kani.yml`).
+/// Compiled only under `--cfg kani`; invisible to the normal build/clippy/test.
 #[cfg(kani)]
 #[kani::proof]
 fn byte_range_core_is_bounds_safe() {
@@ -3696,6 +3695,7 @@ mod integration_tests {
         assert_eq!(parse_byte_range("bytes=5-3", 10), None); // reversed
         assert_eq!(parse_byte_range("nonsense", 10), None); // unparsable
         assert_eq!(parse_byte_range("bytes=0-3", 0), None); // empty object
+
         // mutation-found gaps (cargo-mutants): exercise the single-byte range
         // and the suffix form against an empty object.
         assert_eq!(parse_byte_range("bytes=5-5", 10), Some((5, 5))); // single byte (kills `>`→`>=`)

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -3696,6 +3696,10 @@ mod integration_tests {
         assert_eq!(parse_byte_range("bytes=5-3", 10), None); // reversed
         assert_eq!(parse_byte_range("nonsense", 10), None); // unparsable
         assert_eq!(parse_byte_range("bytes=0-3", 0), None); // empty object
+        // mutation-found gaps (cargo-mutants): exercise the single-byte range
+        // and the suffix form against an empty object.
+        assert_eq!(parse_byte_range("bytes=5-5", 10), Some((5, 5))); // single byte (kills `>`→`>=`)
+        assert_eq!(parse_byte_range("bytes=-5", 0), None); // suffix + empty (kills `||`→`&&`)
     }
 
     proptest::proptest! {

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -243,18 +243,46 @@ async fn storage_get_reader_with_fallback(
 fn parse_byte_range(value: &str, size: u64) -> Option<(u64, u64)> {
     let spec = value.strip_prefix("bytes=")?.split(',').next()?.trim();
     let (s, e) = spec.split_once('-')?;
-    let (start, end) = if s.is_empty() {
+    if s.is_empty() {
+        // suffix form "bytes=-N": the last N bytes
         let n: u64 = e.trim().parse().ok()?;
+        byte_range_core(true, 0, false, n, size)
+    } else {
+        let start: u64 = s.trim().parse().ok()?;
+        let (end_empty, end_in) = if e.trim().is_empty() {
+            (true, 0)
+        } else {
+            (false, e.trim().parse::<u64>().ok()?)
+        };
+        byte_range_core(false, start, end_empty, end_in, size)
+    }
+}
+
+/// Arithmetic core of [`parse_byte_range`], split out so the out-of-bounds /
+/// inverted-range / overflow bug-class can be *proven* absent over the whole
+/// `u64` space. String lexing stays in the caller — symbolically lexing a
+/// UTF-8 string is intractable for a bounded model checker, while the bounds
+/// invariant lives entirely in this arithmetic. For any inputs it never
+/// panics/overflows; any `Some((start, end))` satisfies `start <= end < size`.
+fn byte_range_core(
+    suffix: bool,
+    start_in: u64,
+    end_empty: bool,
+    end_in: u64,
+    size: u64,
+) -> Option<(u64, u64)> {
+    let (start, end) = if suffix {
+        let n = end_in;
         if n == 0 || size == 0 {
             return None;
         }
         (size.saturating_sub(n), size - 1)
     } else {
-        let start: u64 = s.trim().parse().ok()?;
-        let end = if e.trim().is_empty() {
+        let start = start_in;
+        let end = if end_empty {
             size.saturating_sub(1)
         } else {
-            e.trim().parse::<u64>().ok()?.min(size.saturating_sub(1))
+            end_in.min(size.saturating_sub(1))
         };
         (start, end)
     };
@@ -262,6 +290,31 @@ fn parse_byte_range(value: &str, size: u64) -> Option<(u64, u64)> {
         return None;
     }
     Some((start, end))
+}
+
+/// Kani proof: [`byte_range_core`] is total and bounds-safe. For ANY
+/// `(suffix, start_in, end_empty, end_in, size)` over the full `u64` space it
+/// never panics or overflows, and any `Some((start, end))` is well-formed:
+/// `start <= end < size` — the whole "out-of-bounds / inverted Range" bug-class
+/// discharged at verification time, not at runtime. (Verified GREEN standalone
+/// in ~0.35s, 17/17 checks; the in-crate `cargo kani` run currently needs a
+/// prometheus/Kani-toolchain dependency alignment to compile the full crate.)
+///
+/// Run: `cargo kani -p nora-registry --harness byte_range_core_is_bounds_safe`
+/// (compiled only under `--cfg kani`; invisible to the normal build/clippy/test).
+#[cfg(kani)]
+#[kani::proof]
+fn byte_range_core_is_bounds_safe() {
+    let suffix: bool = kani::any();
+    let start_in: u64 = kani::any();
+    let end_empty: bool = kani::any();
+    let end_in: u64 = kani::any();
+    let size: u64 = kani::any();
+    if let Some((start, end)) = byte_range_core(suffix, start_in, end_empty, end_in, size) {
+        assert!(start <= end, "Range start must never exceed end");
+        assert!(end < size, "Range end must stay within the object size");
+        assert!(start < size, "Range start must stay within the object size");
+    }
 }
 
 async fn storage_get_range_with_fallback(

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -3698,6 +3698,25 @@ mod integration_tests {
         assert_eq!(parse_byte_range("bytes=0-3", 0), None); // empty object
     }
 
+    proptest::proptest! {
+        /// Property test (#3): fuzz the string LEXER of `parse_byte_range` — the
+        /// part Kani cannot symbolically execute. Over biased range-like strings
+        /// and any size it must never panic, and any `Some((s, e))` is
+        /// well-formed: `s <= e < size`. Pairs with the Kani proof of
+        /// `byte_range_core` (the arithmetic) for full-function coverage.
+        #[test]
+        fn parse_byte_range_lexer_invariant(
+            value in "bytes=-?[0-9]{0,9}-?[0-9]{0,9}",
+            size in proptest::prelude::any::<u64>(),
+        ) {
+            if let Some((s, e)) = super::parse_byte_range(&value, size) {
+                proptest::prop_assert!(s <= e, "inverted: {} > {}", s, e);
+                proptest::prop_assert!(e < size, "oob end: {} >= {}", e, size);
+                proptest::prop_assert!(s < size, "oob start: {} >= {}", s, size);
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_docker_blob_range_request() {
         use tower::ServiceExt;


### PR DESCRIPTION
## What

Adds bounded model checking for the Docker byte-range parser and runs it in CI.

- **`byte_range_core` is proven total and bounds-safe for all `u64` inputs**: any
  `Some((start, end))` it returns satisfies `start <= end < size`. The
  out-of-bounds / inverted-range bug class on HTTP `Range` handling is discharged
  at verification time, not runtime. (Kani / CBMC, ~0.3s, 17/17 checks.)
- The parser is split into a string **lexer** + an arithmetic **core** so the
  core is tractable for CBMC (symbolic UTF-8 lexing is not) — also a
  design-for-verifiability win.
- **proptest** over the lexer + **mutation-tested** unit tests (single-byte
  range; suffix-on-empty-object) so the tests have teeth.
- **`.github/workflows/kani.yml`**: a dedicated, path-scoped + manually
  dispatchable workflow. Kani installs its own toolchain and runs CBMC (heavier
  than the unit suite), so it is kept out of the fast CI job. Kani is installed
  via a pinned cargo version rather than a third-party action.
- **`make kani`** target. `cfg(kani)` is declared in the workspace lints;
  harnesses are `#[cfg(kani)]`, invisible to the normal build / clippy / tests.

## Note on `auth/namespace.rs`

Binds `provider` as `&str` once before the metric label slices. The mixed
`&[&Arc<str>, &'static str]` array relied on element coercion that Kani's pinned
rustc rejects (E0308) where stable accepts it. Behaviour-identical; compiles
under both toolchains.

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, the full test suite (1379
unit + 6 doctests), and `make kani` (VERIFICATION SUCCESSFUL) all pass.
