### PR TITLE
fix(ui): prefix the API-docs link and Swagger spec URL for sub-path mounts

### DIFF
--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -178,29 +178,41 @@ fn apply_base_path(html: &str, base: &str) -> String {
         .replace("'/ui", &format!("'{base}/ui"))
         .replace("\"/api/ui", &format!("\"{base}/api/ui"))
         .replace("'/api/ui", &format!("'{base}/api/ui"))
+        // The API-docs (Swagger UI) entry link in the nav and the root-absolute
+        // spec URL the Swagger initializer embeds ("/api-docs/openapi.json").
+        .replace("\"/api-docs", &format!("\"{base}/api-docs"))
+        .replace("'/api-docs", &format!("'{base}/api-docs"))
 }
 
 /// Response middleware: rewrite the UI's root-absolute self-links to carry the
 /// configured `public_url` path prefix. Covers HTML bodies (links + inline JS
-/// `fetch`) and redirect `Location` headers. A no-op when `base_path` is empty
-/// (the router keeps serving `/ui` and `/api/ui`; the proxy strips the prefix).
+/// `fetch`), the Swagger UI initializer's spec URL, and redirect `Location`
+/// headers. A no-op when `base_path` is empty (the router keeps serving `/ui`,
+/// `/api/ui` and `/api-docs`; the proxy strips the prefix).
 pub(crate) async fn rewrite_ui_base_path(
     State(state): State<AppState>,
     req: Request,
     next: Next,
 ) -> Response {
     let base = state.config.server.base_path();
+    // Capture the path before the request is consumed: the Swagger initializer
+    // is served as JS (not HTML) yet embeds a root-absolute spec URL that needs
+    // the same prefix, so it is rewritten by path rather than by content type.
+    let path = req.uri().path().to_string();
     let mut resp = next.run(req).await;
     if base.is_empty() {
         return resp;
     }
-    // A redirect target (e.g. "/" -> "/ui/") must carry the prefix too.
+    // A redirect target (e.g. "/" -> "/ui/", "/api-docs" -> "/api-docs/") must
+    // carry the prefix too.
     if let Some(loc) = resp
         .headers()
         .get(header::LOCATION)
         .and_then(|v| v.to_str().ok())
     {
-        if (loc.starts_with("/ui") || loc.starts_with("/api/ui")) && !loc.starts_with(&base) {
+        if (loc.starts_with("/ui") || loc.starts_with("/api/ui") || loc.starts_with("/api-docs"))
+            && !loc.starts_with(&base)
+        {
             if let Ok(hv) = HeaderValue::from_str(&format!("{base}{loc}")) {
                 resp.headers_mut().insert(header::LOCATION, hv);
             }
@@ -211,7 +223,11 @@ pub(crate) async fn rewrite_ui_base_path(
         .get(header::CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
         .is_some_and(|c| c.contains("text/html"));
-    if !is_html {
+    // The Swagger UI initializer is JS but embeds a root-absolute spec URL
+    // ("/api-docs/openapi.json"); rewrite it too so the docs load under a
+    // sub-path. Scoped to that one small file — large JS bundles pass through.
+    let is_swagger_init = path.ends_with("/swagger-initializer.js");
+    if !is_html && !is_swagger_init {
         return resp;
     }
     let (mut parts, body) = resp.into_parts();
@@ -1006,6 +1022,21 @@ mod base_path_tests {
         assert!(!out.contains(r#"href="/ui/"#));
         assert!(!out.contains("fetch('/api/ui"));
         assert!(!out.contains("/nora/nora/"));
+    }
+
+    #[test]
+    fn apply_base_path_prefixes_api_docs_link_and_spec_url() {
+        // The "API Docs" nav link (HTML) and the Swagger initializer's embedded
+        // spec URL (JS) are both root-absolute /api-docs paths that break under a
+        // sub-path unless prefixed. Regression guard for the #686 residual.
+        let html = r#"<a href="/api-docs" title="API Docs">d</a>"#;
+        let init = r#"window.ui = SwaggerUIBundle({ "url": "/api-docs/openapi.json" });"#;
+        assert!(apply_base_path(html, "/nora").contains(r#"href="/nora/api-docs""#));
+        let out = apply_base_path(init, "/nora");
+        assert!(out.contains(r#""url": "/nora/api-docs/openapi.json""#));
+        assert!(!out.contains(r#""/api-docs/openapi.json""#));
+        // Empty base is still a no-op for the api-docs paths.
+        assert_eq!(apply_base_path(html, ""), html);
     }
 
     #[test]


### PR DESCRIPTION
Closes #689.

#686 routed the UI's root-absolute self-links through the `NORA_PUBLIC_URL` base path so the UI works under a sub-path reverse proxy. Two references to the API-docs surface were missed and still 404 under a sub-path:

- the **"API Docs" nav link** (`href="/api-docs"` in `ui/components.rs`), and
- the **Swagger initializer's embedded spec URL** (`"/api-docs/openapi.json"`), which is served as JS, not HTML, so the HTML-only rewrite never touched it.

This extends the existing response-layer rewrite (no new mechanism):

- `apply_base_path` also prefixes `"/api-docs` / `'/api-docs` — covering the nav link (HTML) and the embedded spec URL;
- `rewrite_ui_base_path` now also rewrites the `swagger-initializer.js` response, matched by request path (it is `application/javascript`); large JS bundles pass through untouched;
- redirect `Location` rewriting now covers the utoipa `/api-docs` → `/api-docs/` redirect.

No-op when the `public_url` path is empty, so root-vhost deploys are unchanged. Swagger's own assets are relative (`./swagger-ui.css`) and already resolved correctly under a sub-path.

### Verification

Unit: `apply_base_path_prefixes_api_docs_link_and_spec_url` (nav link + spec URL prefixed; no-op on empty base).

End-to-end, behind a real `nginx` stripping proxy (`location /nora/ { proxy_pass http://nora:4000/; }`) with `NORA_PUBLIC_URL=…/nora`, resolving every emitted self-link the way a browser would:

| | pre-#686 | #686 | this PR |
|---|---|---|---|
| dashboard self-links | 18/18 broken | 1/18 broken | 0/18 broken |
| "API Docs" link | 404 | 404 | 303 → 200 |
| Swagger spec fetch | 404 | 404 | 200 |

Root-vhost (`/ui/`, `/api-docs`, `/api-docs/openapi.json`) stays 200.
