### PR TITLE
fix(curation): apply namespace isolation to metadata requests

### DIFF
--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -2734,8 +2734,7 @@ mod tests {
         let mut engine = CurationEngine::new(CurationConfig::default());
         let ns_filter = super::NamespaceFilter::new(vec!["@internal/*".to_string()]);
         engine.set_namespace_filter(Box::new(ns_filter));
-        let result =
-            super::check_namespace_isolation(&engine, RegistryType::Npm, "public-pkg");
+        let result = super::check_namespace_isolation(&engine, RegistryType::Npm, "public-pkg");
         assert!(result.is_none());
     }
 

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -329,6 +329,48 @@ pub fn check_download(
     }
 }
 
+/// Check namespace isolation only — no full curation pipeline.
+///
+/// Returns `Some(Response)` if the package name matches an internal namespace
+/// pattern. This prevents dependency confusion by ensuring internal packages
+/// are never fetched from upstream registries.
+///
+/// Unlike [`check_download`], this does NOT run the blocklist, allowlist, or
+/// min-release-age filters — it only evaluates the namespace filter.
+pub fn check_namespace_isolation(
+    engine: &CurationEngine,
+    registry: RegistryType,
+    name: &str,
+) -> Option<Response> {
+    let request = FilterRequest {
+        registry,
+        upstream: None,
+        name: name.to_string(),
+        version: None,
+        integrity: None,
+        bypass: false,
+        publish_date: None,
+    };
+
+    if let Some(ref ns_filter) = engine.namespace_filter {
+        let decision = ns_filter.evaluate(&request);
+        if let Decision::Block { rule, reason } = &decision {
+            engine.metrics.blocked.fetch_add(1, Ordering::Relaxed);
+            return Some(
+                BlockedResponse {
+                    rule: rule.clone(),
+                    reason: reason.clone(),
+                    registry: registry.to_string(),
+                    package: name.to_string(),
+                    version: None,
+                }
+                .into_response(),
+            );
+        }
+    }
+    None
+}
+
 /// Extract publish date from file mtime. ONLY for hosted registries —
 /// proxy mtime reflects cache time, not actual publish date.
 // TODO(#513): trust_upstream_dates config for high-security installs
@@ -2675,6 +2717,46 @@ mod tests {
             None,
         );
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_namespace_isolation_matches_blocks() {
+        let mut engine = CurationEngine::new(CurationConfig::default());
+        let ns_filter = super::NamespaceFilter::new(vec!["@internal/*".to_string()]);
+        engine.set_namespace_filter(Box::new(ns_filter));
+        let result = super::check_namespace_isolation(&engine, RegistryType::Npm, "@internal/pkg");
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_check_namespace_isolation_no_match_returns_none() {
+        let mut engine = CurationEngine::new(CurationConfig::default());
+        let ns_filter = super::NamespaceFilter::new(vec!["@internal/*".to_string()]);
+        engine.set_namespace_filter(Box::new(ns_filter));
+        let result =
+            super::check_namespace_isolation(&engine, RegistryType::Npm, "public-pkg");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_namespace_isolation_no_filter_returns_none() {
+        let engine = CurationEngine::new(CurationConfig::default());
+        let result = super::check_namespace_isolation(&engine, RegistryType::Npm, "@internal/pkg");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_check_namespace_isolation_active_even_in_off_mode() {
+        // Namespace isolation is always active, even when curation is Off
+        let mut engine = CurationEngine::new(CurationConfig {
+            mode: CurationMode::Off,
+            ..CurationConfig::default()
+        });
+        let ns_filter = super::NamespaceFilter::new(vec!["@internal/*".to_string()]);
+        engine.set_namespace_filter(Box::new(ns_filter));
+        let result = super::check_namespace_isolation(&engine, RegistryType::Npm, "@internal/pkg");
+        assert!(result.is_some());
     }
 
     // ================================================================

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -288,6 +288,18 @@ async fn handle_request(
         return with_content_type(true, data).into_response();
     }
 
+    // --- Namespace isolation: prevent proxying internal namespaces ---
+    // Metadata requests skip the curation check_download (which only runs for
+    // tarballs), so we must protect the proxy path separately. This runs after
+    // cache lookup so locally-published packages are still served from cache.
+    if let Some(response) = crate::curation::check_namespace_isolation(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Npm,
+        &package_name,
+    ) {
+        return response;
+    }
+
     // --- Proxy fetch path ---
     if let Some(proxy_url) = &state.config.npm.proxy {
         let url = format!("{}/{}", proxy_url.trim_end_matches('/'), path);


### PR DESCRIPTION
## Description

Namespace isolation (the `internal_namespaces` config) is designed to prevent dependency confusion by blocking proxy requests for packages matching internal namespace patterns. However, it was only enforced for **tarball downloads** — metadata requests (`GET /npm/@scope/name`) bypassed the check entirely and were proxied upstream, leaking internal package names.

When a metadata request for an internal namespace package (e.g. `@company/private-pkg`) was proxied to the public npm registry, it would fail with a 404 (since the package does not exist there), producing the log: `"Proxy failed, returning 404"`.

## Fix

1. Added `check_namespace_isolation()` to `curation.rs` — evaluates only the namespace filter (not the full blocklist/allowlist/min-release-age pipeline), so metadata stays unrestricted by other curation rules.

2. Called it from `handle_request()` in `npm.rs` **after cache miss but before proxy fetch**, so:
   - Locally-published internal packages are still served from cache
   - Internal packages not in cache get a 403 instead of being proxied
   - External packages are proxied as normal

## Key design decisions

- Runs **after** cache lookup → locally-published internal packages still work
- Does **not** run blocklist/allowlist filters → metadata stays unrestricted by other curation rules (those apply only to tarballs)
- Always active (even in `mode = "off"`) → matches existing namespace filter behavior
- Returns the standard blocked response format with `X-Nora-Decision: blocked`

## Testing

- Added 4 unit tests covering: matching block, no match, no filter configured, and active in off mode
- All 1359 tests pass (4 new + 1355 existing)
- `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test --lib --bin nora` all pass