### PR TITLE
ci: enforce the coverage fail-under floor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # Run on every PR (so the fail-under floor actually gates merges) and on
+    # main pushes (to refresh the badge). Previously main-push-only, so the
+    # floor never ran on the PRs it was meant to protect.
+    if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main'
     permissions:
       contents: read
     steps:
@@ -118,13 +121,19 @@ jobs:
         run: cargo install cargo-tarpaulin --locked
 
       - name: Run coverage
+        # No pipe: tarpaulin's exit code (non-zero when coverage < fail-under)
+        # must reach the runner. The old `| tee` masked it behind tee's exit 0,
+        # so the fail-under floor never failed the build.
         run: |
-          cargo tarpaulin --config tarpaulin.toml 2>&1 | tee /tmp/tarpaulin.log
+          cargo tarpaulin --config tarpaulin.toml
           COVERAGE=$(python3 -c "import json; d=json.load(open('coverage/tarpaulin-report.json')); print(f\"{d['coverage']:.1f}\")")
           echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
           echo "Coverage: $COVERAGE%"
 
       - name: Update coverage badge
+        # Badge needs the GIST_TOKEN secret and only makes sense for the
+        # canonical branch — skip on PRs (incl. forks without secrets).
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}

--- a/tarpaulin.toml
+++ b/tarpaulin.toml
@@ -1,7 +1,7 @@
 [nora]
 packages = ["nora-registry"]
 engine = "Llvm"
-fail-under = 38
+fail-under = 60
 out = ["Json", "Html"]
 output-dir = "coverage"
 test-timeout = "5m"


### PR DESCRIPTION
## Summary
The coverage job did not actually gate:
- the run piped tarpaulin through `tee`, so the step saw tee s exit 0 and never
  failed when coverage fell below `fail-under`;
- it ran only on pushes to main, so the floor never ran on pull requests;
- `fail-under` sat at 38, far below actual coverage.

## Change
- Drop the pipe so tarpaulin s exit code reaches the runner.
- Run the job on pull requests as well as main.
- Gate the badge-update step (needs a secret) to main pushes only.
- Raise `fail-under` to 60 — a real floor with headroom below current coverage.