### PR TITLE
fix(metrics): serve dashboard counters from Prometheus, drop metrics.json

### DIFF
--- a/nora-registry/src/dashboard_metrics.rs
+++ b/nora-registry/src/dashboard_metrics.rs
@@ -1,207 +1,102 @@
 // Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
+//! Dashboard activity counters — a thin facade over the Prometheus registry,
+//! which is the single source of truth (#626).
+//!
+//! Nothing is persisted. Earlier this module kept its own `AtomicU64` copy of
+//! every counter and flushed a `metrics.json` to disk every 30s — constant idle
+//! IOPS, and after a restart the UI showed the restored totals while `/metrics`
+//! started from zero (divergence). The Prometheus counters already track exactly
+//! the same events, so the dashboard now reads straight from them: no on-disk
+//! copy, no periodic write, and the UI numbers can never disagree with
+//! `/metrics`. Because Prometheus counters reset on process restart, the
+//! dashboard figures are "since restart" (the UI labels them so, anchored by the
+//! uptime shown alongside).
+
 use crate::metrics::{CACHE_REQUESTS, DOWNLOADS_TOTAL, UPLOADS_TOTAL};
 use crate::registry_type::RegistryType;
-use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::time::Instant;
-use tracing::{info, warn};
 
-/// Registry names derived from RegistryType (single source of truth).
+/// Registry names from `RegistryType` (single source of truth) for aggregation.
 fn registry_names() -> Vec<&'static str> {
     RegistryType::all().iter().map(|rt| rt.as_str()).collect()
 }
 
