### PR TITLE
fix(circuit-breaker): fence probe reports by generation (stale "lost" probe)

### DIFF
--- a/nora-registry/src/circuit_breaker.rs
+++ b/nora-registry/src/circuit_breaker.rs
@@ -34,6 +34,22 @@ impl BreakerState {
     }
 }
 
+/// Identifies the probe a caller was allowed to run, so a later
+/// `record_success`/`record_failure`/`record_alive` can be FENCED. When the
+/// #585 stall-recovery starts a fresh probe, the old probe is superseded; its
+/// late report carries an older generation and must NOT mutate the breaker
+/// ("treat as lost" — the comment's intent, now enforced). A non-probe
+/// (Closed-path) request carries [`ProbeToken::BACKGROUND`], which is never
+/// fenced — its failure simply accrues to the Closed-path tally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProbeToken(u64);
+
+impl ProbeToken {
+    /// Not a probe — a Closed-path request. Its outcome accrues normally and is
+    /// never fenced.
+    pub(crate) const BACKGROUND: ProbeToken = ProbeToken(0);
+}
+
 #[derive(Debug)]
 struct BreakerInner {
     state: BreakerState,
@@ -45,6 +61,12 @@ struct BreakerInner {
     /// caller exited without `record_success`/`record_failure`, e.g. a 4xx or
     /// body-extract path), so the breaker cannot wedge at 503 forever (#585).
     half_open_started: Option<Instant>,
+    /// Monotonic generation of the CURRENT probe. Bumped each time `check()`
+    /// grants a probe slot (Open→HalfOpen, or a fresh probe after a #585 stall).
+    /// A probe holds the generation it was granted; `record_*` fence on it so a
+    /// superseded ("lost") probe's late report is ignored (contract
+    /// `circuit-breaker-probe-fenced`).
+    probe_gen: u64,
 }
 
 impl BreakerInner {
@@ -55,7 +77,22 @@ impl BreakerInner {
             last_failure: None,
             half_open_in_flight: false,
             half_open_started: None,
+            probe_gen: 0,
         }
+    }
+
+    /// Grant a fresh probe slot: bump the generation and return its token.
+    fn grant_probe(&mut self) -> ProbeToken {
+        self.probe_gen += 1;
+        self.half_open_in_flight = true;
+        self.half_open_started = Some(Instant::now());
+        ProbeToken(self.probe_gen)
+    }
+
+    /// True if `token` is NOT the current probe and not a background request —
+    /// i.e. a superseded "lost" probe whose report must be ignored.
+    fn is_stale(&self, token: ProbeToken) -> bool {
+        token != ProbeToken::BACKGROUND && token.0 != self.probe_gen
     }
 }
 
@@ -112,10 +149,15 @@ impl CircuitBreakerRegistry {
     }
 
     /// Check if a request to `registry` should proceed.
+    ///
+    /// On success returns a [`ProbeToken`] the caller MUST pass back to
+    /// `record_success`/`record_failure`/`record_alive` so a superseded probe's
+    /// report can be fenced (#585 stall recovery). A Closed-path request gets
+    /// [`ProbeToken::BACKGROUND`]; a HalfOpen probe gets its generation's token.
     /// Returns `Err(ProxyError::CircuitOpen)` if the breaker is open.
