### PR TITLE
feat: add npm /-/whoami endpoint for token-based identity

### DIFF
--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -18,6 +18,10 @@ pub use namespace::{enforce_namespace_scope, NamespaceAuthority};
 pub use oidc::OidcValidator;
 pub use token_routes::{token_routes, TokenListItem, TokenListResponse};
 
+/// Authenticated username carried in request extensions after successful auth.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedUser(pub String);
+
 use axum::{
     body::Body,
     extract::{ConnectInfo, State},
@@ -177,6 +181,9 @@ pub async fn auth_middleware(
         request
             .extensions_mut()
             .insert(NamespaceAuthority::Unrestricted);
+        request
+            .extensions_mut()
+            .insert(AuthenticatedUser("anonymous".to_string()));
         return next.run(request).await;
     }
 
@@ -185,6 +192,9 @@ pub async fn auth_middleware(
         request
             .extensions_mut()
             .insert(NamespaceAuthority::Unrestricted);
+        request
+            .extensions_mut()
+            .insert(AuthenticatedUser("anonymous".to_string()));
         return next.run(request).await;
     }
 
@@ -199,7 +209,10 @@ pub async fn auth_middleware(
     // Token management always requires auth, even with anonymous_read
     let is_token_management = path.starts_with("/ui/tokens") || path.starts_with("/api/ui/tokens");
 
-    // Allow anonymous read if configured (but not for Docker /v2/ or token management)
+    // npm whoami always requires auth (otherwise it returns "anonymous" for every user)
+    let is_whoami = path.ends_with("/-/whoami");
+
+    // Allow anonymous read if configured (but not for Docker /v2/, token management, or whoami)
     let is_read_method = matches!(
         *request.method(),
         axum::http::Method::GET | axum::http::Method::HEAD
@@ -208,11 +221,15 @@ pub async fn auth_middleware(
         && is_read_method
         && !is_docker_challenge
         && !is_token_management
+        && !is_whoami
     {
         // Read requests allowed without auth
         request
             .extensions_mut()
             .insert(NamespaceAuthority::Unrestricted);
+        request
+            .extensions_mut()
+            .insert(AuthenticatedUser("anonymous".to_string()));
         return next.run(request).await;
     }
 
@@ -254,7 +271,7 @@ pub async fn auth_middleware(
         // 1. Try opaque token (nra_ prefix)
         if let Some(ref token_store) = state.tokens {
             match token_store.verify_token(token) {
-                Ok((_user, role)) => {
+                Ok((user, role)) => {
                     if let Some(ip) = client_ip {
                         state.auth_failures.record_success(&ip);
                     }
@@ -271,6 +288,7 @@ pub async fn auth_middleware(
                     request
                         .extensions_mut()
                         .insert(NamespaceAuthority::Unrestricted);
+                    request.extensions_mut().insert(AuthenticatedUser(user));
                     return next.run(request).await;
                 }
                 Err(_) => {
@@ -311,6 +329,9 @@ pub async fn auth_middleware(
                             identity.namespace_scope_enforcement,
                         );
                         request.extensions_mut().insert(authority);
+                        request
+                            .extensions_mut()
+                            .insert(AuthenticatedUser(identity.subject.clone()));
                         return next.run(request).await;
                     }
                     Err(_) => {
@@ -370,6 +391,9 @@ pub async fn auth_middleware(
     request
         .extensions_mut()
         .insert(NamespaceAuthority::Unrestricted);
+    request
+        .extensions_mut()
+        .insert(AuthenticatedUser(username.to_string()));
     next.run(request).await
 }
 

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -3,7 +3,7 @@
 
 use crate::activity_log::{ActionType, ActivityEntry};
 use crate::audit::AuditEntry;
-use crate::auth::{enforce_namespace_scope, NamespaceAuthority};
+use crate::auth::{enforce_namespace_scope, AuthenticatedUser, NamespaceAuthority};
 use crate::metrics::METADATA_CORRUPT_TOTAL;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_conditional,
@@ -106,12 +106,28 @@ fn replace_upstream_bytes(data: &[u8], upstream_url: &str, nora_npm_base: &str) 
     result
 }
 
+/// npm whoami handler: returns `{"username": "..."}`
+async fn handle_whoami(user: &AuthenticatedUser) -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        format!(r#"{{"username":"{}"}}"#, user.0),
+    )
+        .into_response()
+}
+
 // LOCK-SAFE: cache-through proxy — get miss → fetch upstream → put; no RMW race
 async fn handle_request(
     State(state): State<AppState>,
     headers: axum::http::HeaderMap,
     Path(path): Path<String>,
+    Extension(user): Extension<AuthenticatedUser>,
 ) -> Response {
+    // Handle npm whoami endpoint
+    if path == "-/whoami" {
+        return handle_whoami(&user).await;
+    }
+
     let is_tarball = path.contains("/-/");
 
     let key = if is_tarball {
@@ -1184,7 +1200,9 @@ mod tests {
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod integration_tests {
-    use crate::test_helpers::{body_bytes, create_test_context, send};
+    use crate::test_helpers::{
+        body_bytes, create_test_context, create_test_context_with_auth, send, send_with_headers,
+    };
 
     #[tokio::test]
     async fn test_npm_namespace_scope_enforced() {
@@ -1513,6 +1531,53 @@ mod integration_tests {
         let response = send(&ctx.app, Method::PUT, "/npm/newpkg", Body::from(body_bytes)).await;
 
         assert_eq!(response.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn test_npm_whoami_anonymous() {
+        use axum::http::StatusCode;
+
+        let ctx = create_test_context();
+        let resp = send(&ctx.app, axum::http::Method::GET, "/npm/-/whoami", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["username"], "anonymous");
+    }
+
+    #[tokio::test]
+    async fn test_npm_whoami_authenticated() {
+        use axum::http::StatusCode;
+        use base64::Engine;
+
+        let ctx = create_test_context_with_auth(&[("alice", "hunter2")]);
+
+        let basic = format!(
+            "Basic {}",
+            base64::engine::general_purpose::STANDARD.encode("alice:hunter2")
+        );
+        let resp = send_with_headers(
+            &ctx.app,
+            axum::http::Method::GET,
+            "/npm/-/whoami",
+            vec![("authorization", &basic)],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["username"], "alice");
+    }
+
+    #[tokio::test]
+    async fn test_npm_whoami_requires_auth() {
+        use axum::http::StatusCode;
+
+        let ctx = create_test_context_with_auth(&[("alice", "hunter2")]);
+
+        let resp = send(&ctx.app, axum::http::Method::GET, "/npm/-/whoami", "").await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }
 


### PR DESCRIPTION
## Summary

Implement the npm `/-/whoami` endpoint so that `npm whoami` works with tokens and basic auth.

## Changes

### `nora-registry/src/auth/mod.rs`

- Add `AuthenticatedUser(String)` struct that carries the authenticated username through request extensions
- Insert it in all auth paths (token, OIDC, basic auth, anonymous, auth-disabled)
- Exclude `/npm/-/whoami` from `anonymous_read` shortcut — otherwise it would always return `"anonymous"` regardless of credentials

### `nora-registry/src/registry/npm.rs`

- Add `handle_whoami()` that returns `{"username": "..."}` for `GET /npm/-/whoami`
- Wire it into the existing wildcard handler before any package lookup logic

## Why

npm CLI calls `GET /-/whoami` when resolving credentials for token-based auth (see `@npmcli/get-identity.js`). Without this endpoint, `npm whoami` and any command that internally verifies identity with a token will fail with `ENEEDAUTH`.

## How to use

Create an API token from the dashboard UI (`/ui/tokens`), then configure `.npmrc`:

```
//your-registry/npm/:_authToken=nra_xxxxxxxxxxxx
//your-registry/:_authToken=nra_xxxxxxxxxxxx
```

Due to npm's `nerfDart()` URL normalization inconsistency between `@npmcli/config` and `npm-registry-fetch`, two lines are needed to cover both `npm whoami` and `npm publish`.

## Limitations

`npm login` / `npm adduser` are **not** supported. Nora does not implement the CouchDB-style endpoints (`/-/v1/login`, `/-/user/org.couchdb.user:*`). To support those, the following would need to be added:

- `POST /npm/-/v1/login` — web-based OAuth login flow
- `PUT /npm/-/user/org.couchdb.user:{username}` — legacy CouchDB login
- Session token handling and OTP support

## Testing

- `test_npm_whoami_anonymous` — auth disabled, returns `{"username":"anonymous"}`
- `test_npm_whoami_authenticated` — basic auth, returns the authenticated username
- `test_npm_whoami_requires_auth` — no credentials, returns 401
- All 1353 existing tests pass