### PR TITLE
feat(server): bind dual-stack (IPv4+IPv6) for the :: wildcard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
  "serde_json",
  "sha1",
  "sha2 0.11.0",
+ "socket2",
  "subtle",
  "tar",
  "tempfile",

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN microdnf install -y ca-certificates shadow-utils curl \
 COPY --from=builder --chown=nora:nora /nora /usr/local/bin/nora
 
 ENV RUST_LOG=info \
-    NORA_HOST=0.0.0.0 \
+    NORA_HOST=:: \
     NORA_PORT=4000 \
     NORA_PUBLIC_URL=http://localhost:4000 \
     NORA_STORAGE_PATH=/data/storage \
@@ -109,7 +109,7 @@ RUN apt-get update \
 COPY --from=builder --chown=nora:nora /nora /usr/local/bin/nora
 
 ENV RUST_LOG=info \
-    NORA_HOST=0.0.0.0 \
+    NORA_HOST=:: \
     NORA_PORT=4000 \
     NORA_PUBLIC_URL=http://localhost:4000 \
     NORA_STORAGE_PATH=/data/storage \
@@ -136,7 +136,7 @@ RUN apk upgrade --no-cache \
 COPY --from=builder --chown=nora:nora /nora /usr/local/bin/nora
 
 ENV RUST_LOG=info \
-    NORA_HOST=0.0.0.0 \
+    NORA_HOST=:: \
     NORA_PORT=4000 \
     NORA_PUBLIC_URL=http://localhost:4000 \
     NORA_STORAGE_PATH=/data/storage \

--- a/deploy/Dockerfile.release
+++ b/deploy/Dockerfile.release
@@ -21,7 +21,7 @@ COPY --chown=nora:nora nora-linux-${TARGETARCH} /usr/local/bin/nora
 RUN chmod +x /usr/local/bin/nora
 
 ENV RUST_LOG=info \
-    NORA_HOST=0.0.0.0 \
+    NORA_HOST=:: \
     NORA_PORT=4000 \
     NORA_PUBLIC_URL=http://localhost:4000 \
     NORA_STORAGE_PATH=/data/storage \

--- a/nora-registry/Cargo.toml
+++ b/nora-registry/Cargo.toml
@@ -59,6 +59,8 @@ subtle = "2"
 tokio-util = "0.7"
 arc-swap = "1"
 memchr = "2"
+# Dual-stack TCP bind: clear IPV6_V6ONLY so a `::` listener also accepts IPv4 (#574).
+socket2 = "0.6"
 
 [dev-dependencies]
 proptest = "1"

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -460,6 +460,66 @@ mod healthcheck_tests {
     }
 }
 
+/// Bind the server's TCP listener, preferring dual-stack for the IPv6 wildcard.
+///
+/// For `::` we create the socket explicitly and clear `IPV6_V6ONLY`, so the
+/// listener accepts both IPv4 and IPv6 regardless of the host's `bindv6only`
+/// sysctl (#574). If IPv6 is unavailable, we fall back to `0.0.0.0` (IPv4-only)
+/// rather than failing to start. Any other host (specific IP or name) binds
+/// normally.
+async fn bind_listener(host: &str, port: u16) -> std::io::Result<tokio::net::TcpListener> {
+    use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+
+    if host == "::" || host == "0:0:0:0:0:0:0:0" {
+        let v6 = SocketAddr::from((Ipv6Addr::UNSPECIFIED, port));
+        match bind_v6_dual_stack(v6) {
+            Ok(listener) => return Ok(listener),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "dual-stack bind on [::] failed; falling back to 0.0.0.0 (IPv4-only)"
+                );
+                let v4 = SocketAddr::from((Ipv4Addr::UNSPECIFIED, port));
+                return tokio::net::TcpListener::bind(v4).await;
+            }
+        }
+    }
+    tokio::net::TcpListener::bind((host, port)).await
+}
+
+/// Create a dual-stack (`IPV6_V6ONLY = false`) IPv6 listener via `socket2`,
+/// returning it as a non-blocking `tokio` listener.
+fn bind_v6_dual_stack(addr: std::net::SocketAddr) -> std::io::Result<tokio::net::TcpListener> {
+    use socket2::{Domain, Socket, Type};
+
+    let socket = Socket::new(Domain::IPV6, Type::STREAM, None)?;
+    socket.set_only_v6(false)?;
+    socket.set_reuse_address(true)?;
+    socket.set_nonblocking(true)?;
+    socket.bind(&addr.into())?;
+    socket.listen(1024)?;
+    let std_listener: std::net::TcpListener = socket.into();
+    tokio::net::TcpListener::from_std(std_listener)
+}
+
+#[cfg(test)]
+mod bind_tests {
+    use super::bind_listener;
+
+    #[tokio::test]
+    async fn dual_stack_listener_accepts_ipv4() {
+        // A "::" bind must accept IPv4 clients — via dual-stack, or via the
+        // 0.0.0.0 fallback when IPv6 is unavailable. Guards against an IPv4
+        // regression from defaulting the container bind to "::".
+        let listener = bind_listener("::", 0).await.expect("bind ::");
+        let port = listener.local_addr().unwrap().port();
+        tokio::spawn(async move { while listener.accept().await.is_ok() {} });
+        tokio::net::TcpStream::connect(("127.0.0.1", port))
+            .await
+            .expect("IPv4 loopback connects to a :: listener");
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
@@ -1462,10 +1522,14 @@ async fn run_server(mut config: Config, storage: Storage) {
         registry::docker::cleanup_proxy_temp_dir(&state.config.storage.path);
     }
 
-    let addr = state.config.server.bind_addr();
-    let listener = tokio::net::TcpListener::bind(&addr)
+    let listener = bind_listener(&state.config.server.host, state.config.server.port)
         .await
         .expect("Failed to bind");
+    // Report the address actually bound (reflects any IPv6 -> IPv4 fallback).
+    let addr = listener
+        .local_addr()
+        .map(|a| a.to_string())
+        .unwrap_or_else(|_| state.config.server.bind_addr());
 
     info!(
         address = %addr,


### PR DESCRIPTION
Closes #574.

The container images bound `NORA_HOST=0.0.0.0` (IPv4-only), so IPv6 clients could not reach NORA without extra configuration. This defaults the images to the IPv6 wildcard and binds it dual-stack.

(The issue assumed the code default was `0.0.0.0`; it is actually the `127.0.0.1` loopback, which stays unchanged — only the container ENV default moves, so there is no new bind-all-interfaces-by-default behavior.)

- **`bind_listener` / `bind_v6_dual_stack`** — for `::` the socket is created via `socket2` with `IPV6_V6ONLY` cleared, so the listener accepts both IPv4 and IPv6 regardless of the host's `bindv6only` sysctl. If IPv6 is unavailable the bind falls back to `0.0.0.0` (IPv4-only) instead of failing to start. Any other host (specific IP or name) binds normally.
- **Docker / release images** — `NORA_HOST` `0.0.0.0` → `::`. The startup log reports the address actually bound, so a fallback is visible.

### Behavior change

Container deployments now listen dual-stack instead of IPv4-only. Port mapping (`-p 4000:4000`) is unaffected and existing IPv4 clients keep working. On a host without IPv6 the bind falls back to IPv4-only, so there is no startup regression.

### Verification

- Unit: a `::` listener accepts an IPv4 loopback client.
- End-to-end: against a `::` bind, both `127.0.0.1` (IPv4) and `::1` (IPv6) return 200, and the socket reports dual-stack (`IPV6_V6ONLY = 0`).
