### PR TITLE
docs(curation): correct the MinReleaseAgeFilter unknown-date comment to fail-closed

### DIFF
--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -1005,9 +1005,12 @@ pub fn parse_duration(s: &str) -> Result<i64, String> {
 
 /// Filter that blocks packages published less than `min_age_secs` ago.
 ///
-/// If `publish_date` is `None` (unknown), the filter returns `Skip` (no opinion).
-/// Supports per-registry overrides: if a registry has its own threshold,
-/// it takes precedence over the global `min_age_secs`.
+/// If `publish_date` is `None` (unknown), the filter fails **closed**: it returns
+/// `Block` when the quarantine is active (threshold > 0), so an unverifiable age
+/// cannot slip past the cooldown, and `Skip` only when the quarantine is disabled
+/// for that registry (threshold `0`). Supports per-registry overrides: if a
+/// registry has its own threshold, it takes precedence over the global
+/// `min_age_secs`.
 pub struct MinReleaseAgeFilter {
     min_age_secs: i64,
     label: String,


### PR DESCRIPTION
## What
The `MinReleaseAgeFilter` struct doc still said an unknown `publish_date` returns `Skip` ("no opinion"), but the filter now **fails closed**: it returns `Block` when the quarantine is active (threshold > 0) and `Skip` only when the quarantine is disabled for that registry. The comment contradicted the code.

## How
Doc-comment only — sync the wording to the actual `evaluate` behavior. No code or test change.

## Verification
`cargo fmt --check` clean, compiles; the behavior is already covered by `test_min_release_age_unknown_date_blocked_fail_closed` + `_skips_when_disabled`.