### PR TITLE
docs: correct binary-size claim to < 27 MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Open [http://localhost:4000/ui/](http://localhost:4000/ui/) — your registry is
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/nora)](https://artifacthub.io/packages/helm/nora/nora)
 [![Docker Pulls](https://img.shields.io/docker/pulls/getnora/nora)](https://hub.docker.com/r/getnora/nora)
 
-**< 25 MB** binary | **< 50 MB** RAM idle | **3s** startup | **13** registries
+**< 27 MB** binary | **< 50 MB** RAM idle | **3s** startup | **13** registries
 
 ## Supported Registries
 
@@ -137,7 +137,7 @@ docker run -d -p 4000:4000 \
 |--------|------|-------|-------|
 | Startup | < 3s | 30-60s | 30-60s |
 | Memory | < 50 MB idle | 2-4 GB | 2-4 GB |
-| Binary | < 25 MB | 600+ MB | 1+ GB |
+| Binary | < 27 MB | 600+ MB | 1+ GB |
 
 ## Roadmap
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # NORA
 
-A lightweight, open-source artifact registry. 13 formats in a single < 23 MB binary: Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
+A lightweight, open-source artifact registry. 13 formats in a single < 27 MB binary: Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
 
 > The artifact registry that grows with you. Zero-config to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
 
@@ -179,13 +179,13 @@ cd nora && cargo build --release
 |--------|------|-------|-------------------|
 | Startup | < 3s | 30-60s | 30-60s |
 | Memory | < 50 MB idle | 2-4 GB | 2-4 GB |
-| Binary | < 23 MB | 600+ MB | 1+ GB |
+| Binary | < 27 MB | 600+ MB | 1+ GB |
 | Dependencies | None | Java 11+ | Java 11+ |
 | Database | None (filesystem) | Embedded/PostgreSQL | Embedded/PostgreSQL |
 
 ## How NORA compares to alternatives
 
-- vs Sonatype Nexus: NORA is 24x smaller (< 23 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
+- vs Sonatype Nexus: NORA is over 20x smaller (< 27 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
 - vs JFrog Artifactory: NORA is free and open-source with no feature gating. Artifactory has more enterprise features (replication, Xray scanning, RBAC)
 - vs Docker Distribution (registry:2): NORA adds 12 more formats, Web UI, upstream proxy, backup/restore, metrics. Distribution is Docker-only
 - vs Verdaccio: Verdaccio is npm-only. NORA handles npm plus 12 other formats


### PR DESCRIPTION
The headline + perf-table binary size in README (`< 25 MB`) and llms.txt (`< 23 MB`) understated the shipped artifact — the amd64 release binary is ~25.2 MB (arm64 ~22.6 MB), so both were false for amd64. Raised to `< 27 MB` (true for both arches, with headroom) and softened the Nexus comparison `24x` → `over 20x` to stay arithmetically honest. Caught + re-verified by the polygon's doc↔reality A/B check (`claims-verify.sh`); startup / idle-RAM / registry-count / endpoints claims verified accurate.