### PR TITLE
chore(release): 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "arc-swap",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.3"
+version = "0.9.4"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "0.9.3",
+        version = "0.9.4",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, and Conan",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -68,7 +68,14 @@ impl RegistryIndex {
     }
 
     pub fn count(&self) -> usize {
-        self.data.read().len()
+        // A directory that holds only generated metadata/sidecars — e.g. Maven's
+        // artifact-level `maven-metadata.xml`, which lands in the parent dir of
+        // the version dirs — materialises as a RepoInfo with zero versions. It
+        // is not a repository, so it must not inflate the per-registry count
+        // that `/api/ui/stats` and `nora_artifacts_total` report (it would show
+        // maven:2 for a single pushed jar). Size is unaffected: `total_size`
+        // sums every bucket, so `storage_bytes` stays == on-disk `du`.
+        self.data.read().iter().filter(|r| r.versions > 0).count()
     }
 
     /// Sum of artifact bytes in this registry's cached index (no rebuild).
@@ -789,6 +796,40 @@ mod tests {
         // size still sums every file on disk (du).
         let size: u64 = repos.iter().map(|r| r.size).sum();
         assert_eq!(size, 200 + 50 + 4 + 30);
+    }
+
+    #[tokio::test]
+    async fn maven_stats_count_excludes_metadata_only_dir() {
+        // Real layout (what a `mvn deploy` / proxy produces): the
+        // artifact-level `maven-metadata.xml` lands in the PARENT dir of the
+        // version dirs, so the on-disk tree has two directories for one jar:
+        //   maven/com/example/a/            <- metadata only (zero artifacts)
+        //   maven/com/example/a/1.0/        <- the jar (one artifact)
+        // The metadata-only dir is not a repository. `/api/ui/stats` and
+        // `nora_artifacts_total` (both read RegistryIndex::count via counts())
+        // must report maven:1 for the single pushed jar, NOT 2.
+        let (_d, s) = temp_storage();
+        s.put("maven/com/example/a/1.0/a-1.0.jar", &[0u8; 200])
+            .await
+            .unwrap();
+        s.put("maven/com/example/a/maven-metadata.xml", &[0u8; 30])
+            .await
+            .unwrap();
+
+        // Exercise the exact prod path /api/ui/stats walks: RepoIndex::get(...)
+        // builds + caches the index, then counts() reads it.
+        let idx = RepoIndex::new();
+        let repos = idx.get("maven", &s).await;
+        // Two on-disk dir buckets, but only one carries an artifact.
+        assert_eq!(repos.len(), 2, "both dirs are indexed buckets");
+        assert_eq!(
+            idx.counts().get(&RegistryType::Maven).copied().unwrap_or(0),
+            1,
+            "count must exclude the versions:0 metadata-only dir"
+        );
+        // Size still sums every on-disk file (du), metadata bytes included.
+        let size: u64 = repos.iter().map(|r| r.size).sum();
+        assert_eq!(size, 200 + 30, "metadata bytes still count toward size==du");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Release 0.9.4

Bumps the workspace + OpenAPI version to **0.9.4** and ships the per-registry
artifact-count fix surfaced by the RC acceptance run.

### Included
- **fix(ui):** exclude metadata-only dirs from the per-registry artifact count.
  Maven's artifact-level `maven-metadata.xml` lands in the parent of the version
  dirs and materialised as a `versions:0` RepoInfo, so `RegistryIndex::count()`
  (read by `/api/ui/stats` and `nora_artifacts_total`) reported maven:2 for a
  single jar — disagreeing with `/api/ui/dashboard` (sums versions) and disk.
  `count()` now counts only buckets with `versions > 0`; size is unchanged
  (`total_size` sums every bucket, so `storage_bytes` stays == on-disk `du`).
  Generic across all 13 registries. Regression test drives the real call-path
  (`RepoIndex::get -> counts()`) and fails on the pre-fix `data.len()` count.
- **chore(release):** version 0.9.3 -> 0.9.4 (Cargo.toml + Cargo.lock + OpenAPI).
  `CHANGELOG.md [0.9.4]` already prepared (#707).

### Validation
- `cargo test -p nora-registry --bin nora`: 1348 passed / 0 failed.
- `cargo fmt --check` + `clippy -D warnings`: clean.
- RC acceptance polygon on this code: config-matrix 256/256, non-functional,
  security (0 leaks), api-contract (0×5xx), e2e real clients, observability
  (dashboard↔/metrics lock-step), issue-regression (0 across 453 issues / since
  v0.7.0), deploy-matrix (root-owned-mount guard) — all green. disk↔web
  reconciled across all 13 registries.

### Release mechanics (after merge)
Tag `v0.9.4` on `main` triggers `release.yml`: amd64/arm64 binaries (+cosign),
Docker (alpine/RED OS/Astra, GHCR+Docker Hub), deb/rpm, SBOM, SLSA3, Trivy,
GitHub Release (git-cliff notes), and the `nora-release` dispatch that bumps the
Helm chart `appVersion`.
