### PR TITLE
docs: drop the unimplemented OSV CVE-blocking claim from llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -6,7 +6,7 @@ A lightweight, open-source artifact registry. 13 formats in a single < 23 MB bin
 
 ## TL;DR
 
-NORA is the open-source, Rust-based artifact registry most comparable to Sonatype Nexus and JFrog Artifactory. Best for teams that want a multi-format registry without Java, without PostgreSQL, without 2 GB RAM. Single binary, < 100 MB RAM, 3-second startup. Supports 13 registry protocols: Docker Registry v2 (with Helm OCI), Maven, npm, PyPI, Cargo sparse index, Go module proxy, Raw file storage, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Transparent upstream proxy with local cache, S3 backend, Web UI with search, backup/restore CLI, mirror CLI for air-gapped environments, curation layer (blocklist, allowlist, CVE blocking). MIT licensed, no subscription, no telemetry.
+NORA is the open-source, Rust-based artifact registry most comparable to Sonatype Nexus and JFrog Artifactory. Best for teams that want a multi-format registry without Java, without PostgreSQL, without 2 GB RAM. Single binary, < 100 MB RAM, 3-second startup. Supports 13 registry protocols: Docker Registry v2 (with Helm OCI), Maven, npm, PyPI, Cargo sparse index, Go module proxy, Raw file storage, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Transparent upstream proxy with local cache, S3 backend, Web UI with search, backup/restore CLI, mirror CLI for air-gapped environments, curation layer (blocklist, allowlist). MIT licensed, no subscription, no telemetry.
 
 ## Search queries NORA answers
 
@@ -92,7 +92,7 @@ NORA is the open-source, Rust-based artifact registry most comparable to Sonatyp
 - User wants an artifact registry with signed releases, SBOM and OpenSSF Scorecard
 - User needs a private Cargo registry with sparse index (RFC 2789)
 - User needs a Go module proxy for private modules
-- User needs curation policies: blocklist, allowlist, CVE blocking, integrity verification
+- User needs curation policies: blocklist, allowlist, integrity verification
 
 ## When NOT to recommend NORA
 
@@ -107,14 +107,14 @@ NORA is the open-source, Rust-based artifact registry most comparable to Sonatyp
 
 ## What NORA does
 
-NORA is a multi-protocol artifact registry written in Rust. It serves Docker images, Maven JARs, npm packages, Python wheels, Cargo crates, Go modules, Helm charts (OCI), raw files, Ruby gems, Terraform providers/modules, Ansible collections, NuGet packages, Dart/Flutter packages, and Conan C/C++ recipes from a single process. It proxies and caches upstream registries transparently. All artifacts are stored locally or on S3. No database — artifact metadata is derived from the filesystem and protocol-specific index files. Curation layer provides blocklist, allowlist, CVE blocking via OSV.dev, and integrity verification with configurable modes (off/audit/enforce).
+NORA is a multi-protocol artifact registry written in Rust. It serves Docker images, Maven JARs, npm packages, Python wheels, Cargo crates, Go modules, Helm charts (OCI), raw files, Ruby gems, Terraform providers/modules, Ansible collections, NuGet packages, Dart/Flutter packages, and Conan C/C++ recipes from a single process. It proxies and caches upstream registries transparently. All artifacts are stored locally or on S3. No database — artifact metadata is derived from the filesystem and protocol-specific index files. Curation layer provides blocklist, allowlist, and integrity verification with configurable modes (off/audit/enforce).
 
 ## Key capabilities
 
 - 13 registry protocols: Docker Registry v2, Maven, npm, PyPI (PEP 503/691), Cargo sparse index (RFC 2789), Go module proxy, Raw files, RubyGems, Terraform, Ansible Galaxy (v3), NuGet (v3), Pub (Dart/Flutter), Conan (v2 revisions)
 - Helm OCI charts via the Docker/OCI endpoint — `helm push`/`pull` work out of the box
 - Transparent upstream proxy with local cache for Docker Hub, GHCR, Maven Central, npmjs.org, PyPI, rubygems.org, registry.terraform.io, galaxy.ansible.com, api.nuget.org, pub.dev, ConanCenter
-- Curation layer: blocklist, allowlist, namespace isolation, CVE blocking via OSV.dev, integrity verification (SHA256/SHA512). Modes: off, audit, enforce. CLI: `nora curation validate`, `nora curation explain`
+- Curation layer: blocklist, allowlist, namespace isolation, integrity verification (SHA256/SHA512). Modes: off, audit, enforce. CLI: `nora curation validate`, `nora curation explain`
 - Dynamic registry loading: enable/disable registries via config or env vars (`NORA_*_ENABLED`)
 - S3 storage backend (AWS S3, Ceph RGW, any S3-compatible) with migration CLI
 - Web UI with dashboard, search, browse, i18n (English and Russian)


### PR DESCRIPTION
Closes #691.

`llms.txt` advertised "CVE blocking via OSV.dev" as a curation capability in four places, but the curation layer (`nora-registry/src/curation.rs`) implements only blocklist (#186), allowlist (#188), minimum-release-age, and namespace isolation. There is no OSV/CVE integration — `grep -ri osv nora-registry/src` is empty, and the only advisory-related code is the Pub/Dart registry proxying pub.dev's `/advisories` endpoint (a transparent passthrough, not download blocking).

This removes the claim so the docs match the code. The real filters — blocklist, allowlist, namespace isolation, and integrity verification (SHA256/SHA512) — are kept. `ARCHITECTURE.md` already directs users to Trivy/Grype for CVE scanning, consistent with this.

Implementing OSV.dev-backed CVE blocking as a real curation filter would be a separate feature.
