### PR TITLE
docs(s3): correct the RustFS repository URL (dead link)

### DIFF
--- a/docs-site/src/content/docs/configuration/s3-storage.md
+++ b/docs-site/src/content/docs/configuration/s3-storage.md
@@ -102,7 +102,7 @@ Check MinIO Console at `http://localhost:9001` — you should see objects in the
 
 ## RustFS
 
-[RustFS](https://github.com/nicholasrust/rustfs) is a lightweight S3-compatible storage written in Rust. Configuration is identical to MinIO with one difference: the health check endpoint is `/health` instead of `/minio/health/live`.
+[RustFS](https://github.com/rustfs/rustfs) is a lightweight S3-compatible storage written in Rust. Configuration is identical to MinIO with one difference: the health check endpoint is `/health` instead of `/minio/health/live`.
 
 ### Docker Compose
 


### PR DESCRIPTION
## Summary
The RustFS link in the S3-storage docs points at `github.com/nicholasrust/rustfs`, which is a **404**. The real repository is `github.com/rustfs/rustfs`.

Re-applies the one-line fix from #726 (self-closed by its author moments after opening) — credited via `Co-authored-by`, thanks @tshaykhutdinov-smartlabs.

While here, the `/health` note on the same line was **verified against a running RustFS** (not changed, just confirmed): `GET /health` → 200 (`{"service":"rustfs-endpoint","status":"ok"}`), `GET /minio/health/live` → 403. So the whole line is now accurate.

## Test plan
- [x] old URL `nicholasrust/rustfs` returns 404; new URL `rustfs/rustfs` is the real repo
- [x] `/health` endpoint claim confirmed against a live RustFS instance