### PR TITLE
feat(verified): roll out the integrity witness to buffered artifact serves

### DIFF
--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -269,8 +269,14 @@ async fn download_tarball(
         return response;
     }
 
-    // Immutable cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable cache. get_verified discharges the integrity witness at serve
+    // (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Integrity check
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -303,9 +303,21 @@ async fn download(
         crate_name, version, crate_name, version
     );
 
-    // Try local storage first
-    if let Ok(data) = state.storage.get(&key).await {
-        // Post-download integrity verification (issue #189)
+    // Try local storage first. `get_verified` runs the same fail-closed pin gate
+    // as `get`, but reflects the outcome in the type: the integrity witness is
+    // discharged once, here at the serve site, through `verified_body` — serving
+    // raw or merely tamper-evident bytes on this path is a compile error. An
+    // open-world read (unpinned key / S3 backend) is served knowingly, never
+    // silently. (Typestate rollout — see `crate::verified`, raw.rs is the PoC.)
+    if let Ok(outcome) = state.storage.get_verified(&key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
+
+        // Post-download integrity verification (issue #189) — a curation policy
+        // check, separate from the typestate pin gate, run on the witnessed bytes.
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,
             crate::curation::RegistryType::Cargo,

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -323,8 +323,14 @@ async fn recipe_file_download(
 
     let storage_key = format!("conan/{}/revisions/{}/files/{}", ref_str, rrev, filename);
 
-    // Immutable cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable cache. get_verified discharges the integrity witness at serve
+    // (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Curation integrity
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,
@@ -599,8 +605,14 @@ async fn package_file_download(
         ref_str, rrev, pkg_id, prev, filename
     );
 
-    // Immutable cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable cache. get_verified discharges the integrity witness at serve
+    // (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Curation integrity
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -307,8 +307,14 @@ async fn download_gem(
         return response;
     }
 
-    // Immutable: if cached, serve directly
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable: if cached, serve directly. get_verified discharges the integrity
+    // witness at the serve site (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Curation integrity
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,
@@ -390,8 +396,13 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
     let artifact = format!("{}-{}", name, version);
     let storage_key = format!("gems/quick/Marshal.4.8/{}.gemspec.rz", artifact);
 
-    // Immutable cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable cache. get_verified discharges the integrity witness at serve.
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         state.metrics.record_download("gems");
         state.metrics.record_cache_hit("gems");
         state.activity.push(ActivityEntry::new(

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -163,7 +163,17 @@ async fn handle_request(
     }
 
     // --- Cache hit path ---
-    if let Ok(data) = state.storage.get(&key).await {
+    // get_verified discharges the integrity witness at the serve site (compile-time
+    // guarantee — see crate::verified). Both the tarball serve (pinned, Verified arm)
+    // and the metadata serve (unpinned, Unpinned arm) flow the discharged bytes. The
+    // .sha256 sidecar check below stays: it is the integrity check on S3 (storage
+    // pins are local-only).
+    if let Ok(outcome) = state.storage.get_verified(&key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Metadata TTL: if stale, try to refetch from upstream
         if !is_tarball {
             let ttl = state.config.npm.metadata_ttl;

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -675,8 +675,14 @@ async fn flatcontainer_download(
         "application/octet-stream"
     };
 
-    // Immutable cache
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable cache. get_verified discharges the integrity witness at serve
+    // (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         if ends_with_ci(filename, ".nupkg") {
             if let Some(response) = crate::curation::verify_integrity(
                 &state.curation().curation_engine,

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -365,7 +365,15 @@ async fn download_archive(
 
     let key = format!("pub/packages/{}/versions/{}.tar.gz", package, version);
 
-    if let Ok(data) = state.storage.get(&key).await {
+    // get_verified discharges the integrity witness at the serve site (compile-time
+    // guarantee — see crate::verified). The .sha256 sidecar check below is kept: it
+    // is the integrity check on S3 (storage pins are local-only).
+    if let Ok(outcome) = state.storage.get_verified(&key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Integrity verification (curation allowlist)
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -249,8 +249,14 @@ async fn download_file(
 
     let key = format!("pypi/{}/{}", normalized, filename);
 
-    // Try local storage first
-    if let Ok(data) = state.storage.get(&key).await {
+    // Try local storage first. get_verified discharges the integrity witness at
+    // the serve site (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         // Curation integrity verification (issue #189)
         if let Some(response) = crate::curation::verify_integrity(
             &state.curation().curation_engine,

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -296,8 +296,14 @@ async fn provider_download_binary(
 
     let storage_key = format!("terraform/download/{}", path);
 
-    // Immutable: if cached, serve directly
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable: if cached, serve directly. get_verified discharges the integrity
+    // witness at serve (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         state.metrics.record_download("terraform");
         state.metrics.record_cache_hit("terraform");
         state.activity.push(ActivityEntry::new(
@@ -552,8 +558,14 @@ async fn module_source_download(
         ns, name, provider, ver
     );
 
-    // Immutable: if cached, serve directly
-    if let Ok(data) = state.storage.get(&storage_key).await {
+    // Immutable: if cached, serve directly. get_verified discharges the integrity
+    // witness at serve (compile-time guarantee — see crate::verified).
+    if let Ok(outcome) = state.storage.get_verified(&storage_key).await {
+        use nora_registry::verified::{verified_body, GateOutcome};
+        let data = match outcome {
+            GateOutcome::Verified(blob) => verified_body(blob),
+            GateOutcome::Unpinned(blob) => blob.into_inner(),
+        };
         state.metrics.record_download("terraform");
         state.metrics.record_cache_hit("terraform");
         return with_binary(data.to_vec());


### PR DESCRIPTION
## What

Extend the compile-time integrity witness (`crate::verified`, the `raw.rs` PoC) from one serve path to **every buffered serve of NORA-stored artifact content** — 9 registries. Each local-cache serve now reads via `Storage::get_verified` and discharges the witness at the serve site:

```rust
let data = match outcome {
    GateOutcome::Verified(blob) => verified_body(blob),   // pinned: integrity-proven
    GateOutcome::Unpinned(blob) => blob.into_inner(),     // open-world (no pin / S3): served knowingly
};
```

`verified_body` accepts only `Blob<Verified>`, so serving raw or merely tamper-evident bytes on these paths is a **compile error**. `get_verified` runs the *same* fail-closed pin gate as `get()` — behaviour-preserving, plus a type-level guarantee that the served bytes came from a discharged witness.

## Registries (one commit each)

`cargo`, `gems`, `conan`, `terraform`, `ansible`, `nuget`, `pypi`, `npm`, `pub` — the buffered artifact downloads (`.crate`, `.gem`/`.gemspec.rz`, recipe/package files, provider/module `.zip`, collection `.tar.gz`, `.nupkg`/`.nuspec`, sdist/wheel, npm tarball, pub archive).

## Notes

- **Sidecar checks kept.** Where a handler already recomputes a `.sha256` sidecar at serve (npm, pub), that check is **kept** — it is the integrity check on **S3**, where storage pins are unavailable (`pin_store=None`). The witness adds the local pin guarantee on top; nothing is removed, so there is no S3 regression.
- **Curation unchanged.** The `verify_integrity` (#189) policy check still runs, now on the witnessed bytes.
- **Out of scope (follow-ups):** docker blobs are *streamed* via `VerifyingReader` (content-addressed, checked at EOF) → the `TamperEvident` tier, which needs a separate streaming-witness design; `maven`/`go` serve the immutable artifact from the *same* `Option<Bytes>` that drives the metadata TTL/stale path, so they need a small handler split first.

`cargo fmt --check`, `clippy --package nora-registry -- -D warnings`, and the full suite (lib 55 / bin 1327 / doctests) green locally.
