### PR TITLE
fix(ui): dashboard follow-ups — since-restart tooltip + all pypi upstreams

### DIFF
--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -219,7 +219,13 @@ pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardRespo
                 .collect(),
             RegistryType::Npm => state.config.npm.proxy.clone().into_iter().collect(),
             RegistryType::Cargo => state.config.cargo.proxy.clone().into_iter().collect(),
-            RegistryType::PyPI => state.config.pypi.proxy.clone().into_iter().collect(),
+            RegistryType::PyPI => state
+                .config
+                .pypi
+                .upstreams()
+                .iter()
+                .map(|u| u.url().to_string())
+                .collect(),
             RegistryType::Go => state.config.go.proxy.clone().into_iter().collect(),
             RegistryType::Raw => vec![],
             RegistryType::Gems => state.config.gems.proxy.clone().into_iter().collect(),

--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -421,14 +421,18 @@ pub fn render_global_stats(
     lang: Lang,
 ) -> String {
     let t = get_translations(lang);
+    // Downloads / uploads / cache-hit derive from Prometheus counters, which reset
+    // on process restart (#626). Rather than clutter the labels, each such card
+    // carries a hover tooltip (`title`) + a small ⓘ marker; current-state cards
+    // (artifacts, storage) have neither.
     format!(
         r##"
-        <div class="grid grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-2 md:gap-4 mb-2">
-            <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700">
+        <div class="grid grid-cols-3 md:grid-cols-3 lg:grid-cols-5 gap-2 md:gap-4 mb-6">
+            <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700 cursor-help" title="{}">
                 <div class="text-slate-400 text-xs md:text-sm mb-0.5 md:mb-1 truncate">{}</div>
                 <div id="stat-downloads" class="text-base md:text-2xl font-bold text-slate-200">{}</div>
             </div>
-            <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700">
+            <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700 cursor-help" title="{}">
                 <div class="text-slate-400 text-xs md:text-sm mb-0.5 md:mb-1 truncate">{}</div>
                 <div id="stat-uploads" class="text-base md:text-2xl font-bold text-slate-200">{}</div>
             </div>
@@ -436,7 +440,7 @@ pub fn render_global_stats(
                 <div class="text-slate-400 text-xs md:text-sm mb-0.5 md:mb-1 truncate">{}</div>
                 <div id="stat-artifacts" class="text-base md:text-2xl font-bold text-slate-200">{}</div>
             </div>
-            <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700">
+            <div class="bg-[#1e293b] rounded-lg p-2 md:p-4 border border-slate-700 cursor-help" title="{}">
                 <div class="text-slate-400 text-xs md:text-sm mb-0.5 md:mb-1 truncate">{}</div>
                 <div id="stat-cache-hit" class="text-base md:text-2xl font-bold text-slate-200">{:.1}%</div>
             </div>
@@ -445,19 +449,20 @@ pub fn render_global_stats(
                 <div id="stat-storage" class="text-base md:text-2xl font-bold text-slate-200">{}</div>
             </div>
         </div>
-        <div class="text-slate-500 text-xs mb-6">&#9432; {}</div>
         "##,
+        t.stats_since_restart,
         t.stat_downloads,
         downloads,
+        t.stats_since_restart,
         t.stat_uploads,
         uploads,
         t.stat_artifacts,
         artifacts,
+        t.stats_since_restart,
         t.stat_cache_hit,
         cache_hit_percent,
         t.stat_storage,
-        format_size(storage_bytes),
-        t.stats_since_restart
+        format_size(storage_bytes)
     )
 }
 

--- a/nora-registry/src/ui/i18n.rs
+++ b/nora-registry/src/ui/i18n.rs
@@ -162,7 +162,7 @@ pub static TRANSLATIONS_EN: Translations = Translations {
     stat_artifacts: "Artifacts",
     stat_cache_hit: "Cache Hit",
     stat_storage: "Storage",
-    stats_since_restart: "Counters since restart",
+    stats_since_restart: "since restart",
 
     // Registry cards
     active: "ACTIVE",
@@ -271,7 +271,7 @@ pub static TRANSLATIONS_RU: Translations = Translations {
     stat_artifacts: "Артефакты",
     stat_cache_hit: "Кэш",
     stat_storage: "Хранилище",
-    stats_since_restart: "счётчики с момента перезапуска",
+    stats_since_restart: "с момента перезапуска",
 
     // Registry cards
     active: "АКТИВЕН",


### PR DESCRIPTION
## Summary

Two small dashboard fixes on top of the merged metrics (#626) and multi-upstream (#663) work, both surfaced while reviewing the dashboard UI.

## What changed

- **Since-restart tooltip.** `#626` made the dashboard counters "since restart" (they reset on process restart, mirroring the Prometheus counters). That was conveyed by a standalone caption line under the stats grid, which read as clutter. The downloads / uploads / cache-hit cards now carry a `since restart` **hover tooltip** (`title` + a help cursor) instead; the labels stay clean and current-state cards (artifacts, storage) have no tooltip.
- **All PyPI upstreams in mount points.** The mount-points table built the PyPI upstream list from the legacy single `pypi.proxy`, so a multi-upstream config (`NORA_PYPI_PROXIES`, #663) showed only the legacy/default entry. It now builds from `pypi.upstreams()` — the same precedence-ordered source the handlers use — matching how Docker and Maven already render their upstream lists.

## Test plan

- `cargo test -p nora-registry` — ui suite green (32/0); fmt + clippy clean
- Verified on a running instance: the stat cards show the `since restart` tooltip on hover (no standalone caption); the mount-points table lists every configured Docker **and** PyPI upstream