-/// Serializable snapshot of metrics for persistence.
-/// Uses HashMap for per-registry counters — adding a new registry only
-/// requires adding it to RegistryType enum (single source of truth).
-#[derive(Serialize, Deserialize, Default)]
-struct MetricsSnapshot {
-    downloads: u64,
-    uploads: u64,
-    cache_hits: u64,
-    cache_misses: u64,
-    #[serde(default)]
-    registry_downloads: HashMap<String, u64>,
-    #[serde(default)]
-    registry_uploads: HashMap<String, u64>,
-}
-
-/// Thread-safe atomic counter map for per-registry metrics.
-struct CounterMap(HashMap<String, AtomicU64>);
-
-impl CounterMap {
-    fn new(keys: &[&str]) -> Self {
-        let mut map = HashMap::with_capacity(keys.len());
-        for &k in keys {
-            map.insert(k.to_string(), AtomicU64::new(0));
-        }
-        Self(map)
-    }
-
-    fn inc(&self, key: &str) {
-        if let Some(counter) = self.0.get(key) {
-            counter.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-
-    fn get(&self, key: &str) -> u64 {
-        self.0
-            .get(key)
-            .map(|c| c.load(Ordering::Relaxed))
-            .unwrap_or(0)
-    }
-
-    fn snapshot(&self) -> HashMap<String, u64> {
-        self.0
-            .iter()
-            .map(|(k, v)| (k.clone(), v.load(Ordering::Relaxed)))
-            .collect()
-    }
-
-    fn load_from(&self, data: &HashMap<String, u64>) {
-        for (k, v) in data {
-            if let Some(counter) = self.0.get(k.as_str()) {
-                counter.store(*v, Ordering::Relaxed);
-            }
-        }
-    }
-}
-
-/// Dashboard metrics for tracking registry activity.
-/// Global counters are separate fields; per-registry counters use CounterMap.
-pub struct DashboardMetrics {
-    pub downloads: AtomicU64,
-    pub uploads: AtomicU64,
-    pub cache_hits: AtomicU64,
-    pub cache_misses: AtomicU64,
-
-    registry_downloads: CounterMap,
-    registry_uploads: CounterMap,
-
-    pub start_time: Instant,
-    persist_path: Option<PathBuf>,
-}
+/// Dashboard activity facade. Holds no state of its own — reads and writes both
+/// go to the process-global Prometheus counters, so the UI and `/metrics` stay
+/// in lock-step.
+#[derive(Default)]
+pub struct DashboardMetrics;
 
 impl DashboardMetrics {
     pub fn new() -> Self {
-        Self {
-            downloads: AtomicU64::new(0),
-            uploads: AtomicU64::new(0),
-            cache_hits: AtomicU64::new(0),
-            cache_misses: AtomicU64::new(0),
-            registry_downloads: CounterMap::new(&registry_names()),
-            registry_uploads: CounterMap::new(&registry_names()),
-            start_time: Instant::now(),
-            persist_path: None,
-        }
+        Self
     }
 
-    /// Create metrics with persistence — loads existing data from metrics.json
-    pub fn with_persistence(storage_path: &str) -> Self {
-        let path = Path::new(storage_path).join("metrics.json");
-        let mut metrics = Self::new();
-
-        if path.exists() {
-            match std::fs::read_to_string(&path) {
-                Ok(data) => match serde_json::from_str::<MetricsSnapshot>(&data) {
-                    Ok(snap) => {
-                        metrics.downloads = AtomicU64::new(snap.downloads);
-                        metrics.uploads = AtomicU64::new(snap.uploads);
-                        metrics.cache_hits = AtomicU64::new(snap.cache_hits);
-                        metrics.cache_misses = AtomicU64::new(snap.cache_misses);
-                        metrics
-                            .registry_downloads
-                            .load_from(&snap.registry_downloads);
-                        metrics.registry_uploads.load_from(&snap.registry_uploads);
-                        info!(
-                            downloads = snap.downloads,
-                            uploads = snap.uploads,
-                            "Loaded persisted metrics"
-                        );
-                    }
-                    Err(e) => warn!("Failed to parse metrics.json: {}", e),
-                },
-                Err(e) => warn!("Failed to read metrics.json: {}", e),
-            }
-        }
-
-        metrics.persist_path = Some(path);
-        metrics
-    }
-
-    /// Save current metrics to disk (async to avoid blocking the runtime)
-    pub async fn save(&self) {
-        let Some(path) = &self.persist_path else {
-            return;
-        };
-        let snap = MetricsSnapshot {
-            downloads: self.downloads.load(Ordering::Relaxed),
-            uploads: self.uploads.load(Ordering::Relaxed),
-            cache_hits: self.cache_hits.load(Ordering::Relaxed),
-            cache_misses: self.cache_misses.load(Ordering::Relaxed),
-            registry_downloads: self.registry_downloads.snapshot(),
-            registry_uploads: self.registry_uploads.snapshot(),
-        };
-        let tmp = path.with_extension("json.tmp");
-        if let Some(parent) = tmp.parent() {
-            let _ = tokio::fs::create_dir_all(parent).await;
-        }
-        if let Ok(data) = serde_json::to_string_pretty(&snap) {
-            if tokio::fs::write(&tmp, &data).await.is_ok() {
-                let _ = tokio::fs::rename(&tmp, path).await;
-            }
-        }
-    }
+    // ---- writes: increment the Prometheus counter (the only store) ----
 
     pub fn record_download(&self, registry: &str) {
-        self.downloads.fetch_add(1, Ordering::Relaxed);
-        self.registry_downloads.inc(registry);
         DOWNLOADS_TOTAL.with_label_values(&[registry]).inc();
     }
 
     pub fn record_upload(&self, registry: &str) {
-        self.uploads.fetch_add(1, Ordering::Relaxed);
-        self.registry_uploads.inc(registry);
         UPLOADS_TOTAL.with_label_values(&[registry]).inc();
     }
 
     pub fn record_cache_hit(&self, registry: &str) {
-        self.cache_hits.fetch_add(1, Ordering::Relaxed);
         CACHE_REQUESTS.with_label_values(&[registry, "hit"]).inc();
     }
 
     pub fn record_cache_miss(&self, registry: &str) {
-        self.cache_misses.fetch_add(1, Ordering::Relaxed);
         CACHE_REQUESTS.with_label_values(&[registry, "miss"]).inc();
     }
 
+    // ---- reads: derived from the Prometheus counters (since restart) ----
+
+    pub fn get_registry_downloads(&self, registry: &str) -> u64 {
+        DOWNLOADS_TOTAL.with_label_values(&[registry]).get()
+    }
+
+    pub fn get_registry_uploads(&self, registry: &str) -> u64 {
+        UPLOADS_TOTAL.with_label_values(&[registry]).get()
+    }
+
+    pub fn downloads(&self) -> u64 {
+        registry_names()
+            .iter()
+            .map(|&r| DOWNLOADS_TOTAL.with_label_values(&[r]).get())
+            .sum()
+    }
+
+    pub fn uploads(&self) -> u64 {
+        registry_names()
+            .iter()
+            .map(|&r| UPLOADS_TOTAL.with_label_values(&[r]).get())
+            .sum()
+    }
+
+    pub fn cache_hits(&self) -> u64 {
+        registry_names()
+            .iter()
+            .map(|&r| CACHE_REQUESTS.with_label_values(&[r, "hit"]).get())
+            .sum()
+    }
+
+    pub fn cache_misses(&self) -> u64 {
+        registry_names()
+            .iter()
+            .map(|&r| CACHE_REQUESTS.with_label_values(&[r, "miss"]).get())
+            .sum()
+    }
+
     pub fn cache_hit_rate(&self) -> f64 {
-        let hits = self.cache_hits.load(Ordering::Relaxed);
-        let misses = self.cache_misses.load(Ordering::Relaxed);
-        let total = hits + misses;
+        let hits = self.cache_hits();
+        let total = hits + self.cache_misses();
         if total == 0 {
             0.0
         } else {
             (hits as f64 / total as f64) * 100.0
         }
-    }
-
-    pub fn get_registry_downloads(&self, registry: &str) -> u64 {
-        self.registry_downloads.get(registry)
-    }
-
-    pub fn get_registry_uploads(&self, registry: &str) -> u64 {
-        self.registry_uploads.get(registry)
-    }
-}
-
-impl Default for DashboardMetrics {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -209,149 +104,78 @@ impl Default for DashboardMetrics {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
+
+    // The Prometheus counters are process-global and shared across all tests, so
+    // exact-value assertions would race under cargo's parallel test runner. Each
+    // test therefore uses a UNIQUE registry label (deterministic on its own
+    // series) and asserts the DELTA, or asserts a monotone lower bound for the
+    // global aggregate (`>= before + n`) which is parallel-safe.
 
     #[test]
-    fn test_new_defaults() {
+    fn record_download_increments_that_registry_series() {
         let m = DashboardMetrics::new();
-        assert_eq!(m.downloads.load(Ordering::Relaxed), 0);
-        assert_eq!(m.uploads.load(Ordering::Relaxed), 0);
-        assert_eq!(m.cache_hits.load(Ordering::Relaxed), 0);
-        assert_eq!(m.cache_misses.load(Ordering::Relaxed), 0);
+        let reg = "test-dl-unique-a";
+        let before = m.get_registry_downloads(reg);
+        m.record_download(reg);
+        m.record_download(reg);
+        assert_eq!(m.get_registry_downloads(reg) - before, 2);
     }
 
     #[test]
-    fn test_record_download_all_registries() {
+    fn record_upload_increments_that_registry_series() {
         let m = DashboardMetrics::new();
-        for reg in &["docker", "npm", "maven", "cargo", "pypi", "go", "raw"] {
-            m.record_download(reg);
-        }
-        assert_eq!(m.downloads.load(Ordering::Relaxed), 7);
-        assert_eq!(m.get_registry_downloads("docker"), 1);
-        assert_eq!(m.get_registry_downloads("npm"), 1);
-        assert_eq!(m.get_registry_downloads("maven"), 1);
-        assert_eq!(m.get_registry_downloads("cargo"), 1);
-        assert_eq!(m.get_registry_downloads("pypi"), 1);
-        assert_eq!(m.get_registry_downloads("go"), 1);
-        assert_eq!(m.get_registry_downloads("raw"), 1);
+        let reg = "test-ul-unique-b";
+        let before = m.get_registry_uploads(reg);
+        m.record_upload(reg);
+        assert_eq!(m.get_registry_uploads(reg) - before, 1);
     }
 
     #[test]
-    fn test_record_download_unknown_registry() {
+    fn downloads_aggregate_reflects_a_real_registry_record() {
+        // downloads() sums over RegistryType::all(); recording on a real registry
+        // must be included. `>= before + 1` is parallel-safe (other tests may add).
         let m = DashboardMetrics::new();
-        m.record_download("unknown");
-        assert_eq!(m.downloads.load(Ordering::Relaxed), 1);
-        assert_eq!(m.get_registry_downloads("docker"), 0);
+        let before = m.downloads();
+        m.record_download("docker");
+        assert!(m.downloads() >= before + 1);
     }
 
     #[test]
-    fn test_record_upload_all_registries() {
+    fn uploads_aggregate_reflects_a_real_registry_record() {
         let m = DashboardMetrics::new();
-        for reg in &["docker", "npm", "maven", "cargo", "pypi", "go", "raw"] {
-            m.record_upload(reg);
-        }
-        assert_eq!(m.uploads.load(Ordering::Relaxed), 7);
-        assert_eq!(m.get_registry_uploads("docker"), 1);
-        assert_eq!(m.get_registry_uploads("npm"), 1);
-        assert_eq!(m.get_registry_uploads("maven"), 1);
-        assert_eq!(m.get_registry_uploads("cargo"), 1);
-        assert_eq!(m.get_registry_uploads("pypi"), 1);
-        assert_eq!(m.get_registry_uploads("go"), 1);
-        assert_eq!(m.get_registry_uploads("raw"), 1);
+        let before = m.uploads();
+        m.record_upload("maven");
+        assert!(m.uploads() >= before + 1);
     }
 
     #[test]
-    fn test_record_upload_unknown_registry() {
-        let m = DashboardMetrics::new();
-        m.record_upload("npm");
-        assert_eq!(m.uploads.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn test_cache_hit_rate_zero() {
-        let m = DashboardMetrics::new();
-        assert_eq!(m.cache_hit_rate(), 0.0);
-    }
-
-    #[test]
-    fn test_cache_hit_rate_all_hits() {
+    fn cache_hit_rate_is_a_percentage_and_moves_with_hits() {
+        // Rate is global; assert the invariant (0..=100) and that a recorded hit
+        // keeps it strictly positive — without asserting an exact global value.
         let m = DashboardMetrics::new();
         m.record_cache_hit("docker");
-        m.record_cache_hit("docker");
-        assert_eq!(m.cache_hit_rate(), 100.0);
+        let rate = m.cache_hit_rate();
+        assert!((0.0..=100.0).contains(&rate));
+        assert!(m.cache_hits() >= 1);
     }
 
     #[test]
-    fn test_cache_hit_rate_mixed() {
+    fn unknown_registry_label_is_isolated() {
+        // A never-recorded unique label reads as 0 (its own series), independent
+        // of any other registry's traffic.
         let m = DashboardMetrics::new();
-        m.record_cache_hit("npm");
-        m.record_cache_miss("npm");
-        assert_eq!(m.cache_hit_rate(), 50.0);
+        assert_eq!(m.get_registry_downloads("test-never-recorded-zzz"), 0);
     }
 
     #[test]
-    fn test_get_registry_downloads() {
-        let m = DashboardMetrics::new();
-        m.record_download("docker");
-        m.record_download("docker");
-        m.record_download("npm");
-        assert_eq!(m.get_registry_downloads("docker"), 2);
-        assert_eq!(m.get_registry_downloads("npm"), 1);
-        assert_eq!(m.get_registry_downloads("cargo"), 0);
-        assert_eq!(m.get_registry_downloads("unknown"), 0);
-    }
-
-    #[test]
-    fn test_get_registry_uploads() {
-        let m = DashboardMetrics::new();
-        m.record_upload("docker");
-        assert_eq!(m.get_registry_uploads("docker"), 1);
-        assert_eq!(m.get_registry_uploads("maven"), 0);
-        assert_eq!(m.get_registry_uploads("unknown"), 0);
-    }
-
-    #[tokio::test]
-    async fn test_persistence_save_and_load() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().to_str().unwrap();
-
-        {
-            let m = DashboardMetrics::with_persistence(path);
-            m.record_download("docker");
-            m.record_download("docker");
-            m.record_upload("maven");
-            m.record_cache_hit("docker");
-            m.save().await;
-        }
-
-        {
-            let m = DashboardMetrics::with_persistence(path);
-            assert_eq!(m.downloads.load(Ordering::Relaxed), 2);
-            assert_eq!(m.uploads.load(Ordering::Relaxed), 1);
-            assert_eq!(m.get_registry_downloads("docker"), 2);
-            assert_eq!(m.get_registry_uploads("maven"), 1);
-            assert_eq!(m.cache_hits.load(Ordering::Relaxed), 1);
-        }
-    }
-
-    #[test]
-    fn test_persistence_missing_file() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().to_str().unwrap();
-        let m = DashboardMetrics::with_persistence(path);
-        assert_eq!(m.downloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
-    fn test_default() {
-        let m = DashboardMetrics::default();
-        assert_eq!(m.downloads.load(Ordering::Relaxed), 0);
-    }
-
-    #[test]
-    fn test_go_registry_supported() {
-        let m = DashboardMetrics::new();
-        m.record_download("go");
-        assert_eq!(m.get_registry_downloads("go"), 1);
+    fn record_is_stateless_across_instances() {
+        // Two facades share the same global counters (no per-instance state):
+        // recording via one is visible via the other.
+        let reg = "test-shared-instance-c";
+        let a = DashboardMetrics::new();
+        let b = DashboardMetrics::new();
+        let before = b.get_registry_downloads(reg);
+        a.record_download(reg);
+        assert_eq!(b.get_registry_downloads(reg) - before, 1);
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1420,7 +1420,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         startup_duration_ms,
         auth: auth.map(Arc::new),
         tokens,
-        metrics: Arc::new(DashboardMetrics::with_persistence(&storage_path)),
+        metrics: Arc::new(DashboardMetrics::new()),
         activity: Arc::new(ActivityLog::new(50)),
         audit: Arc::new(AuditLog::new(&storage_path, audit_mode)),
         docker_auth: Arc::new(docker_auth),
@@ -1585,7 +1585,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         "System endpoints"
     );
 
-    // Background task: persist metrics and flush token last_used every 30 seconds
+    // Background task: flush token last_used + periodic maintenance every 30 seconds
     let metrics_state = state.clone();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
@@ -1593,7 +1593,6 @@ async fn run_server(mut config: Config, storage: Storage) {
         loop {
             interval.tick().await;
             tick_count += 1;
-            metrics_state.metrics.save().await;
             if let Some(ref token_store) = metrics_state.tokens {
                 token_store.flush_last_used().await;
             }
@@ -1689,9 +1688,6 @@ async fn run_server(mut config: Config, storage: Storage) {
 
     // Drain audit log — AFTER schedulers finish so their final entries are captured (#543)
     state.audit.shutdown().await;
-
-    // Save metrics on shutdown
-    state.metrics.save().await;
 
     // Flush token last_used timestamps to disk
     if let Some(ref token_store) = state.tokens {

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -15,7 +15,6 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::atomic::Ordering;
 use utoipa::ToSchema;
 
 #[derive(Serialize)]
@@ -239,8 +238,8 @@ pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardRespo
     }
 
     let global_stats = GlobalStats {
-        downloads: state.metrics.downloads.load(Ordering::Relaxed),
-        uploads: state.metrics.uploads.load(Ordering::Relaxed),
+        downloads: state.metrics.downloads(),
+        uploads: state.metrics.uploads(),
         artifacts: total_artifacts as u64,
         cache_hit_percent: state.metrics.cache_hit_rate(),
         storage_bytes: total_storage,

--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -423,7 +423,7 @@ pub fn render_global_stats(
     let t = get_translations(lang);
     format!(
         r##"
-        <div class="grid grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-2 md:gap-4 mb-6">
+        <div class="grid grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-2 md:gap-4 mb-2">
             <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700">
                 <div class="text-slate-400 text-xs md:text-sm mb-0.5 md:mb-1 truncate">{}</div>
                 <div id="stat-downloads" class="text-base md:text-2xl font-bold text-slate-200">{}</div>
@@ -445,6 +445,7 @@ pub fn render_global_stats(
                 <div id="stat-storage" class="text-base md:text-2xl font-bold text-slate-200">{}</div>
             </div>
         </div>
+        <div class="text-slate-500 text-xs mb-6">&#9432; {}</div>
         "##,
         t.stat_downloads,
         downloads,
@@ -455,7 +456,8 @@ pub fn render_global_stats(
         t.stat_cache_hit,
         cache_hit_percent,
         t.stat_storage,
-        format_size(storage_bytes)
+        format_size(storage_bytes),
+        t.stats_since_restart
     )
 }
 

--- a/nora-registry/src/ui/i18n.rs
+++ b/nora-registry/src/ui/i18n.rs
@@ -46,6 +46,7 @@ pub struct Translations {
     pub stat_artifacts: &'static str,
     pub stat_cache_hit: &'static str,
     pub stat_storage: &'static str,
+    pub stats_since_restart: &'static str,
 
     // Registry cards
     pub active: &'static str,
@@ -161,6 +162,7 @@ pub static TRANSLATIONS_EN: Translations = Translations {
     stat_artifacts: "Artifacts",
     stat_cache_hit: "Cache Hit",
     stat_storage: "Storage",
+    stats_since_restart: "Counters since restart",
 
     // Registry cards
     active: "ACTIVE",
@@ -269,6 +271,7 @@ pub static TRANSLATIONS_RU: Translations = Translations {
     stat_artifacts: "Артефакты",
     stat_cache_hit: "Кэш",
     stat_storage: "Хранилище",
+    stats_since_restart: "счётчики с момента перезапуска",
 
     // Registry cards
     active: "АКТИВЕН",


### PR DESCRIPTION
## Summary

Fixes #626. The dashboard kept its own `AtomicU64` copy of every counter and flushed a `metrics.json` to disk every 30s (and on shutdown) — constant idle disk IOPS even when nothing changed, and after a restart the UI showed the restored totals while `/metrics` started from zero (the two diverged).

`DashboardMetrics` is now a thin facade over the Prometheus counters (`nora_downloads_total` / `nora_uploads_total` / `nora_cache_requests_total`), which already track the same events: `record_*` increments them and the read accessors sum them over `RegistryType::all()`. No on-disk copy, no periodic write, and the dashboard can no longer disagree with `/metrics`. Counters reset on process restart, so the figures are "since restart" — surfaced via a hover tooltip on the affected stat cards.

## What changed

- remove `metrics.json` persistence (`with_persistence` / `save` / `MetricsSnapshot` / `CounterMap` / the `AtomicU64` mirror)
- `main.rs`: drop the periodic and shutdown `save()` calls — the 30s background loop keeps doing token-flush / session cleanup / S3 size refresh
- ui: read via `downloads()` / `uploads()` accessors; the since-restart stat cards (downloads, uploads, cache hit) carry a "since restart" hover tooltip instead of cluttering the labels

## Test plan

- `cargo test -p nora-registry` — 1339 passed / 0 failed. New `dashboard_metrics` tests use unique registry labels + delta assertions so they stay deterministic under the parallel test runner (the counters are now process-global).
- Smoke (local + S3): upload + download → the dashboard API and `/metrics` agree (`downloads:1`, `uploads:1`), and **no `metrics.json` is written** to storage even past the 30s tick that used to write it.
- Metric names and labels are unchanged, so existing Grafana dashboards are unaffected.

## Notes

- Dashboard figures are now "since restart" (Prometheus counter semantics). For historical/cumulative totals, scrape `/metrics` into Prometheus and use `increase()` / `rate()`.
- An old deployment's `<storage>/metrics.json` becomes an orphan (nothing reads or writes it); it can be safely deleted.

Closes #626
