### PR TITLE
fix(npm): escape whoami response with serde_json instead of format!

### DIFF
--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -108,12 +108,10 @@ fn replace_upstream_bytes(data: &[u8], upstream_url: &str, nora_npm_base: &str) 
 
 /// npm whoami handler: returns `{"username": "..."}`
 async fn handle_whoami(user: &AuthenticatedUser) -> Response {
-    (
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, "application/json")],
-        format!(r#"{{"username":"{}"}}"#, user.0),
-    )
-        .into_response()
+    // Serialize via serde_json, NOT format!: a username can contain `"` (e.g. the
+    // OIDC `sub` claim, which is not charset-validated) and would otherwise break
+    // the JSON or inject extra fields into the response.
+    axum::Json(serde_json::json!({ "username": user.0 })).into_response()
 }
 
 // LOCK-SAFE: cache-through proxy — get miss → fetch upstream → put; no RMW race
@@ -1578,6 +1576,20 @@ mod integration_tests {
 
         let resp = send(&ctx.app, axum::http::Method::GET, "/npm/-/whoami", "").await;
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // A username containing `"` (reachable via the OIDC `sub` claim) must NOT
+    // break the JSON or inject extra fields — handle_whoami serializes via serde.
+    #[tokio::test]
+    async fn test_npm_whoami_escapes_username() {
+        use crate::auth::AuthenticatedUser;
+
+        let evil = r#"a","admin":"x"#;
+        let resp = super::handle_whoami(&AuthenticatedUser(evil.to_string())).await;
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["username"], evil);
+        assert!(json.get("admin").is_none());
     }
 }
 


### PR DESCRIPTION
Follow-up hardening to #720 (npm `/-/whoami`).

`handle_whoami` built the response body by hand:

```rust
format!(r#"{{"username":"{}"}}"#, user.0)
```

This does not escape the username. The value flows in from the authenticated identity — including the **OIDC `sub` claim** (`auth/oidc.rs`: `subject = claims.sub.unwrap_or_default()`), which is **not charset-validated**. A username containing `"` breaks the JSON or injects extra fields:

```
username = a","admin":"x   ->   {"username":"a","admin":"x"}
```

The npm client only reads `username`, so direct exploitation is limited, but it's a JSON-injection antipattern and breaks for any legitimate name with a quote / backslash / control char.

### Fix

Serialize with `serde_json` (via `axum::Json`), which always escapes:

```rust
axum::Json(serde_json::json!({ "username": user.0 })).into_response()
```

`axum::Json` also sets `Content-Type: application/json`, so the manual header is no longer needed.

### Test

`test_npm_whoami_escapes_username` calls `handle_whoami` with `a","admin":"x` and asserts the body is valid JSON, `username` is the literal string, and no `admin` field was injected.

All four whoami tests pass; `cargo clippy --package nora-registry -- -D warnings` clean; 90 npm tests green.

Caught in review of #720; the auth trust boundary itself was verified sound (no bypass) — this is the one follow-up noted there.
