### PR TITLE
fix(docker): sweep orphaned upload temp files periodically, not only at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Docker upload temp files orphaned by a write failure are now reclaimed periodically** — `cleanup_upload_temp_dir` ran only at startup, so a temp file left behind by a storage-write failure — whose upload session entry is already gone, and so is never freed by the expired-session sweep — survived on disk until the next restart, slowly leaking disk. It now also runs on the 5-minute background sweep (mirroring the proxy temp dir); the `SESSION_TTL` age guard keeps in-progress uploads safe (#683).
 - **Cargo sparse-index rebuild is now all-or-fail** — regenerating the index swallowed a transient list/read error (`unwrap_or_default()` on the entry listing, `if let Ok` per entry), so an I/O blip could publish a truncated — or empty — index as authoritative and silently drop versions a client had already published successfully. A read error now aborts the rebuild (the publish returns `500` and the existing index stays intact); a genuinely empty crate is still handled as empty (#681).
 - **Docker pull command in the UI** — the package detail view built `docker pull` from `public_url` verbatim, so a configured `public_url` with a scheme produced an invalid `docker pull https://host/image`. The pull command now uses the bare host authority.
 - **IPv6 fallback base URL** — when `public_url` is unset and the bind host is an IPv6 literal, the advertised base URL now brackets the address (`http://[::1]:4000`), matching the listen address format.

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1427,13 +1427,20 @@ async fn run_server(mut config: Config, storage: Storage) {
             }
 
             // Every 5 minutes (tick_count % 10 == 0): evict unused publish locks
-            // + clean up stale proxy temp files (#580)
+            // + clean up stale proxy and upload temp files (#580)
             if tick_count.is_multiple_of(10) {
                 let mut locks = metrics_state.publish_locks.lock();
                 locks.retain(|_, arc| Arc::strong_count(arc) > 1);
                 let storage_path = metrics_state.config.storage.path.clone();
                 tokio::task::spawn_blocking(move || {
                     registry::docker::cleanup_proxy_temp_dir(&storage_path);
+                    // Reclaim upload temp files orphaned by a storage-write failure
+                    // without waiting for a restart. cleanup_expired_sessions only
+                    // frees temps still tracked by a live (expired) session, so an
+                    // orphan whose session entry is already gone would otherwise
+                    // survive on disk until the next boot. Age-guarded by SESSION_TTL,
+                    // so in-progress uploads are never reaped.
+                    registry::docker::cleanup_upload_temp_dir(&storage_path);
                 });
             }
         }

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -581,10 +581,14 @@ fn validate_upload_uuid(uuid: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
-/// Remove stale temp files from the Docker upload directory on startup.
+/// Remove stale temp files from the Docker upload directory.
 ///
 /// Files older than `SESSION_TTL` are removed regardless of name format.
-/// This catches orphans from previous crashes, TOCTOU races, and legacy naming.
+/// Called at startup and periodically from the background task (mirrors
+/// [`cleanup_proxy_temp_dir`]), so an upload temp orphaned by a storage-write
+/// failure — whose session entry is already gone, so `cleanup_expired_sessions`
+/// will never free it — is reclaimed without waiting for a restart. The
+/// `SESSION_TTL` age guard keeps in-progress uploads safe under the periodic call.
 pub fn cleanup_upload_temp_dir(data_dir: &str) {
     let dir = std::path::PathBuf::from(data_dir).join("tmp/docker-uploads");
     let entries = match std::fs::read_dir(&dir) {
@@ -608,7 +612,7 @@ pub fn cleanup_upload_temp_dir(data_dir: &str) {
         }
     }
     if removed > 0 {
-        tracing::info!(removed, dir = %dir.display(), "Cleaned up stale Docker upload temp files on startup");
+        tracing::info!(removed, dir = %dir.display(), "Cleaned up stale Docker upload temp files");
     }
 }
 


### PR DESCRIPTION
## What
`cleanup_upload_temp_dir` ran only at startup, so an upload temp file orphaned by a storage-write failure — one whose session entry is already gone, so the expired-session sweep never frees it — survived on disk until the next restart, slowly leaking disk on a long-running server.

## How
- Call `cleanup_upload_temp_dir` on the existing 5-minute background sweep, next to `cleanup_proxy_temp_dir`.
- Doc/log updated to reflect that it now runs periodically too.

## Safety
The `SESSION_TTL` age guard means only files older than the session TTL are removed, so in-progress uploads are never reaped. Already covered by `test_cleanup_upload_temp_dir_removes_old_files` (asserts old removed, recent preserved).

## Verification
`make check` green (fmt, clippy `-D warnings`, full test suite, coherence, lock-audit, changelog).

Closes #683