### PR TITLE
fix(config): allow partial config.toml by adding serde defaults for server and storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **Partial `config.toml`** — missing `[server]`, `[storage]`, or fields like `host`/`port` no longer prevent startup; serde defaults are applied for all unset values.
+
 ## [0.9.4] - 2026-06-13
 
 ### Added

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -100,7 +100,9 @@ pub(crate) fn parse_env_warn<T: std::str::FromStr + std::fmt::Display>(
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
+    #[serde(default)]
     pub server: ServerConfig,
+    #[serde(default)]
     pub storage: StorageConfig,
     #[serde(default)]
     pub maven: MavenConfig,
@@ -1320,6 +1322,40 @@ mod tests {
         assert_eq!(config.docker.upstreams.len(), 1);
         assert!(config.raw.enabled);
         assert!(!config.auth.enabled);
+    }
+
+    #[test]
+    fn test_config_from_toml_partial() {
+        // Missing host and port in [server] — should use defaults
+        let toml = r#"
+            [server]
+            [storage]
+            mode = "local"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 4000);
+        assert_eq!(config.storage.path, "data/storage");
+
+        // Missing [server] entirely — should use defaults
+        let toml = r#"
+            [storage]
+            mode = "local"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 4000);
+
+        // Missing [storage] entirely — should use defaults
+        let toml = r#"
+            [server]
+            host = "0.0.0.0"
+            port = 8080
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 8080);
+        assert_eq!(config.storage.mode, StorageMode::Local);
     }
 
     #[test]

--- a/nora-registry/src/config/server.rs
+++ b/nora-registry/src/config/server.rs
@@ -8,7 +8,9 @@ use std::env;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
+    #[serde(default = "default_server_host")]
     pub host: String,
+    #[serde(default = "default_server_port")]
     pub port: u16,
     /// Public URL for generating pull commands (e.g., "registry.example.com")
     #[serde(default)]
@@ -21,6 +23,14 @@ pub struct ServerConfig {
     /// every concurrent request fetch independently (kill-switch).
     #[serde(default = "default_proxy_coalesce")]
     pub proxy_coalesce: bool,
+}
+
+pub(super) fn default_server_host() -> String {
+    String::from("127.0.0.1")
+}
+
+pub(super) fn default_server_port() -> u16 {
+    4000
 }
 
 pub(super) fn default_body_limit_mb() -> usize {
@@ -37,6 +47,18 @@ pub struct TlsConfig {
     /// Path to PEM-encoded CA certificate bundle (appended to system CAs)
     #[serde(default)]
     pub ca_cert: Option<String>,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: default_server_host(),
+            port: default_server_port(),
+            public_url: None,
+            body_limit_mb: default_body_limit_mb(),
+            proxy_coalesce: default_proxy_coalesce(),
+        }
+    }
 }
 
 impl ServerConfig {

--- a/nora-registry/src/config/storage.rs
+++ b/nora-registry/src/config/storage.rs
@@ -52,6 +52,20 @@ pub(super) fn default_bucket() -> String {
     "registry".to_string()
 }
 
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            mode: StorageMode::Local,
+            path: default_storage_path(),
+            s3_url: default_s3_url(),
+            bucket: default_bucket(),
+            s3_access_key: None,
+            s3_secret_key: None,
+            s3_region: default_s3_region(),
+        }
+    }
+}
+
 impl StorageConfig {
     /// Apply environment variable overrides for storage config.
     ///


### PR DESCRIPTION
When config.toml exists but lacks certain values (e.g. host / port in [server], or a [server]/[storage] section entirely), serde deserialization failed and the app could not start. With these changes all unset fields fall back to sensible defaults.

- Added `#[serde(default)]` to `server` and `storage` in `Config`
- Added `#[serde(default = "...")]` for `host` and `port` in `ServerConfig`
- Added `impl Default` for `ServerConfig` and `StorageConfig`
- Updated CHANGELOG and added test