### PR TITLE
fix(storage): fsync parent dir after atomic rename for crash durability

### DIFF
--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -13,6 +13,25 @@ use super::{FileMeta, Result, StorageBackend, StorageError};
 /// Monotonic counter for unique temp file names (atomic — no collisions).
 static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
 
+/// fsync the parent directory of `path` so the directory entry written by a
+/// just-completed `rename` is durable across power-loss. The file's own data is
+/// fsync'd (`sync_all`) before the rename; the rename only becomes crash-durable
+/// once the *parent directory* is also fsync'd. Without this, a power-loss after
+/// `Ok` was returned can leave the file missing (or the old version) — violating
+/// the "Ok implies durable" contract (L3 durability). Fails closed: a parent that
+/// cannot be fsync'd means durability is not guaranteed, so we return Err.
+async fn sync_parent_dir(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        let dir = fs::File::open(parent)
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+        dir.sync_all()
+            .await
+            .map_err(|e| StorageError::Io(e.to_string()))?;
+    }
+    Ok(())
+}
+
 /// Local filesystem storage backend (zero-config default)
 pub struct LocalStorage {
     base_path: PathBuf,
@@ -84,6 +103,8 @@ impl StorageBackend for LocalStorage {
             fs::rename(&tmp, &path)
                 .await
                 .map_err(|e| StorageError::Io(e.to_string()))?;
+            // Durability: make the rename's directory entry survive power-loss.
+            sync_parent_dir(&path).await?;
             Ok(())
         }
         .await;
@@ -215,7 +236,11 @@ impl StorageBackend for LocalStorage {
         // Try atomic rename first; fall back to streaming copy on EXDEV
         // (cross-device link — src and dest on different filesystems).
         match fs::rename(src, &dest).await {
-            Ok(()) => Ok(()),
+            Ok(()) => {
+                // Durability: make the rename's directory entry survive power-loss.
+                sync_parent_dir(&dest).await?;
+                Ok(())
+            }
             Err(e) if e.raw_os_error() == Some(18 /* EXDEV */) => {
                 let mut reader = fs::File::open(src)
                     .await
@@ -243,9 +268,19 @@ impl StorageBackend for LocalStorage {
                         .flush()
                         .await
                         .map_err(|e| StorageError::Io(e.to_string()))?;
+                    // Durability: fsync the copied data before publishing it.
+                    // flush() only pushes to the OS; sync_all() makes it crash-
+                    // durable, matching the put() path (the direct-rename branch
+                    // relies on the caller having fsync'd src).
+                    writer
+                        .sync_all()
+                        .await
+                        .map_err(|e| StorageError::Io(e.to_string()))?;
                     fs::rename(&tmp, &dest)
                         .await
                         .map_err(|e| StorageError::Io(e.to_string()))?;
+                    // Durability: make the rename's directory entry durable.
+                    sync_parent_dir(&dest).await?;
                     Ok(())
                 }
                 .await;


### PR DESCRIPTION
## Summary
- The local backend fsync'd file data (`sync_all`) and renamed it into place, but never fsync'd the **parent directory** — so a power-loss after `Ok` was returned could lose the directory entry (file missing or reverted to the old version on reboot), breaking the "Ok implies durable" guarantee.
- Add `sync_parent_dir()` after **every** rename: `put()`, and both branches of `put_from_path()` (direct rename + the EXDEV streaming-copy fallback). Fails closed — if the parent cannot be fsync'd, `put()` returns `Err`.
- Also `sync_all()` the EXDEV-copied data before its rename (it previously only `flush()`'d, leaving the copied bytes non-durable before publish).

## Test plan
- [x] Full test suite green (1355 + 55 + 6 pass, 0 fail); storage round-trip / overwrite / concurrent-read / nested-dir paths exercise the new fsync.
- [x] `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean.
- [ ] Directory fsync is the standard durable-rename idiom; crash-durability itself is not unit-asserted (needs a fault-injection harness).