### PR TITLE
fix(docker): ship config defaults as a file so config.toml is not overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Fixed
 - **Partial `config.toml`** — missing `[server]`, `[storage]`, or fields like `host`/`port` no longer prevent startup; serde defaults are applied for all unset values.
+- **Container image no longer overrides `config.toml`** — the image shipped config *values* (`NORA_PUBLIC_URL`, `NORA_PORT`, `NORA_STORAGE_PATH`, `NORA_AUTH_TOKEN_STORAGE`) as baked `ENV`, which silently won over a user-provided `config.toml` (env has the highest precedence in `Config::load`). Defaults now ship as a file (`/etc/nora/config.toml`, loaded via `NORA_CONFIG_PATH`); a bind-mounted `config.toml` takes full effect. Only `NORA_HOST` stays in `ENV` so binding survives a partial mounted config and the container stays reachable (#719).
 
 ## [0.9.4] - 2026-06-13
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,10 +82,13 @@ COPY --from=builder --chown=nora:nora /nora /usr/local/bin/nora
 
 ENV RUST_LOG=info \
     NORA_HOST=:: \
-    NORA_PORT=4000 \
-    NORA_PUBLIC_URL=http://localhost:4000 \
-    NORA_STORAGE_PATH=/data/storage \
-    NORA_AUTH_TOKEN_STORAGE=/data/tokens
+    NORA_CONFIG_PATH=/etc/nora/config.toml
+
+# Config *values* ship as a FILE, not ENV: env has the highest precedence in
+# Config::load and would silently override a user-provided config.toml (#719).
+# Only NORA_HOST stays in ENV — binding must survive a bind-mounted (possibly
+# partial) config.toml so the container stays reachable (-e NORA_HOST to change).
+COPY --chown=nora:nora deploy/config.docker.toml /etc/nora/config.toml
 
 EXPOSE 4000
 VOLUME ["/data"]
@@ -110,10 +113,13 @@ COPY --from=builder --chown=nora:nora /nora /usr/local/bin/nora
 
 ENV RUST_LOG=info \
     NORA_HOST=:: \
-    NORA_PORT=4000 \
-    NORA_PUBLIC_URL=http://localhost:4000 \
-    NORA_STORAGE_PATH=/data/storage \
-    NORA_AUTH_TOKEN_STORAGE=/data/tokens
+    NORA_CONFIG_PATH=/etc/nora/config.toml
+
+# Config *values* ship as a FILE, not ENV: env has the highest precedence in
+# Config::load and would silently override a user-provided config.toml (#719).
+# Only NORA_HOST stays in ENV — binding must survive a bind-mounted (possibly
+# partial) config.toml so the container stays reachable (-e NORA_HOST to change).
+COPY --chown=nora:nora deploy/config.docker.toml /etc/nora/config.toml
 
 EXPOSE 4000
 VOLUME ["/data"]
@@ -137,10 +143,13 @@ COPY --from=builder --chown=nora:nora /nora /usr/local/bin/nora
 
 ENV RUST_LOG=info \
     NORA_HOST=:: \
-    NORA_PORT=4000 \
-    NORA_PUBLIC_URL=http://localhost:4000 \
-    NORA_STORAGE_PATH=/data/storage \
-    NORA_AUTH_TOKEN_STORAGE=/data/tokens
+    NORA_CONFIG_PATH=/etc/nora/config.toml
+
+# Config *values* ship as a FILE, not ENV: env has the highest precedence in
+# Config::load and would silently override a user-provided config.toml (#719).
+# Only NORA_HOST stays in ENV — binding must survive a bind-mounted (possibly
+# partial) config.toml so the container stays reachable (-e NORA_HOST to change).
+COPY --chown=nora:nora deploy/config.docker.toml /etc/nora/config.toml
 
 EXPOSE 4000
 VOLUME ["/data"]

--- a/deploy/Dockerfile.release
+++ b/deploy/Dockerfile.release
@@ -22,10 +22,13 @@ RUN chmod +x /usr/local/bin/nora
 
 ENV RUST_LOG=info \
     NORA_HOST=:: \
-    NORA_PORT=4000 \
-    NORA_PUBLIC_URL=http://localhost:4000 \
-    NORA_STORAGE_PATH=/data/storage \
-    NORA_AUTH_TOKEN_STORAGE=/data/tokens
+    NORA_CONFIG_PATH=/etc/nora/config.toml
+
+# Config *values* ship as a FILE, not ENV: env has the highest precedence in
+# Config::load and would silently override a user-provided config.toml (#719).
+# Only NORA_HOST stays in ENV — binding must survive a bind-mounted (possibly
+# partial) config.toml so the container stays reachable (-e NORA_HOST to change).
+COPY --chown=nora:nora deploy/config.docker.toml /etc/nora/config.toml
 
 EXPOSE 4000
 VOLUME ["/data"]

--- a/deploy/config.docker.toml
+++ b/deploy/config.docker.toml
@@ -1,0 +1,25 @@
+# Default configuration baked into the NORA container image, loaded via
+# NORA_CONFIG_PATH (set in the Dockerfile). It exists so the image is zero-config
+# out of the box WITHOUT baking config *values* as `ENV` defaults — `ENV` has the
+# highest precedence in Config::load and silently overrides a user-provided
+# config.toml (#719).
+#
+# The bind address is intentionally NOT here: the container sets it via the
+# `NORA_HOST` env var, so binding survives even when you bind-mount your own
+# (possibly partial) config.toml over this file — the container stays reachable.
+# Override with `-e NORA_HOST=0.0.0.0`.
+#
+# To customise the values below: bind-mount your own file over
+# /etc/nora/config.toml, or point NORA_CONFIG_PATH elsewhere. Individual
+# `-e NORA_*` env vars still override, by design (12-factor).
+
+[server]
+port = 4000
+public_url = "http://localhost:4000" # override for real deployments
+
+[storage]
+mode = "local"
+path = "/data/storage"               # backed by the /data volume
+
+[auth]
+token_storage = "/data/tokens"

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -1341,6 +1341,28 @@ mod tests {
         assert_eq!(from_empty_cfg.server, ServerConfig::default());
     }
 
+    /// The config shipped in the container image (deploy/config.docker.toml,
+    /// loaded via NORA_CONFIG_PATH) must be valid for THIS struct and yield the
+    /// intended container defaults — so the image is zero-config out of the box
+    /// without baking config values as env (#719). A renamed/typo'd key would
+    /// otherwise fall back to a default silently, reintroducing the bug. Host is
+    /// deliberately absent (the container sets it via NORA_HOST).
+    #[test]
+    fn test_shipped_docker_config_is_valid() {
+        let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../deploy/config.docker.toml");
+        let content =
+            std::fs::read_to_string(path).unwrap_or_else(|e| panic!("cannot read {path}: {e}"));
+        let config: Config = toml::from_str(&content).unwrap();
+        assert_eq!(config.server.port, 4000);
+        assert_eq!(
+            config.server.public_url.as_deref(),
+            Some("http://localhost:4000")
+        );
+        assert_eq!(config.storage.mode, StorageMode::Local);
+        assert_eq!(config.storage.path, "/data/storage");
+        assert_eq!(config.auth.token_storage, "/data/tokens");
+    }
+
     #[test]
     fn test_config_toml_docker_upstreams() {
         let toml = r#"


### PR DESCRIPTION
Fixes #719.

The container images baked config *values* as `ENV` defaults — `NORA_PUBLIC_URL`, `NORA_PORT`, `NORA_STORAGE_PATH`, `NORA_AUTH_TOKEN_STORAGE`. Env vars have the highest precedence in `Config::load` (applied after the config file), so these image defaults silently overrode a user-provided `config.toml`: a mounted config with `public_url = "https://example.com"` was ignored and the registry kept advertising `http://localhost:4000` in realms, tarball URLs and UI install commands. The same affected `storage.path`.

### Fix

Ship the defaults as a **file** instead of baked env values:

- `deploy/config.docker.toml` is `COPY`'d to `/etc/nora/config.toml` and loaded via `NORA_CONFIG_PATH`.
- A bind-mounted `config.toml` (over that path, or via your own `NORA_CONFIG_PATH`) now takes full effect.
- Only `NORA_HOST` stays in `ENV`: binding is a deployment concern that must survive a *partial* mounted config, otherwise the server would fall back to the `127.0.0.1` default and the container would be unreachable. Override with `-e NORA_HOST=0.0.0.0`.

Applied to `Dockerfile` (all three runtime stages) and `deploy/Dockerfile.release`. This is the same pattern Docker Distribution uses (ship a default config file; env vars are opt-in overrides, not baked values).

### Verification

- `test_shipped_docker_config_is_valid` asserts the shipped file parses to the `Config` struct and yields the intended container defaults — a typo'd/renamed key can no longer silently fall back to a default and reintroduce the bug.
- `cargo fmt --check`, `cargo clippy --package nora-registry -- -D warnings`, full `cargo test -p nora-registry` (1350 + 55 + 6) all green; both Dockerfiles pass `docker build --check`.
- Built a container from these exact `ENV`/`COPY` lines and ran it:
  - **zero-config:** loads `/etc/nora/config.toml`, binds `[::]:4000`, `/health` → 200, `public_url = http://localhost:4000` (works out of the box).
  - **partial mounted config** (`public_url = "https://example.com"`, no host): user value wins, container still binds `[::]:4000` via `NORA_HOST` and stays reachable.

### Note

`deploy/Dockerfile.astra` and `deploy/Dockerfile.redos` (FSTEC-certified bases, `NORA_HOST=0.0.0.0`, no `NORA_PUBLIC_URL`) carry the lesser `NORA_STORAGE_PATH` override only; left out of this PR to avoid changing certified-image binding without a build test — tracked as follow-up.

Closes #719
