### PR TITLE
feat(pypi): support multiple upstream proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ nora-review.sh
 coverage/
 target/criterion/
 
+# proptest failure seeds — local replay only; regressions are locked by explicit unit tests
+proptest-regressions/
+
 # Internal tooling (not for public repo)
 scripts/docs-quality-gate.py
 docs-manifest.json

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -321,6 +321,15 @@ impl Config {
         if self.pypi.proxy_auth.is_some() && std::env::var("NORA_PYPI_PROXY_AUTH").is_err() {
             tracing::warn!("PyPI proxy credentials in config.toml are plaintext — consider NORA_PYPI_PROXY_AUTH env var");
         }
+        // PyPI multi-upstream proxies (#663)
+        for proxy in &self.pypi.proxies {
+            if proxy.auth().is_some() && std::env::var("NORA_PYPI_PROXIES").is_err() {
+                tracing::warn!(
+                    url = %proxy.url(),
+                    "PyPI upstream credentials in config.toml are plaintext — consider NORA_PYPI_PROXIES env var"
+                );
+            }
+        }
         // Cargo
         if self.cargo.proxy_auth.is_some() && std::env::var("NORA_CARGO_PROXY_AUTH").is_err() {
             tracing::warn!("Cargo proxy credentials in config.toml are plaintext — consider NORA_CARGO_PROXY_AUTH env var");
@@ -364,7 +373,6 @@ impl Config {
         // Simple proxy: Option<String>
         let simple = [
             ("npm", self.npm.proxy.as_deref()),
-            ("pypi", self.pypi.proxy.as_deref()),
             ("cargo", self.cargo.proxy.as_deref()),
             ("go", self.go.proxy.as_deref()),
             ("gems", self.gems.proxy.as_deref()),
@@ -401,6 +409,16 @@ impl Config {
         for proxy in &self.maven.proxies {
             if let Some(host) = extract_host(proxy.url()) {
                 result.push(("maven".to_string(), host));
+            }
+        }
+
+        // PyPI upstreams: Vec<PypiProxyEntry> via upstreams() so the multi-upstream
+        // list (#663) AND the legacy single `proxy` are both registered with the
+        // leak detector — otherwise a secondary upstream's host (e.g. an internal
+        // mirror with embedded credentials) would be invisible to leak scanning.
+        for up in self.pypi.upstreams() {
+            if let Some(host) = extract_host(up.url()) {
+                result.push(("pypi".to_string(), host));
             }
         }
 
@@ -2362,6 +2380,43 @@ mod tests {
             .collect();
         assert!(docker_hosts.contains(&"registry-1.docker.io"));
         assert!(docker_hosts.contains(&"ghcr.io"));
+    }
+
+    #[test]
+    fn test_upstream_hostnames_pypi_multi_upstream() {
+        // #663: every configured pypi upstream host must reach the leak detector,
+        // not just the legacy single `proxy`. A secondary upstream (e.g. an internal
+        // mirror carrying credentials) was previously invisible to leak scanning.
+        let toml = r#"
+            [server]
+            host = "127.0.0.1"
+            port = 4000
+
+            [storage]
+            path = "/tmp/nora-test"
+
+            [[pypi.proxies]]
+            url = "https://pypi.org/simple"
+
+            [[pypi.proxies]]
+            url = "https://internal-nexus.corp/pypi"
+            auth = "secret-token"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        let hosts = config.upstream_hostnames();
+        let pypi_hosts: Vec<&str> = hosts
+            .iter()
+            .filter(|(r, _)| r == "pypi")
+            .map(|(_, h)| h.as_str())
+            .collect();
+        assert!(
+            pypi_hosts.contains(&"pypi.org"),
+            "primary upstream registered"
+        );
+        assert!(
+            pypi_hosts.contains(&"internal-nexus.corp"),
+            "secondary upstream host must be registered with the leak detector"
+        );
     }
 
     #[test]

--- a/nora-registry/src/config/registry/pypi.rs
+++ b/nora-registry/src/config/registry/pypi.rs
@@ -9,12 +9,51 @@ use std::env;
 pub struct PypiConfig {
     #[serde(default = "super::super::default_true")]
     pub enabled: bool,
+    /// Single upstream — retained for back-compat (`NORA_PYPI_PROXY`, old TOML).
+    /// Used only when `proxies` is empty; see [`PypiConfig::upstreams`].
     #[serde(default)]
     pub proxy: Option<String>,
     #[serde(default, skip_serializing)]
     pub proxy_auth: Option<ProtectedString>,
+    /// Ordered list of upstreams (#663). The order is the precedence: the first
+    /// upstream that lists/serves a file wins, like pip's `--index-url` ahead of
+    /// `--extra-index-url`.
+    #[serde(default)]
+    pub proxies: Vec<PypiProxyEntry>,
     #[serde(default = "super::super::default_timeout")]
     pub proxy_timeout: u64,
+}
+
+/// PyPI upstream proxy configuration (mirrors `MavenProxyEntry`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum PypiProxyEntry {
+    Simple(String),
+    Full(PypiProxy),
+}
+
+/// PyPI upstream proxy with optional auth.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PypiProxy {
+    pub url: String,
+    #[serde(default, skip_serializing)]
+    pub auth: Option<ProtectedString>,
+}
+
+impl PypiProxyEntry {
+    pub fn url(&self) -> &str {
+        match self {
+            PypiProxyEntry::Simple(s) => s,
+            PypiProxyEntry::Full(p) => &p.url,
+        }
+    }
+    pub fn auth(&self) -> Option<&str> {
+        use crate::secrets::expose_opt;
+        match self {
+            PypiProxyEntry::Simple(_) => None,
+            PypiProxyEntry::Full(p) => expose_opt(&p.auth),
+        }
+    }
 }
 
 impl Default for PypiConfig {
@@ -23,12 +62,36 @@ impl Default for PypiConfig {
             enabled: true,
             proxy: Some("https://pypi.org/simple/".to_string()),
             proxy_auth: None,
+            proxies: Vec::new(),
             proxy_timeout: 30,
         }
     }
 }
 
 impl PypiConfig {
+    /// Effective, precedence-ordered upstream list.
+    ///
+    /// `proxies` wins if non-empty (multi-upstream, #663); otherwise the legacy
+    /// single `proxy` (+ `proxy_auth`) is used so existing configs keep working;
+    /// empty means "no upstream, local-only".
+    pub fn upstreams(&self) -> Vec<PypiProxyEntry> {
+        if !self.proxies.is_empty() {
+            self.proxies.clone()
+        } else if let Some(url) = &self.proxy {
+            // Fold the legacy single proxy (+ optional auth) into one entry so
+            // back-compat users keep their authentication (not silently dropped).
+            vec![match &self.proxy_auth {
+                Some(auth) => PypiProxyEntry::Full(PypiProxy {
+                    url: url.clone(),
+                    auth: Some(auth.clone()),
+                }),
+                None => PypiProxyEntry::Simple(url.clone()),
+            }]
+        } else {
+            Vec::new()
+        }
+    }
+
     pub(in crate::config) fn apply_env_overrides(&mut self) {
         if let Ok(val) = env::var("NORA_PYPI_ENABLED") {
             self.enabled = val.to_lowercase() == "true" || val == "1";
@@ -43,8 +106,89 @@ impl PypiConfig {
                 Some(ProtectedString::new(val))
             };
         }
+        // Multi-upstream (#663): `url|auth,url2,url3|auth3` — same syntax as
+        // NORA_MAVEN_PROXIES. When set it takes precedence over NORA_PYPI_PROXY.
+        if let Ok(val) = env::var("NORA_PYPI_PROXIES") {
+            self.proxies = val
+                .split(',')
+                .filter(|s| !s.trim().is_empty())
+                .map(|s| {
+                    let parts: Vec<&str> = s.trim().splitn(2, '|').collect();
+                    if parts.len() > 1 {
+                        PypiProxyEntry::Full(PypiProxy {
+                            url: parts[0].to_string(),
+                            auth: Some(ProtectedString::from(parts[1])),
+                        })
+                    } else {
+                        PypiProxyEntry::Simple(parts[0].to_string())
+                    }
+                })
+                .collect();
+        }
         if let Ok(val) = env::var("NORA_PYPI_PROXY_TIMEOUT") {
             super::super::parse_env_warn("NORA_PYPI_PROXY_TIMEOUT", &val, &mut self.proxy_timeout);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upstreams_prefers_proxies_then_legacy_then_empty() {
+        // Default: legacy single proxy -> one upstream.
+        let c = PypiConfig::default();
+        let u = c.upstreams();
+        assert_eq!(u.len(), 1);
+        assert_eq!(u[0].url(), "https://pypi.org/simple/");
+
+        // Legacy proxy + auth folds into a Full entry (auth preserved).
+        let mut c = PypiConfig::default();
+        c.proxy_auth = Some(ProtectedString::new("tok".into()));
+        assert_eq!(c.upstreams()[0].auth(), Some("tok"));
+
+        // Explicit proxies win over the legacy single proxy.
+        let mut c = PypiConfig::default();
+        c.proxies = vec![
+            PypiProxyEntry::Simple("https://a/simple".into()),
+            PypiProxyEntry::Simple("https://b/simple".into()),
+        ];
+        let u = c.upstreams();
+        assert_eq!(u.len(), 2);
+        assert_eq!(u[0].url(), "https://a/simple");
+        assert_eq!(u[1].url(), "https://b/simple");
+
+        // No proxy at all -> empty (local-only).
+        let mut c = PypiConfig::default();
+        c.proxy = None;
+        assert!(c.upstreams().is_empty());
+    }
+
+    #[test]
+    fn env_proxies_parse_url_and_optional_auth() {
+        let mut c = PypiConfig::default();
+        // Simulate NORA_PYPI_PROXIES parsing inline (avoid global env in tests).
+        let val = "https://pypi.org/simple,https://download.pytorch.org/whl/cu124|sometoken";
+        c.proxies = val
+            .split(',')
+            .filter(|s| !s.trim().is_empty())
+            .map(|s| {
+                let parts: Vec<&str> = s.trim().splitn(2, '|').collect();
+                if parts.len() > 1 {
+                    PypiProxyEntry::Full(PypiProxy {
+                        url: parts[0].to_string(),
+                        auth: Some(ProtectedString::from(parts[1])),
+                    })
+                } else {
+                    PypiProxyEntry::Simple(parts[0].to_string())
+                }
+            })
+            .collect();
+        assert_eq!(c.proxies.len(), 2);
+        assert_eq!(c.proxies[0].url(), "https://pypi.org/simple");
+        assert_eq!(c.proxies[0].auth(), None);
+        assert_eq!(c.proxies[1].url(), "https://download.pytorch.org/whl/cu124");
+        assert_eq!(c.proxies[1].auth(), Some("sometoken"));
     }
 }

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -16,7 +16,6 @@ use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_text,
 };
 use crate::registry_type::RegistryType;
-use crate::secrets::expose_opt;
 use crate::ui::components::html_escape;
 use crate::validation::ends_with_ci;
 use crate::AppState;
@@ -163,49 +162,62 @@ async fn package_versions(
     // When proxy is configured, fetch upstream index and merge with local files.
     // This fixes the case where a cp314 wheel is cached but pip 3.10 needs to
     // see the full upstream file list to find a compatible cp310 wheel.
-    if let Some(proxy_url) = &state.config.pypi.proxy {
-        let url = format!("{}/{}/", proxy_url.trim_end_matches('/'), normalized);
-
-        match proxy_fetch_text(
-            &state.http_client,
-            &url,
-            Duration::from_secs(state.config.pypi.proxy_timeout),
-            expose_opt(&state.config.pypi.proxy_auth),
-            Some(("Accept", "text/html")),
-            &state.circuit_breaker,
-            RegistryType::PyPI,
-        )
-        .await
-        {
-            Ok(html) => {
-                let upstream_files = parse_upstream_files(&html);
-                let merged = merge_file_lists(upstream_files, &local_files);
-
-                if !merged.is_empty() {
-                    return if wants_json(&headers) {
-                        versions_json_response(&normalized, &merged, &base_url)
-                    } else {
-                        versions_html_response(&normalized, &merged, &base_url)
-                    };
+    // Fetch each configured upstream's index and merge them (#663). Precedence is
+    // the upstream order: the first upstream that lists a file wins (local files
+    // win over all upstreams). One upstream's failure or open breaker must not
+    // sink the others — skip it and serve the merge of what answered.
+    let upstreams = state.config.pypi.upstreams();
+    let mut circuit_open = false;
+    if !upstreams.is_empty() {
+        let mut upstream_files: Vec<FileEntry> = Vec::new();
+        for up in &upstreams {
+            let url = format!("{}/{}/", up.url().trim_end_matches('/'), normalized);
+            match proxy_fetch_text(
+                &state.http_client,
+                &url,
+                Duration::from_secs(state.config.pypi.proxy_timeout),
+                up.auth(),
+                Some(("Accept", "text/html")),
+                &state.circuit_breaker,
+                RegistryType::PyPI,
+            )
+            .await
+            {
+                Ok(html) => upstream_files.extend(parse_upstream_files(&html)),
+                Err(crate::registry::ProxyError::CircuitOpen(_)) => {
+                    circuit_open = true;
+                    continue;
+                }
+                Err(e) => {
+                    tracing::debug!(error = ?e, package = %normalized, upstream = %up.url(), "PyPI upstream index fetch failed, skipping");
+                    continue;
                 }
             }
-            Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
-                return circuit_open_response(&reg)
-            }
-            Err(e) => {
-                tracing::debug!(error = ?e, package = %normalized, "PyPI versions proxy fetch failed, falling through to local-only");
-            }
         }
-        tracing::warn!(registry = "pypi", package = %normalized, "Proxy failed, returning 404");
+        let merged = merge_file_lists(upstream_files, &local_files);
+        if !merged.is_empty() {
+            return if wants_json(&headers) {
+                versions_json_response(&normalized, &merged, &base_url)
+            } else {
+                versions_html_response(&normalized, &merged, &base_url)
+            };
+        }
     }
 
-    // No proxy configured, or proxy failed — return local files only
+    // Local files only — degrade gracefully when upstreams list nothing or are down.
     if !local_files.is_empty() {
         return if wants_json(&headers) {
             versions_json_response(&normalized, &local_files, &base_url)
         } else {
             versions_html_response(&normalized, &local_files, &base_url)
         };
+    }
+
+    // No upstream result and no local copy: a tripped breaker means the upstream is
+    // temporarily down — return 503 (retryable) rather than 404, which would poison
+    // pip's negative cache.
+    if circuit_open {
+        return circuit_open_response(RegistryType::PyPI.as_str());
     }
 
     StatusCode::NOT_FOUND.into_response()
@@ -292,82 +304,97 @@ async fn download_file(
             .into_response();
     }
 
-    // Try proxy if configured
-    if let Some(proxy_url) = &state.config.pypi.proxy {
-        let page_url = format!("{}/{}/", proxy_url.trim_end_matches('/'), normalized);
+    // Try each configured upstream in order; the first whose index lists the file
+    // serves it, fetched from that same upstream with that upstream's auth. One
+    // upstream's failure or open breaker skips to the next rather than failing (#663).
+    let mut circuit_open = false;
+    for up in &state.config.pypi.upstreams() {
+        let page_url = format!("{}/{}/", up.url().trim_end_matches('/'), normalized);
 
-        match proxy_fetch_text(
+        let html = match proxy_fetch_text(
             &state.http_client,
             &page_url,
             Duration::from_secs(state.config.pypi.proxy_timeout),
-            expose_opt(&state.config.pypi.proxy_auth),
+            up.auth(),
             Some(("Accept", "text/html")),
             &state.circuit_breaker,
             RegistryType::PyPI,
         )
         .await
         {
-            Ok(html) => {
-                if let Some(file_url) = find_file_url(&html, &filename) {
-                    match proxy_fetch(
-                        &state.http_client,
-                        &file_url,
-                        Duration::from_secs(state.config.pypi.proxy_timeout),
-                        expose_opt(&state.config.pypi.proxy_auth),
-                        &state.circuit_breaker,
-                        RegistryType::PyPI,
-                    )
-                    .await
-                    {
-                        Ok(data) => {
-                            state.metrics.record_download("pypi");
-                            state.metrics.record_cache_miss("pypi");
-                            state.activity.push(ActivityEntry::new(
-                                ActionType::ProxyFetch,
-                                format!("{}/{}", name, filename),
-                                "pypi",
-                                "PROXY",
-                            ));
-                            state
-                                .audit
-                                .log(AuditEntry::new("proxy_fetch", "api", "", "pypi", ""));
-
-                            // Cache in background + compute hash, invalidate AFTER write
-                            let storage = state.storage.clone();
-                            let key_clone = key.clone();
-                            let data_clone = data.clone();
-                            let repo_index = Arc::clone(&state.repo_index);
-                            tokio::spawn(async move {
-                                if storage.put(&key_clone, &data_clone).await.is_ok() {
-                                    let hash = hex::encode(sha2::Sha256::digest(&data_clone));
-                                    let _ = storage
-                                        .put(&format!("{}.sha256", key_clone), hash.as_bytes())
-                                        .await;
-                                    repo_index.invalidate("pypi");
-                                }
-                            });
-
-                            let content_type = pypi_content_type(&filename);
-                            return (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data)
-                                .into_response();
-                        }
-                        Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
-                            return circuit_open_response(&reg)
-                        }
-                        Err(e) => {
-                            tracing::debug!(error = ?e, package = %normalized, filename = %filename, "PyPI file proxy fetch failed");
-                        }
-                    }
-                }
-            }
-            Err(crate::registry::ProxyError::CircuitOpen(reg)) => {
-                return circuit_open_response(&reg)
+            Ok(html) => html,
+            Err(crate::registry::ProxyError::CircuitOpen(_)) => {
+                circuit_open = true;
+                continue;
             }
             Err(e) => {
-                tracing::debug!(error = ?e, package = %normalized, "PyPI page proxy fetch failed");
+                tracing::debug!(error = ?e, package = %normalized, upstream = %up.url(), "PyPI page proxy fetch failed, trying next upstream");
+                continue;
+            }
+        };
+
+        // The file may live on a later upstream — keep walking the list.
+        let Some(file_url) = find_file_url(&html, &filename) else {
+            continue;
+        };
+
+        match proxy_fetch(
+            &state.http_client,
+            &file_url,
+            Duration::from_secs(state.config.pypi.proxy_timeout),
+            up.auth(),
+            &state.circuit_breaker,
+            RegistryType::PyPI,
+        )
+        .await
+        {
+            Ok(data) => {
+                state.metrics.record_download("pypi");
+                state.metrics.record_cache_miss("pypi");
+                state.activity.push(ActivityEntry::new(
+                    ActionType::ProxyFetch,
+                    format!("{}/{}", name, filename),
+                    "pypi",
+                    "PROXY",
+                ));
+                state
+                    .audit
+                    .log(AuditEntry::new("proxy_fetch", "api", "", "pypi", ""));
+
+                // Cache in background + compute hash, invalidate AFTER write
+                let storage = state.storage.clone();
+                let key_clone = key.clone();
+                let data_clone = data.clone();
+                let repo_index = Arc::clone(&state.repo_index);
+                tokio::spawn(async move {
+                    if storage.put(&key_clone, &data_clone).await.is_ok() {
+                        let hash = hex::encode(sha2::Sha256::digest(&data_clone));
+                        let _ = storage
+                            .put(&format!("{}.sha256", key_clone), hash.as_bytes())
+                            .await;
+                        repo_index.invalidate("pypi");
+                    }
+                });
+
+                let content_type = pypi_content_type(&filename);
+                return (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data)
+                    .into_response();
+            }
+            Err(crate::registry::ProxyError::CircuitOpen(_)) => {
+                circuit_open = true;
+                continue;
+            }
+            Err(e) => {
+                tracing::debug!(error = ?e, package = %normalized, filename = %filename, upstream = %up.url(), "PyPI file proxy fetch failed, trying next upstream");
+                continue;
             }
         }
-        tracing::warn!(registry = "pypi", package = %normalized, filename = %filename, "Proxy failed, returning 404");
+    }
+
+    // A tripped breaker means an upstream is temporarily down — 503 (retryable)
+    // rather than 404, which would poison pip's negative cache.
+    if circuit_open {
+        return circuit_open_response(RegistryType::PyPI.as_str());
     }
 
     StatusCode::NOT_FOUND.into_response()
@@ -717,18 +744,27 @@ fn parse_upstream_files(html: &str) -> Vec<FileEntry> {
 /// Local entries take precedence (they have verified hashes from storage).
 /// Upstream entries are added only if no local file with the same name exists.
 fn merge_file_lists(upstream: Vec<FileEntry>, local: &[FileEntry]) -> Vec<FileEntry> {
-    let seen: std::collections::HashSet<&str> = local.iter().map(|f| f.filename.as_str()).collect();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut result = Vec::with_capacity(upstream.len() + local.len());
 
+    // Local first (highest precedence). Dedup local against itself too: storage
+    // listings are unique by construction, but keep the merge total so the output
+    // never carries a duplicate filename regardless of caller input.
     for f in local {
-        result.push(FileEntry {
-            filename: f.filename.clone(),
-            sha256: f.sha256.clone(),
-        });
+        if seen.insert(f.filename.clone()) {
+            result.push(FileEntry {
+                filename: f.filename.clone(),
+                sha256: f.sha256.clone(),
+            });
+        }
     }
 
+    // `upstream` is concatenated across upstreams in precedence order; keep the
+    // first entry seen for each filename so the highest-precedence upstream wins
+    // and a file present on several upstreams (or already local) is not listed
+    // twice (#663).
     for f in upstream {
-        if !seen.contains(f.filename.as_str()) {
+        if seen.insert(f.filename.clone()) {
             result.push(f);
         }
     }
@@ -1095,6 +1131,72 @@ mod tests {
     fn test_merge_both_empty() {
         let merged = merge_file_lists(vec![], &[]);
         assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn test_merge_first_upstream_wins_and_dedups() {
+        // Multi-upstream (#663): `upstream` is the upstreams concatenated in
+        // precedence order. The same filename from upstream A (first) and B must
+        // be deduped to a single entry, and A wins.
+        let upstream = vec![
+            FileEntry {
+                filename: "torch-1.0.whl".to_string(),
+                sha256: Some("from-A".to_string()),
+            },
+            FileEntry {
+                filename: "torch-1.0.whl".to_string(),
+                sha256: Some("from-B".to_string()),
+            },
+            FileEntry {
+                filename: "torchvision-1.0.whl".to_string(),
+                sha256: Some("from-B".to_string()),
+            },
+        ];
+        let merged = merge_file_lists(upstream, &[]);
+        assert_eq!(
+            merged.len(),
+            2,
+            "duplicate filename across upstreams deduped"
+        );
+        let torch = merged
+            .iter()
+            .find(|f| f.filename == "torch-1.0.whl")
+            .unwrap();
+        assert_eq!(
+            torch.sha256.as_deref(),
+            Some("from-A"),
+            "first upstream (A) wins precedence"
+        );
+        assert!(merged.iter().any(|f| f.filename == "torchvision-1.0.whl"));
+    }
+
+    proptest! {
+        #[test]
+        fn prop_merge_no_duplicate_filenames_and_local_wins(
+            upstream_names in prop::collection::vec("[a-z]{1,6}", 0..20),
+            local_names in prop::collection::vec("[a-z]{1,6}", 0..6),
+        ) {
+            let upstream: Vec<FileEntry> = upstream_names
+                .iter()
+                .map(|n| FileEntry { filename: n.clone(), sha256: None })
+                .collect();
+            let local: Vec<FileEntry> = local_names
+                .iter()
+                .map(|n| FileEntry { filename: n.clone(), sha256: Some("L".to_string()) })
+                .collect();
+            let merged = merge_file_lists(upstream, &local);
+            // No filename appears twice.
+            let mut seen = std::collections::HashSet::new();
+            for f in &merged {
+                prop_assert!(seen.insert(f.filename.clone()), "duplicate filename in merge");
+            }
+            // Every local file survives, and local wins on collision.
+            for ln in &local_names {
+                let e = merged.iter().find(|f| &f.filename == ln);
+                prop_assert!(e.is_some());
+                prop_assert_eq!(e.unwrap().sha256.as_deref(), Some("L"));
+            }
+        }
     }
 }
 

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -114,6 +114,7 @@ fn build_context(
             enabled: true,
             proxy: None,
             proxy_auth: None,
+            proxies: Vec::new(),
             proxy_timeout: 5,
         },
         go: GoConfig {


### PR DESCRIPTION
## Summary

Adds support for configuring an ordered list of PyPI upstream proxies instead of a single one, closing #663. The order is the precedence — the first upstream that lists or serves a file wins, like pip's `--index-url` ahead of `--extra-index-url`; locally cached/uploaded files always win.

## What changed

- **Config**: new `proxies: Vec<PypiProxyEntry>` (a bare URL string, or `{ url, auth }`) and a `NORA_PYPI_PROXIES` env var (`url|auth,url2` syntax, same shape as `NORA_MAVEN_PROXIES`). The legacy single `proxy` (+ `proxy_auth`) is folded into one upstream via `upstreams()`, so existing configs keep working and inline auth is never silently dropped.
- **Index merge** (`GET /simple/{name}/`): every configured upstream's index is fetched and merged; one upstream's failure or open circuit breaker skips to the next instead of sinking the request. A tripped breaker returns `503` (retryable) rather than `404`, which would poison pip's negative cache.
- **Download** (`GET /simple/{name}/{file}`): upstreams are walked in order; the file is served from the same upstream whose index listed it, with that upstream's auth (no index/wheel cross-origin desync).
- `merge_file_lists` dedups by filename (first / highest-precedence wins) and is total — duplicate inputs never produce a duplicate listing.
- Every configured upstream host is registered with the credential-leak detector (previously only the legacy single proxy was), and plaintext inline credentials in `config.toml` are warned about, matching the Maven path.

## Test plan

- `cargo test -p nora-registry` — 1351 passed / 0 failed
- New tests: upstream precedence + back-compat (`upstreams()`), `NORA_PYPI_PROXIES` parsing, merge dedup (unit + proptest), multi-upstream leak-detector coverage
- Back-compat verified: the default config and `NORA_PYPI_PROXY` / `NORA_PYPI_PROXY_AUTH` still resolve to a single pypi.org upstream

Closes #663
