### PR TITLE
feat(auth): configurable token-verify cache TTL (bound cross-replica revocation window)

### DIFF
--- a/nora-registry/src/config/auth.rs
+++ b/nora-registry/src/config/auth.rs
@@ -157,6 +157,13 @@ pub struct AuthConfig {
     pub htpasswd_file: String,
     #[serde(default = "default_token_storage")]
     pub token_storage: String,
+    /// In-memory token-verify cache TTL (seconds). Lower it to bound the
+    /// cross-replica revocation window: under a multi-replica deployment a token
+    /// revoked on one replica is still served from another replica's cache until
+    /// its entry expires.
+    /// Default 300. ENV: NORA_AUTH_TOKEN_CACHE_TTL.
+    #[serde(default = "default_token_cache_ttl")]
+    pub token_cache_ttl: u64,
     /// Trusted proxy IPs/CIDRs — only these sources have XFF/X-Real-IP honored.
     /// Default: 127.0.0.1,::1 (loopback only).
     /// ENV: NORA_AUTH_TRUSTED_PROXIES=127.0.0.1,::1,10.0.0.0/8
@@ -309,6 +316,10 @@ pub(super) fn default_token_storage() -> String {
     "data/tokens".to_string()
 }
 
+pub(super) fn default_token_cache_ttl() -> u64 {
+    300
+}
+
 impl Default for AuthConfig {
     fn default() -> Self {
         Self {
@@ -316,6 +327,7 @@ impl Default for AuthConfig {
             anonymous_read: false,
             htpasswd_file: "users.htpasswd".to_string(),
             token_storage: "data/tokens".to_string(),
+            token_cache_ttl: 300,
             trusted_proxies: TrustedProxies::default_loopback(),
             oidc: OidcConfig::default(),
         }
@@ -333,6 +345,11 @@ impl AuthConfig {
         }
         if let Ok(val) = env::var("NORA_AUTH_HTPASSWD_FILE") {
             self.htpasswd_file = val;
+        }
+        if let Ok(val) = env::var("NORA_AUTH_TOKEN_CACHE_TTL") {
+            if let Ok(secs) = val.parse() {
+                self.token_cache_ttl = secs;
+            }
         }
         if let Ok(val) = env::var("NORA_AUTH_TRUSTED_PROXIES") {
             self.trusted_proxies = TrustedProxies::parse(&val);

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1088,7 +1088,10 @@ async fn run_server(mut config: Config, storage: Storage) {
     let tokens = if config.auth.enabled {
         let token_path = Path::new(&config.auth.token_storage);
         info!(path = %config.auth.token_storage, "Token storage initialized");
-        Some(TokenStore::new(token_path))
+        Some(TokenStore::with_cache_ttl(
+            token_path,
+            std::time::Duration::from_secs(config.auth.token_cache_ttl),
+        ))
     } else {
         None
     };

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -157,6 +157,7 @@ fn build_context(
             anonymous_read,
             htpasswd_file: String::new(),
             token_storage: tempdir.path().join("tokens").to_str().unwrap().to_string(),
+            token_cache_ttl: 300,
             trusted_proxies: crate::config::TrustedProxies::default_loopback(),
             oidc: crate::config::OidcConfig::default(),
         },

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -19,8 +19,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-/// TTL for cached token verifications (avoids Argon2 per request)
-const CACHE_TTL: Duration = Duration::from_secs(300);
+/// Default TTL for cached token verifications (avoids Argon2 per request).
+/// Overridable per-store via [`TokenStore::with_cache_ttl`] (config
+/// `auth.token_cache_ttl`) to bound the cross-replica revocation window.
+const DEFAULT_CACHE_TTL: Duration = Duration::from_secs(300);
 
 /// Cached verification result
 #[derive(Clone)]
@@ -98,13 +100,23 @@ pub struct TokenStore {
     storage_path: PathBuf,
     /// In-memory cache: SHA256(token) -> verified result (avoids Argon2 per request)
     cache: Arc<RwLock<HashMap<String, CachedToken>>>,
+    /// How long a cached verification is trusted before the slow path re-checks
+    /// disk. Shorter = smaller cross-replica revocation window.
+    cache_ttl: Duration,
     /// Pending last_used updates: file_id_prefix -> timestamp (flushed periodically)
     pending_last_used: Arc<RwLock<HashMap<String, u64>>>,
 }
 
 impl TokenStore {
-    /// Create a new token store
+    /// Create a new token store with the default verify-cache TTL.
     pub fn new(storage_path: &Path) -> Self {
+        Self::with_cache_ttl(storage_path, DEFAULT_CACHE_TTL)
+    }
+
+    /// Create a token store with an explicit verify-cache TTL. A shorter TTL
+    /// bounds the window in which a token revoked on another replica is still
+    /// served from this replica's cache.
+    pub fn with_cache_ttl(storage_path: &Path, cache_ttl: Duration) -> Self {
         // Ensure directory exists with restricted permissions
         let _ = fs::create_dir_all(storage_path);
         #[cfg(unix)]
@@ -114,6 +126,7 @@ impl TokenStore {
         Self {
             storage_path: storage_path.to_path_buf(),
             cache: Arc::new(RwLock::new(HashMap::new())),
+            cache_ttl,
             pending_last_used: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -178,7 +191,7 @@ impl TokenStore {
         {
             let cache = self.cache.read();
             if let Some(cached) = cache.get(&cache_key) {
-                if cached.cached_at.elapsed() < CACHE_TTL {
+                if cached.cached_at.elapsed() < self.cache_ttl {
                     let now = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .unwrap_or_default()
@@ -474,6 +487,43 @@ mod tests {
 
         assert!(token.starts_with("nra_"));
         assert_eq!(token.len(), 4 + 32); // prefix + uuid without dashes
+    }
+
+    /// The verify-cache TTL bounds the cross-replica revocation window. Two
+    /// stores share one token dir (= two HA replicas, each with its own in-memory
+    /// cache). A token revoked on replica A is still served from replica B's cache
+    /// until B's `cache_ttl` elapses — and a short TTL bounds exactly that window.
+    #[test]
+    fn cache_ttl_bounds_cross_replica_revocation_window() {
+        use std::thread::sleep;
+        let dir = TempDir::new().unwrap();
+        let replica_a = TokenStore::new(dir.path());
+        let replica_b = TokenStore::with_cache_ttl(dir.path(), Duration::from_secs(1));
+
+        let token = replica_a.create_token("u", 30, None, Role::Write).unwrap();
+
+        // B verifies and caches the token.
+        assert!(replica_b.verify_token(&token).is_ok());
+
+        // A revokes it (removes the on-disk token + clears A's cache). B's cache is
+        // untouched — there is no cross-pod invalidation.
+        let hash_prefix = sha256_hex(&token)[..16].to_string();
+        replica_a.revoke_token(&hash_prefix).unwrap();
+
+        // WITHIN cache_ttl, B still serves the revoked token from cache — the
+        // documented window.
+        assert!(
+            replica_b.verify_token(&token).is_ok(),
+            "within cache_ttl, B serves from cache (bounded window)"
+        );
+
+        // After cache_ttl, B's entry is stale -> slow path re-reads disk -> the
+        // revoked (deleted) token is rejected. The TTL bounds the window.
+        sleep(Duration::from_millis(1100));
+        assert!(
+            matches!(replica_b.verify_token(&token), Err(TokenError::NotFound)),
+            "after cache_ttl, B re-reads disk and rejects the revoked token"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The token-verify cache (`tokens.rs`) serves a positive verification for `CACHE_TTL` without re-reading disk (avoids an Argon2 hash per request). `revoke` clears only the **local** replica's cache — so under a multi-replica deployment, a token revoked on one replica is still accepted on another until that replica's cache entry expires. The window was a hardcoded **300s**.

## Change

Make the window configurable so operators can bound it:

- `config auth.token_cache_ttl` (default `300`) + ENV `NORA_AUTH_TOKEN_CACHE_TTL`.
- `TokenStore::with_cache_ttl(path, Duration)`; `new()` keeps the default; `verify` uses the per-store TTL. `main.rs` wires the config value through.

## Test

`cache_ttl_bounds_cross_replica_revocation_window`: two stores sharing one token dir (= two replicas, each with its own in-memory cache). A token revoked on replica A is still served from B's cache **within** the TTL and **rejected after** it — pinning the exact window the knob controls.

## Scope

Mitigation only. True cross-replica cache invalidation (a revocation epoch / shared pub/sub) remains the documented upgrade for deployments that need instant revocation. `cargo fmt --check`, `clippy -D warnings`, and the full suite green locally.