-    pub(crate) fn check(&self, registry: &str) -> Result<(), ProxyError> {
+    pub(crate) fn check(&self, registry: &str) -> Result<ProbeToken, ProxyError> {
         if !self.config.enabled {
-            return Ok(());
+            return Ok(ProbeToken::BACKGROUND);
         }
 
         let mut breakers = self.breakers.write();
@@ -124,17 +166,16 @@ impl CircuitBreakerRegistry {
             .or_insert_with(BreakerInner::new);
 
         match breaker.state {
-            BreakerState::Closed => Ok(()),
+            BreakerState::Closed => Ok(ProbeToken::BACKGROUND),
             BreakerState::Open => {
                 let elapsed = breaker
                     .last_failure
                     .map(|t| t.elapsed().as_secs())
                     .unwrap_or(u64::MAX);
                 if elapsed >= self.reset_timeout_for(registry) {
-                    // Transition to HalfOpen — allow one probe
+                    // Transition to HalfOpen — allow one probe (fresh generation).
                     breaker.state = BreakerState::HalfOpen;
-                    breaker.half_open_in_flight = true;
-                    breaker.half_open_started = Some(Instant::now());
+                    let token = breaker.grant_probe();
                     CIRCUIT_BREAKER_STATE
                         .with_label_values(&[registry])
                         .set(BreakerState::HalfOpen.as_gauge());
@@ -142,7 +183,7 @@ impl CircuitBreakerRegistry {
                         registry = registry,
                         "Circuit breaker half-open, allowing probe"
                     );
-                    Ok(())
+                    Ok(token)
                 } else {
                     CIRCUIT_BREAKER_REJECTIONS
                         .with_label_values(&[registry])
@@ -182,17 +223,19 @@ impl CircuitBreakerRegistry {
                             "Circuit breaker probe stalled (no result within reset timeout) — starting fresh probe"
                         );
                     }
-                    // Slot free, or previous probe was lost — start a fresh probe.
-                    breaker.half_open_in_flight = true;
-                    breaker.half_open_started = Some(Instant::now());
-                    Ok(())
+                    // Slot free, or previous probe was lost — start a fresh probe
+                    // (new generation supersedes the lost one; its late report is
+                    // fenced in record_*).
+                    let token = breaker.grant_probe();
+                    Ok(token)
                 }
             }
         }
     }
 
-    /// Record a successful upstream response.
-    pub(crate) fn record_success(&self, registry: &str) {
+    /// Record a successful upstream response. `token` is the [`ProbeToken`] from
+    /// the matching `check()`; a superseded ("lost") probe's report is fenced.
+    pub(crate) fn record_success(&self, registry: &str, token: ProbeToken) {
         if !self.config.enabled {
             return;
         }
@@ -201,6 +244,12 @@ impl CircuitBreakerRegistry {
         let breaker = breakers
             .entry(registry.to_string())
             .or_insert_with(BreakerInner::new);
+
+        // Fence: ignore a superseded ("lost") probe's late report (#585) so it
+        // cannot close/free a breaker that a newer probe now owns.
+        if breaker.is_stale(token) {
+            return;
+        }
 
         if breaker.state != BreakerState::Closed {
             tracing::info!(
@@ -227,7 +276,7 @@ impl CircuitBreakerRegistry {
     /// an upstream interleaving 4xx (cache-miss probes) with 5xx (real failures)
     /// would never trip the breaker. This is stronger than `record_success`,
     /// which always resets `failures` and would mask such a partial outage.
-    pub(crate) fn record_alive(&self, registry: &str) {
+    pub(crate) fn record_alive(&self, registry: &str, token: ProbeToken) {
         if !self.config.enabled {
             return;
         }
@@ -236,6 +285,11 @@ impl CircuitBreakerRegistry {
         let breaker = breakers
             .entry(registry.to_string())
             .or_insert_with(BreakerInner::new);
+
+        // Fence: ignore a superseded ("lost") probe's late report (#585).
+        if breaker.is_stale(token) {
+            return;
+        }
 
         // Only HalfOpen transitions on an "alive" signal; Closed/Open are left
         // untouched so a 4xx never clears a real failure tally.
@@ -254,8 +308,10 @@ impl CircuitBreakerRegistry {
         }
     }
 
-    /// Record a failed upstream response.
-    pub(crate) fn record_failure(&self, registry: &str) {
+    /// Record a failed upstream response. `token` is the [`ProbeToken`] from the
+    /// matching `check()`; a superseded ("lost") probe's report is fenced so it
+    /// cannot re-open or ghost-increment a breaker a newer probe now owns.
+    pub(crate) fn record_failure(&self, registry: &str, token: ProbeToken) {
         if !self.config.enabled {
             return;
         }
@@ -265,6 +321,11 @@ impl CircuitBreakerRegistry {
         let breaker = breakers
             .entry(registry.to_string())
             .or_insert_with(BreakerInner::new);
+
+        // Fence: ignore a superseded ("lost") probe's late report (#585).
+        if breaker.is_stale(token) {
+            return;
+        }
 
         match breaker.state {
             BreakerState::Closed => {
@@ -360,7 +421,7 @@ mod tests {
         let cb = CircuitBreakerRegistry::new(disabled_config());
         // Even with many failures, check always succeeds
         for _ in 0..100 {
-            cb.record_failure("npm");
+            cb.record_failure("npm", ProbeToken::BACKGROUND);
         }
         assert!(cb.check("npm").is_ok());
     }
@@ -377,12 +438,12 @@ mod tests {
         let cb = CircuitBreakerRegistry::new(enabled_config(5, 30));
         // 4 failures should not trip
         for _ in 0..4 {
-            cb.record_failure("npm");
+            cb.record_failure("npm", ProbeToken::BACKGROUND);
         }
         assert!(cb.check("npm").is_ok());
 
         // 5th failure trips
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         assert!(matches!(cb.check("npm"), Err(ProxyError::CircuitOpen(_))));
     }
 
@@ -390,12 +451,12 @@ mod tests {
     fn test_success_resets_failure_count() {
         let cb = CircuitBreakerRegistry::new(enabled_config(5, 30));
         for _ in 0..4 {
-            cb.record_failure("npm");
+            cb.record_failure("npm", ProbeToken::BACKGROUND);
         }
-        cb.record_success("npm");
+        cb.record_success("npm", ProbeToken::BACKGROUND);
         // After reset, 4 more failures should not trip
         for _ in 0..4 {
-            cb.record_failure("npm");
+            cb.record_failure("npm", ProbeToken::BACKGROUND);
         }
         assert!(cb.check("npm").is_ok());
     }
@@ -408,12 +469,12 @@ mod tests {
     fn test_record_alive_closed_preserves_failure_count() {
         let cb = CircuitBreakerRegistry::new(enabled_config(5, 30));
         for _ in 0..4 {
-            cb.record_failure("npm");
+            cb.record_failure("npm", ProbeToken::BACKGROUND);
         }
         // An "alive" 4xx must leave the 4 accumulated failures intact...
-        cb.record_alive("npm");
+        cb.record_alive("npm", ProbeToken::BACKGROUND);
         // ...so the 5th real failure still trips the breaker.
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         assert!(matches!(cb.check("npm"), Err(ProxyError::CircuitOpen(_))));
     }
 
@@ -422,12 +483,12 @@ mod tests {
     #[test]
     fn test_record_alive_halfopen_closes() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 0));
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // Open + reset_timeout 0 → next check transitions to HalfOpen (probe).
         assert!(cb.check("npm").is_ok());
         // The probe answered 4xx → upstream alive → breaker closes.
-        cb.record_alive("npm");
+        cb.record_alive("npm", ProbeToken::BACKGROUND);
         // Closed: repeated checks pass (not the single-probe HalfOpen behavior).
         assert!(cb.check("npm").is_ok());
         assert!(cb.check("npm").is_ok());
@@ -436,8 +497,8 @@ mod tests {
     #[test]
     fn test_open_to_halfopen_after_timeout() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 0)); // 0s timeout = immediate
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // Should be open, but timeout=0 means immediate half-open transition
         assert!(cb.check("npm").is_ok()); // transitions to HalfOpen, probe allowed
     }
@@ -445,12 +506,12 @@ mod tests {
     #[test]
     fn test_halfopen_probe_success_closes() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 0));
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // Transition to half-open
         assert!(cb.check("npm").is_ok());
         // Probe success
-        cb.record_success("npm");
+        cb.record_success("npm", ProbeToken::BACKGROUND);
         // Should be closed now
         assert!(cb.check("npm").is_ok());
     }
@@ -458,12 +519,12 @@ mod tests {
     #[test]
     fn test_halfopen_probe_failure_reopens() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 0));
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // Transition to half-open
         assert!(cb.check("npm").is_ok());
         // Probe fails
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // Should be open again — next check transitions to half-open (timeout=0)
         // but the FIRST check after re-open with timeout=0 transitions immediately
         let result = cb.check("npm");
@@ -473,8 +534,8 @@ mod tests {
     #[test]
     fn test_halfopen_rejects_concurrent() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 0));
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // First check — probe allowed
         assert!(cb.check("npm").is_ok());
         // Second check — probe in flight, reject
@@ -489,8 +550,8 @@ mod tests {
     #[test]
     fn test_halfopen_stalled_probe_recovers() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 1));
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
 
         // Backdate last_failure so the Open→HalfOpen transition fires now.
         {
@@ -522,8 +583,8 @@ mod tests {
     #[test]
     fn test_per_registry_isolation() {
         let cb = CircuitBreakerRegistry::new(enabled_config(2, 30));
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         // npm is open
         assert!(matches!(cb.check("npm"), Err(ProxyError::CircuitOpen(_))));
         // pypi is unaffected
@@ -543,8 +604,8 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 for _ in 0..50 {
                     let _ = cb.check(&registry);
-                    cb.record_failure(&registry);
-                    cb.record_success(&registry);
+                    cb.record_failure(&registry, ProbeToken::BACKGROUND);
+                    cb.record_success(&registry, ProbeToken::BACKGROUND);
                 }
             }));
         }
@@ -577,22 +638,72 @@ mod tests {
         let cb = CircuitBreakerRegistry::new(config);
 
         // Default key trips after 2 failures
-        cb.record_failure("npm");
-        cb.record_failure("npm");
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
+        cb.record_failure("npm", ProbeToken::BACKGROUND);
         assert!(matches!(cb.check("npm"), Err(ProxyError::CircuitOpen(_))));
 
         // Docker Hub override requires 10 failures
         let docker_key = "docker:https://registry-1.docker.io";
         for _ in 0..9 {
-            cb.record_failure(docker_key);
+            cb.record_failure(docker_key, ProbeToken::BACKGROUND);
         }
         assert!(cb.check(docker_key).is_ok());
         // 10th trips it
-        cb.record_failure(docker_key);
+        cb.record_failure(docker_key, ProbeToken::BACKGROUND);
         assert!(matches!(
             cb.check(docker_key),
             Err(ProxyError::CircuitOpen(_))
         ));
+    }
+
+    /// Regression for the #585 stale-probe race (found by TLA+ model checking of
+    /// the probe lifecycle): a probe the breaker has SUPERSEDED (a fresh probe started
+    /// after it stalled) must NOT mutate the breaker when it finally reports — its
+    /// ProbeToken is fenced. Before the fix, the stale report closed/ghost-failed a
+    /// breaker a newer probe owned.
+    #[test]
+    fn stale_probe_report_is_fenced() {
+        use std::thread::sleep;
+        use std::time::Duration;
+        let cb = CircuitBreakerRegistry::new(enabled_config(1, 1)); // threshold 1, reset 1s
+        let reg = "stale_probe_fence_test";
+
+        // Trip to Open (threshold 1).
+        cb.record_failure(reg, ProbeToken::BACKGROUND);
+        assert!(matches!(cb.check(reg), Err(ProxyError::CircuitOpen(_))));
+
+        // After reset_timeout -> HalfOpen, probe g1.
+        sleep(Duration::from_millis(1100));
+        let t1 = cb.check(reg).expect("half-open should grant probe g1");
+
+        // g1 stalls (outlives reset_timeout) -> a fresh check grants probe g2;
+        // g1 is now superseded ("lost").
+        sleep(Duration::from_millis(1100));
+        let t2 = cb.check(reg).expect("stalled probe -> fresh probe g2");
+        assert_ne!(t1, t2, "fresh probe must be a new generation");
+
+        // The STALE probe g1 reports SUCCESS late: FENCED, so it must NOT close the
+        // breaker — g2 is still the live in-flight probe.
+        cb.record_success(reg, t1);
+        assert!(
+            matches!(cb.check(reg), Err(ProxyError::CircuitOpen(_))),
+            "stale probe success must not close the breaker (g2 still in flight)"
+        );
+
+        // The CURRENT probe g2 closes it correctly.
+        cb.record_success(reg, t2);
+        assert!(
+            cb.check(reg).is_ok(),
+            "current probe success closes the breaker"
+        );
+
+        // A late STALE g1 FAILURE on the now-Closed breaker must also be fenced — no
+        // ghost-increment that could re-trip Open at threshold 1.
+        cb.record_failure(reg, t1);
+        assert!(
+            cb.check(reg).is_ok(),
+            "stale probe failure must not ghost-increment / re-open a recovered breaker"
+        );
     }
 }
 
@@ -600,6 +711,7 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod integration_tests {
+    use super::ProbeToken;
     use crate::test_helpers::*;
     use axum::http::{Method, StatusCode};
 
@@ -615,8 +727,12 @@ mod integration_tests {
         });
 
         // Trip the breaker
-        ctx.state.circuit_breaker.record_failure("npm");
-        ctx.state.circuit_breaker.record_failure("npm");
+        ctx.state
+            .circuit_breaker
+            .record_failure("npm", ProbeToken::BACKGROUND);
+        ctx.state
+            .circuit_breaker
+            .record_failure("npm", ProbeToken::BACKGROUND);
 
         // Request a package NOT in local storage → proxy path → cb.check() → 503
         let response = send(&ctx.app, Method::GET, "/npm/nonexistent-pkg", "").await;
@@ -643,8 +759,12 @@ mod integration_tests {
             cfg.pypi.proxy = Some("http://127.0.0.1:1".into());
         });
 
-        ctx.state.circuit_breaker.record_failure("pypi");
-        ctx.state.circuit_breaker.record_failure("pypi");
+        ctx.state
+            .circuit_breaker
+            .record_failure("pypi", ProbeToken::BACKGROUND);
+        ctx.state
+            .circuit_breaker
+            .record_failure("pypi", ProbeToken::BACKGROUND);
 
         let response = send(&ctx.app, Method::GET, "/simple/nonexistent/", "").await;
 
@@ -669,7 +789,9 @@ mod integration_tests {
 
         // Flood failures — should be ignored
         for _ in 0..100 {
-            ctx.state.circuit_breaker.record_failure("npm");
+            ctx.state
+                .circuit_breaker
+                .record_failure("npm", ProbeToken::BACKGROUND);
         }
 
         let response = send(&ctx.app, Method::GET, "/npm/nonexistent-pkg", "").await;
@@ -696,7 +818,9 @@ mod integration_tests {
             .unwrap();
 
         // Trip the breaker
-        ctx.state.circuit_breaker.record_failure("pypi");
+        ctx.state
+            .circuit_breaker
+            .record_failure("pypi", ProbeToken::BACKGROUND);
 
         // Local read should still succeed
         let response = send(&ctx.app, Method::GET, "/simple/flask/flask-2.0.tar.gz", "").await;
@@ -730,8 +854,12 @@ mod integration_tests {
         });
 
         // Trip the breaker into Open.
-        ctx.state.circuit_breaker.record_failure("npm");
-        ctx.state.circuit_breaker.record_failure("npm");
+        ctx.state
+            .circuit_breaker
+            .record_failure("npm", ProbeToken::BACKGROUND);
+        ctx.state
+            .circuit_breaker
+            .record_failure("npm", ProbeToken::BACKGROUND);
 
         // Request now: Open + reset_timeout 0 → HalfOpen probe → upstream answers
         // 404 → record_success → breaker closes. The probe must reach upstream,

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -2412,7 +2412,7 @@ pub async fn fetch_blob_from_upstream(
     );
 
     let cb_key = format!("docker:{}", upstream_url.trim_end_matches('/'));
-    cb.check(&cb_key)?;
+    let probe = cb.check(&cb_key)?;
 
     let url = format!(
         "{}/v2/{}/blobs/{}",
@@ -2427,7 +2427,7 @@ pub async fn fetch_blob_from_upstream(
         request = request.header("Authorization", basic_auth_header(credentials));
     }
     let response = request.send().await.map_err(|e| {
-        cb.record_failure(&cb_key);
+        cb.record_failure(&cb_key, probe);
         ProxyError::Network(e.to_string())
     })?;
 
@@ -2449,7 +2449,7 @@ pub async fn fetch_blob_from_upstream(
                 .send()
                 .await
                 .map_err(|e| {
-                    cb.record_failure(&cb_key);
+                    cb.record_failure(&cb_key, probe);
                     ProxyError::Network(e.to_string())
                 })?
         } else {
@@ -2466,9 +2466,9 @@ pub async fn fetch_blob_from_upstream(
             // 4xx — upstream is alive and answered (e.g. blob not found); not an
             // availability failure, so recover the breaker instead of counting
             // it against the upstream (#606).
-            cb.record_alive(&cb_key);
+            cb.record_alive(&cb_key, probe);
         } else {
-            cb.record_failure(&cb_key);
+            cb.record_failure(&cb_key, probe);
         }
         return Err(ProxyError::Upstream(status));
     }
@@ -2503,12 +2503,12 @@ pub async fn fetch_blob_from_upstream(
                 bytes_written += chunk.len() as u64;
             }
             Ok(Some(Err(e))) => {
-                cb.record_failure(&cb_key);
+                cb.record_failure(&cb_key, probe);
                 return Err(ProxyError::Network(format!("chunk read error: {}", e)));
             }
             Ok(None) => break, // stream finished
             Err(_) => {
-                cb.record_failure(&cb_key);
+                cb.record_failure(&cb_key, probe);
                 return Err(ProxyError::Network(format!(
                     "read timeout ({}s per chunk)",
                     read_timeout
@@ -2525,7 +2525,7 @@ pub async fn fetch_blob_from_upstream(
     drop(file);
 
     let sha256 = hex::encode(sha2::Digest::finalize(hasher));
-    cb.record_success(&cb_key);
+    cb.record_success(&cb_key, probe);
     PROXY_DOWNLOAD_BYTES.inc_by(bytes_written);
 
     tracing::info!(
@@ -2559,7 +2559,7 @@ pub async fn fetch_manifest_from_upstream(
     cb: &CircuitBreakerRegistry,
 ) -> Result<(Vec<u8>, String), ProxyError> {
     let cb_key = format!("docker:{}", upstream_url.trim_end_matches('/'));
-    cb.check(&cb_key)?;
+    let probe = cb.check(&cb_key)?;
 
     let url = format!(
         "{}/v2/{}/manifests/{}",
@@ -2586,7 +2586,7 @@ pub async fn fetch_manifest_from_upstream(
     }
     let response = request.send().await.map_err(|e| {
         tracing::error!(error = %e, url = %url, "Failed to send request to upstream");
-        cb.record_failure(&cb_key);
+        cb.record_failure(&cb_key, probe);
         ProxyError::Network(e.to_string())
     })?;
 
@@ -2615,7 +2615,7 @@ pub async fn fetch_manifest_from_upstream(
                 .await
                 .map_err(|e| {
                     tracing::error!(error = %e, "Failed to send authenticated request");
-                    cb.record_failure(&cb_key);
+                    cb.record_failure(&cb_key, probe);
                     ProxyError::Network(e.to_string())
                 })?
         } else {
@@ -2635,9 +2635,9 @@ pub async fn fetch_manifest_from_upstream(
         if (400..500).contains(&status) {
             // 4xx — upstream is alive and answered (e.g. manifest not found);
             // recover the breaker rather than counting it as a failure (#606).
-            cb.record_alive(&cb_key);
+            cb.record_alive(&cb_key, probe);
         } else {
-            cb.record_failure(&cb_key);
+            cb.record_failure(&cb_key, probe);
         }
         return Err(ProxyError::Upstream(status));
     }
@@ -2650,11 +2650,11 @@ pub async fn fetch_manifest_from_upstream(
         .to_string();
 
     let bytes = response.bytes().await.map_err(|e| {
-        cb.record_failure(&cb_key);
+        cb.record_failure(&cb_key, probe);
         ProxyError::Network(e.to_string())
     })?;
 
-    cb.record_success(&cb_key);
+    cb.record_success(&cb_key, probe);
     Ok((bytes.to_vec(), content_type))
 }
 
@@ -3253,6 +3253,7 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod integration_tests {
+    use crate::circuit_breaker::ProbeToken;
     use crate::test_helpers::{body_bytes, create_test_context, send};
     use axum::body::Body;
     use axum::http::{header, Method, StatusCode};
@@ -3853,10 +3854,10 @@ mod integration_tests {
         // Trip the breaker for this upstream
         ctx.state
             .circuit_breaker
-            .record_failure("docker:http://127.0.0.1:1");
+            .record_failure("docker:http://127.0.0.1:1", ProbeToken::BACKGROUND);
         ctx.state
             .circuit_breaker
-            .record_failure("docker:http://127.0.0.1:1");
+            .record_failure("docker:http://127.0.0.1:1", ProbeToken::BACKGROUND);
 
         // Request a manifest NOT in local storage → proxy path → cb.check() → 503
         let response = send(
@@ -4111,10 +4112,10 @@ mod integration_tests {
         // Trip only upstream A
         ctx.state
             .circuit_breaker
-            .record_failure("docker:http://127.0.0.1:1");
+            .record_failure("docker:http://127.0.0.1:1", ProbeToken::BACKGROUND);
         ctx.state
             .circuit_breaker
-            .record_failure("docker:http://127.0.0.1:1");
+            .record_failure("docker:http://127.0.0.1:1", ProbeToken::BACKGROUND);
 
         // Upstream A should be open
         assert!(ctx

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -90,7 +90,7 @@ where
     Fut: std::future::Future<Output = Result<T, reqwest::Error>>,
 {
     let registry_str = registry.as_str();
-    cb.check(registry_str)?;
+    let probe = cb.check(registry_str)?;
 
     for attempt in 0..2 {
         let mut request = client.get(url).timeout(timeout);
@@ -113,11 +113,11 @@ where
                         .await
                         .map_err(|e| ProxyError::Network(e.to_string()));
                     if result.is_ok() {
-                        cb.record_success(registry_str);
+                        cb.record_success(registry_str, probe);
                     } else {
                         // 2xx but the body could not be read (e.g. a mid-stream
                         // drop) — treat as a fetch failure for the breaker.
-                        cb.record_failure(registry_str);
+                        cb.record_failure(registry_str, probe);
                     }
                     return result;
                 }
@@ -131,7 +131,7 @@ where
                     // from HalfOpen (so it recovers instead of slow-probing) but
                     // is a no-op in Closed, so a 4xx never clears a real failure
                     // tally (#606).
-                    cb.record_alive(registry_str);
+                    cb.record_alive(registry_str, probe);
                     return Err(ProxyError::NotFound);
                 }
                 if attempt == 0 {
@@ -145,7 +145,7 @@ where
                 UPSTREAM_REQUEST_DURATION
                     .with_label_values(&[registry_str, "5xx"])
                     .observe(elapsed);
-                cb.record_failure(registry_str);
+                cb.record_failure(registry_str, probe);
                 return Err(ProxyError::Upstream(status));
             }
             Err(e) => {
@@ -159,12 +159,12 @@ where
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     continue;
                 }
-                cb.record_failure(registry_str);
+                cb.record_failure(registry_str, probe);
                 return Err(ProxyError::Network(e.to_string()));
             }
         }
     }
-    cb.record_failure(registry_str);
+    cb.record_failure(registry_str, probe);
     Err(ProxyError::Network("max retries exceeded".into()))
 }
 
@@ -298,7 +298,7 @@ pub(crate) async fn proxy_fetch_conditional(
     registry: RegistryType,
 ) -> Result<Revalidation, ProxyError> {
     let registry_str = registry.as_str();
-    cb.check(registry_str)?;
+    let probe = cb.check(registry_str)?;
 
     let mut request = client.get(url).timeout(timeout);
     if let Some(credentials) = auth {
@@ -315,7 +315,7 @@ pub(crate) async fn proxy_fetch_conditional(
         Ok(response) => {
             let status = response.status();
             if status == reqwest::StatusCode::NOT_MODIFIED {
-                cb.record_success(registry_str);
+                cb.record_success(registry_str, probe);
                 return Ok(Revalidation::NotModified);
             }
             if status.is_success() {
@@ -327,7 +327,7 @@ pub(crate) async fn proxy_fetch_conditional(
                     .bytes()
                     .await
                     .map_err(|e| ProxyError::Network(e.to_string()))?;
-                cb.record_success(registry_str);
+                cb.record_success(registry_str, probe);
                 return Ok(Revalidation::Modified {
                     body: body.to_vec(),
                     validators: new_validators,
@@ -337,14 +337,14 @@ pub(crate) async fn proxy_fetch_conditional(
             if (400..500).contains(&code) {
                 // 4xx — upstream alive; recover the breaker without clearing a
                 // real failure tally, consistent with proxy_fetch_core (#606).
-                cb.record_alive(registry_str);
+                cb.record_alive(registry_str, probe);
                 return Err(ProxyError::NotFound);
             }
-            cb.record_failure(registry_str);
+            cb.record_failure(registry_str, probe);
             Err(ProxyError::Upstream(code))
         }
         Err(e) => {
-            cb.record_failure(registry_str);
+            cb.record_failure(registry_str, probe);
             Err(ProxyError::Network(e.to_string()))
         }
     }


### PR DESCRIPTION
## Problem

The #585 stall-recovery logic declares a `HalfOpen` probe that outlives the reset timeout "lost" and starts a fresh one. But `record_success` / `record_failure` / `record_alive` mutated the breaker **unconditionally** — so the "lost" probe's late report still took effect when it finally returned, closing/freeing or ghost-failing a breaker that a newer probe already owns.

Found by TLA+ model checking of the probe lifecycle: a trace exists where a superseded probe's delayed success closes a breaker the live probe is still evaluating.

## Fix — fencing token

Classic fencing-token pattern:

- `check()` now returns a `ProbeToken` carrying the probe's generation.
- `record_*` take the token and **no-op if it is not the current generation**.
- A non-probe, `Closed`-path request carries `ProbeToken::BACKGROUND`, which is never fenced — its outcome accrues normally.
- Call sites (`registry/mod.rs` `proxy_fetch_core` + revalidate, `registry/docker.rs` proxy paths) thread the token from `check()` to the matching `record_*`.

## Test

`stale_probe_report_is_fenced` reproduces the model trace: a superseded probe's late success does **not** close the breaker, and its late failure does **not** ghost-re-open a recovered one.

`cargo fmt --check`, `clippy -D warnings`, and the full suite green locally.
