### PR TITLE
ci: pin builder toolchain via rust-toolchain.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ RUN apk add --no-cache musl-dev
 
 WORKDIR /build
 
+# Pin the build toolchain: rustup reads rust-toolchain.toml and installs the
+# exact channel, so the release binary is reproducible regardless of the base
+# image's bundled rustc.
+COPY rust-toolchain.toml ./
 COPY Cargo.toml Cargo.lock ./
 COPY nora-registry/ nora-registry/
 
@@ -45,9 +49,12 @@ RUN apk add --no-cache musl-dev \
 ENV PATH="/opt/aarch64-linux-musl-cross/bin:$PATH" \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc
 
+WORKDIR /build
+# Pin the toolchain before adding the cross target so the target lands on the
+# pinned channel (rust-toolchain.toml), keeping the arm64 build reproducible.
+COPY rust-toolchain.toml ./
 RUN rustup target add aarch64-unknown-linux-musl
 
-WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY nora-registry/ nora-registry/
 RUN sed -i '/"fuzz"/d' Cargo.toml


### PR DESCRIPTION
## Summary
The release binary is compiled in the builder / cross-arm64 stages on a
`rust:1-alpine3.21` base, whose bundled rustc floats with the base tag. Neither
stage copies `rust-toolchain.toml` into the build context, so rustup never
applies the pinned `channel = "1.96.0"` — the published binary is built by
whatever rustc the base image ships, and is not reproducible from the pin.

## Change
- Copy `rust-toolchain.toml` into both builder stages so rustup installs the
  pinned channel before `cargo build`.
- In the arm64 stage the file is copied before `rustup target add` so the cross
  target is added to the pinned toolchain, not the base default.

## Notes
Build-only, no source changes. The file is already tracked and not excluded by `.dockerignore`.