### PR TITLE
feat(curation): add server.trust_upstream_dates to harden min-release-age

### DIFF
--- a/nora-registry/src/config/server.rs
+++ b/nora-registry/src/config/server.rs
@@ -23,6 +23,18 @@ pub struct ServerConfig {
     /// every concurrent request fetch independently (kill-switch).
     #[serde(default = "default_proxy_coalesce")]
     pub proxy_coalesce: bool,
+    /// Trust upstream-provided publish dates (`published`/`time`/`created_at`/
+    /// `upload_time`/etc.) when enforcing `min_release_age` curation. Default
+    /// `false` (secure, ADR-8): an attacker controlling/MITM-ing an upstream
+    /// registry could spoof an OLD date so a freshly-published malicious package
+    /// appears old and bypasses the new-package quarantine. When `false`, NORA
+    /// derives the package age from its OWN cache timestamp (mtime) instead.
+    /// Set `true` to restore the legacy behavior of trusting upstream dates.
+    /// NB: with `false`, age is measured from when NORA first cached the
+    /// artifact (cache-age), not its real publish date — a long-published
+    /// package just cached will be quarantined for `min_release_age`.
+    #[serde(default = "default_trust_upstream_dates")]
+    pub trust_upstream_dates: bool,
 }
 
 pub(super) fn default_server_host() -> String {
@@ -41,6 +53,10 @@ pub(super) fn default_proxy_coalesce() -> bool {
     true
 }
 
+pub(super) fn default_trust_upstream_dates() -> bool {
+    false
+}
+
 /// TLS configuration for outbound connections to upstream registries.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct TlsConfig {
@@ -57,6 +73,7 @@ impl Default for ServerConfig {
             public_url: None,
             body_limit_mb: default_body_limit_mb(),
             proxy_coalesce: default_proxy_coalesce(),
+            trust_upstream_dates: default_trust_upstream_dates(),
         }
     }
 }
@@ -144,6 +161,13 @@ impl ServerConfig {
         if let Ok(val) = env::var("NORA_BODY_LIMIT_MB") {
             super::parse_env_warn("NORA_BODY_LIMIT_MB", &val, &mut self.body_limit_mb);
         }
+        if let Ok(val) = env::var("NORA_TRUST_UPSTREAM_DATES") {
+            super::parse_env_warn(
+                "NORA_TRUST_UPSTREAM_DATES",
+                &val,
+                &mut self.trust_upstream_dates,
+            );
+        }
     }
 }
 
@@ -158,6 +182,7 @@ mod tests {
             public_url: None,
             body_limit_mb: 2048,
             proxy_coalesce: true,
+            trust_upstream_dates: false,
         }
     }
 

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -371,9 +371,11 @@ pub fn check_namespace_isolation(
     None
 }
 
-/// Extract publish date from file mtime. ONLY for hosted registries —
-/// proxy mtime reflects cache time, not actual publish date.
-// TODO(#513): trust_upstream_dates config for high-security installs
+/// Extract publish date from file mtime. Used for hosted registries, and — when
+/// `server.trust_upstream_dates = false` — for proxy registries too (#513): the
+/// NORA-cache mtime is NORA-controlled, so it cannot be spoofed by an upstream
+/// registry the way an upstream-supplied `published`/`time`/etc. date can. NB in
+/// proxy mode this measures cache-age, not real publish date.
 pub async fn extract_mtime_as_publish_date(
     storage: &crate::storage::Storage,
     key: &str,

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -283,7 +283,13 @@ async fn download(
     // Extract publish date from cached Cargo metadata
     let publish_date = {
         let meta_key = format!("cargo/{}/metadata.json", crate_name);
-        extract_cargo_publish_date(&state.storage, &meta_key, &version).await
+        extract_cargo_publish_date(
+            &state.storage,
+            &meta_key,
+            &version,
+            state.config.server.trust_upstream_dates,
+        )
+        .await
     };
 
     // Curation check — before storage access
@@ -779,7 +785,12 @@ async fn extract_cargo_publish_date(
     storage: &crate::storage::Storage,
     metadata_key: &str,
     version: &str,
+    trust_upstream: bool,
 ) -> Option<i64> {
+    // #513: untrusted upstream dates → NORA cache mtime, never upstream created_at.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, metadata_key).await;
+    }
     let data = storage.get(metadata_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let versions = json.get("versions")?.as_array()?;

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -309,7 +309,15 @@ async fn recipe_file_download(
     let artifact = format!("{} rrev={} {}", ref_str, rrev, filename);
 
     // Extract publish date from cached revision metadata
-    let publish_date = extract_conan_publish_date(&state.storage, &name, &ver, &user, &chan).await;
+    let publish_date = extract_conan_publish_date(
+        &state.storage,
+        &name,
+        &ver,
+        &user,
+        &chan,
+        state.config.server.trust_upstream_dates,
+    )
+    .await;
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
@@ -588,7 +596,15 @@ async fn package_file_download(
     let artifact = format!("{}#{}:{}#{} {}", ref_str, rrev, pkg_id, prev, filename);
 
     // Extract publish date from cached revision metadata
-    let publish_date = extract_conan_publish_date(&state.storage, &name, &ver, &user, &chan).await;
+    let publish_date = extract_conan_publish_date(
+        &state.storage,
+        &name,
+        &ver,
+        &user,
+        &chan,
+        state.config.server.trust_upstream_dates,
+    )
+    .await;
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
@@ -871,16 +887,20 @@ async fn fetch_and_cache_immutable_json(
 /// ```json
 /// { "revision": "abc123", "time": "2024-01-15T10:30:00.000+0000" }
 /// ```
-// TODO(#513): trust_upstream_dates config for high-security installs
 async fn extract_conan_publish_date(
     storage: &crate::storage::Storage,
     name: &str,
     ver: &str,
     user: &str,
     chan: &str,
+    trust_upstream: bool,
 ) -> Option<i64> {
     let ref_str = format!("{}/{}/{}/{}", name, ver, user, chan);
     let meta_key = format!("conan/{}/latest.json", ref_str);
+    // #513: untrusted upstream dates → NORA cache mtime, never upstream time.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, &meta_key).await;
+    }
     let data = storage.get(&meta_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let date_str = json.get("time")?.as_str()?;
@@ -1304,8 +1324,51 @@ mod integration_tests {
             .await
             .unwrap();
 
-        let result = super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_").await;
+        let result =
+            super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_", true).await;
         assert!(result.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_conan_untrusted_dates_use_cache_mtime_not_upstream() {
+        // #513: with trust=false, a spoofed-OLD upstream `time` must be ignored
+        // and NORA's own cache mtime used instead, so an attacker cannot backdate
+        // a freshly-published package past the min-release-age quarantine.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let meta = serde_json::json!({ "revision": "r1", "time": "2000-01-01T00:00:00.000+0000" });
+        storage
+            .put(
+                "conan/zlib/1.3/_/_/latest.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+
+        let trusted =
+            super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_", true).await;
+        let untrusted =
+            super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_", false).await;
+
+        // trust=true honors the (spoofed, old) upstream date
+        assert_eq!(trusted, Some(946_684_800)); // 2000-01-01T00:00:00Z
+                                                // trust=false ignores it and uses the recent cache mtime instead
+        let untrusted = untrusted.expect("cached file has an mtime");
+        assert!(
+            untrusted > 946_684_800,
+            "trust=false must use recent cache mtime, not the old upstream date (got {untrusted})"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_conan_untrusted_dates_fail_closed_when_uncached() {
+        // #513 fail-closed: trust=false with no cached metadata yields None, which
+        // curation's min-release-age treats as Block — never a bypass.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
+        let result =
+            super::extract_conan_publish_date(&storage, "uncached", "1.0", "_", "_", false).await;
+        assert_eq!(result, None);
     }
 
     #[tokio::test]
@@ -1321,7 +1384,8 @@ mod integration_tests {
             .await
             .unwrap();
 
-        let result = super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_").await;
+        let result =
+            super::extract_conan_publish_date(&storage, "zlib", "1.3", "_", "_", true).await;
         assert!(result.is_none());
     }
 
@@ -1331,7 +1395,7 @@ mod integration_tests {
         let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
 
         let result =
-            super::extract_conan_publish_date(&storage, "nonexistent", "1.0", "_", "_").await;
+            super::extract_conan_publish_date(&storage, "nonexistent", "1.0", "_", "_", true).await;
         assert!(result.is_none());
     }
 

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -2855,8 +2855,9 @@ fn detect_manifest_media_type(data: &[u8]) -> String {
 /// Extract publish date from Docker manifest `.meta.json` sidecar.
 ///
 /// Docker metadata sidecar stores `push_timestamp` (Unix seconds) when the
-/// manifest was first pushed or cached.
-// TODO(#513): trust_upstream_dates config for high-security installs
+/// manifest was first pushed or cached. This is a NORA-side timestamp (not an
+/// upstream-supplied date), so it is unaffected by `server.trust_upstream_dates`
+/// (#513) — there is no spoofable upstream date on this path.
 async fn extract_docker_publish_date(
     storage: &Storage,
     name: &str,

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -79,7 +79,12 @@ async fn handle(
         // Extract publish date from cached .info file
         let publish_date = if let Some(ref ver) = version {
             let info_key = format!("go/{}/@v/{}.info", module_encoded, ver);
-            extract_go_publish_date(&state.storage, &info_key).await
+            extract_go_publish_date(
+                &state.storage,
+                &info_key,
+                state.config.server.trust_upstream_dates,
+            )
+            .await
         } else {
             None
         };
@@ -280,7 +285,15 @@ async fn handle(
 /// ```json
 /// { "Version": "v1.0.0", "Time": "2024-01-15T10:30:00Z" }
 /// ```
-async fn extract_go_publish_date(storage: &crate::storage::Storage, info_key: &str) -> Option<i64> {
+async fn extract_go_publish_date(
+    storage: &crate::storage::Storage,
+    info_key: &str,
+    trust_upstream: bool,
+) -> Option<i64> {
+    // #513: untrusted upstream dates → NORA cache mtime, never upstream .info Time.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, info_key).await;
+    }
     let data = storage.get(info_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let date_str = json.get("Time")?.as_str()?;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -158,7 +158,13 @@ async fn handle_request(
         // Extract publish date from cached metadata (npm time field)
         let publish_date = if let Some(ref ver) = tarball_version {
             let meta_key = format!("npm/{}/metadata.json", package_name);
-            extract_npm_publish_date(&state.storage, &meta_key, ver).await
+            extract_npm_publish_date(
+                &state.storage,
+                &meta_key,
+                ver,
+                state.config.server.trust_upstream_dates,
+            )
+            .await
         } else {
             None
         };
@@ -872,7 +878,14 @@ async fn extract_npm_publish_date(
     storage: &crate::storage::Storage,
     metadata_key: &str,
     version: &str,
+    trust_upstream: bool,
 ) -> Option<i64> {
+    // #513: when upstream dates are not trusted, derive age from NORA's own
+    // cache mtime instead of the (spoofable) upstream metadata date. Never fall
+    // back to the upstream date here — that would reopen the spoof vector.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, metadata_key).await;
+    }
     let data = storage.get(metadata_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let date_str = json.get("time")?.get(version)?.as_str()?;

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -769,7 +769,13 @@ async fn flatcontainer_download(
     // Curation check for .nupkg downloads
     if ends_with_ci(filename, ".nupkg") {
         // Extract publish date from cached registration index
-        let publish_date = extract_nuget_publish_date(&state.storage, &id_lower, ver).await;
+        let publish_date = extract_nuget_publish_date(
+            &state.storage,
+            &id_lower,
+            ver,
+            state.config.server.trust_upstream_dates,
+        )
+        .await;
 
         if let Some(response) = crate::curation::check_download(
             &state.curation().curation_engine,
@@ -1000,13 +1006,17 @@ fn serve_stale_or_not_found(
 /// ```json
 /// { "items": [{ "items": [{ "catalogEntry": { "version": "1.0.0", "published": "2024-01-15T10:30:00Z" } }] }] }
 /// ```
-// TODO(#513): trust_upstream_dates config for high-security installs
 async fn extract_nuget_publish_date(
     storage: &crate::storage::Storage,
     id: &str,
     version: &str,
+    trust_upstream: bool,
 ) -> Option<i64> {
     let meta_key = format!("nuget/registration/{}/index.json", id.to_lowercase());
+    // #513: untrusted upstream dates → NORA cache mtime, never upstream published.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, &meta_key).await;
+    }
     let data = storage.get(&meta_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let pages = json.get("items")?.as_array()?;
@@ -1869,7 +1879,8 @@ mod integration_tests {
             .await
             .unwrap();
 
-        let result = super::extract_nuget_publish_date(&storage, "newtonsoft.json", "6.0.0").await;
+        let result =
+            super::extract_nuget_publish_date(&storage, "newtonsoft.json", "6.0.0", true).await;
         assert!(result.is_some());
     }
 
@@ -1888,7 +1899,7 @@ mod integration_tests {
             .await
             .unwrap();
 
-        let result = super::extract_nuget_publish_date(&storage, "test", "9.9.9").await;
+        let result = super::extract_nuget_publish_date(&storage, "test", "9.9.9", true).await;
         assert!(result.is_none());
     }
 
@@ -1897,7 +1908,8 @@ mod integration_tests {
         let dir = tempfile::tempdir().unwrap();
         let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
 
-        let result = super::extract_nuget_publish_date(&storage, "nonexistent", "1.0.0").await;
+        let result =
+            super::extract_nuget_publish_date(&storage, "nonexistent", "1.0.0", true).await;
         assert!(result.is_none());
     }
 
@@ -1931,7 +1943,7 @@ mod integration_tests {
             .unwrap();
 
         // Before #535 fix: this returned None because page 0 had no "items".
-        let result = super::extract_nuget_publish_date(&storage, "sparse-pkg", "2.0.0").await;
+        let result = super::extract_nuget_publish_date(&storage, "sparse-pkg", "2.0.0", true).await;
         assert!(result.is_some(), "date must be found despite sparse page 0");
     }
 

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -405,7 +405,13 @@ async fn download_archive(
     }
 
     // Extract publish date from cached metadata (works for both hosted and proxy)
-    let publish_date = extract_pub_publish_date(&state.storage, &package, version).await;
+    let publish_date = extract_pub_publish_date(
+        &state.storage,
+        &package,
+        version,
+        state.config.server.trust_upstream_dates,
+    )
+    .await;
 
     // Curation check
     if let Some(response) = crate::curation::check_download(
@@ -784,8 +790,13 @@ async fn extract_pub_publish_date(
     storage: &crate::storage::Storage,
     package: &str,
     version: &str,
+    trust_upstream: bool,
 ) -> Option<i64> {
     let meta_key = format!("pub/api/packages/{}.json", package);
+    // #513: untrusted upstream dates → NORA cache mtime, never upstream published.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, &meta_key).await;
+    }
     let data = storage.get(&meta_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let versions = json.get("versions")?.as_array()?;
@@ -1195,7 +1206,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = super::extract_pub_publish_date(&storage, "http", "1.0.0").await;
+        let result = super::extract_pub_publish_date(&storage, "http", "1.0.0", true).await;
         assert!(result.is_some());
     }
 
@@ -1215,7 +1226,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = super::extract_pub_publish_date(&storage, "http", "2.0.0").await;
+        let result = super::extract_pub_publish_date(&storage, "http", "2.0.0", true).await;
         assert!(result.is_none());
     }
 
@@ -1224,7 +1235,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let storage = crate::storage::Storage::new_local(dir.path().join("data").to_str().unwrap());
 
-        let result = super::extract_pub_publish_date(&storage, "nonexistent", "1.0.0").await;
+        let result = super::extract_pub_publish_date(&storage, "nonexistent", "1.0.0", true).await;
         assert!(result.is_none());
     }
 

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -242,7 +242,13 @@ async fn download_file(
     // Extract publish date from cached PyPI metadata
     let publish_date = if let Some(ref ver) = version {
         let meta_key = format!("pypi/{}/metadata.json", normalized);
-        extract_pypi_publish_date(&state.storage, &meta_key, ver).await
+        extract_pypi_publish_date(
+            &state.storage,
+            &meta_key,
+            ver,
+            state.config.server.trust_upstream_dates,
+        )
+        .await
     } else {
         None
     };
@@ -651,7 +657,13 @@ async fn extract_pypi_publish_date(
     storage: &crate::storage::Storage,
     metadata_key: &str,
     version: &str,
+    trust_upstream: bool,
 ) -> Option<i64> {
+    // #513: untrusted upstream dates → use NORA's own cache mtime, never the
+    // (spoofable) upstream upload_time.
+    if !trust_upstream {
+        return crate::curation::extract_mtime_as_publish_date(storage, metadata_key).await;
+    }
     let data = storage.get(metadata_key).await.ok()?;
     let json: serde_json::Value = serde_json::from_slice(&data).ok()?;
     let files = json.get("releases")?.get(version)?.as_array()?;

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -628,25 +628,30 @@ async fn module_source_download(
 ///
 /// Terraform registry API does not reliably include `published_at` in the
 /// versions listing. Falls back to mtime for hosted-only mode.
-// TODO(#513): trust_upstream_dates config for high-security installs
 async fn extract_terraform_publish_date(
     state: &AppState,
     ns: &str,
     ptype: &str,
     ver: &str,
 ) -> Option<i64> {
-    // Try download metadata JSON (per-version cached file)
-    let storage_key = format!("terraform/providers/{}/{}/{}/download.json", ns, ptype, ver);
-    if let Ok(data) = state.storage.get(&storage_key).await {
-        if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&data) {
-            if let Some(date_str) = json.get("published_at").and_then(|v| v.as_str()) {
-                return crate::curation::parse_iso8601_to_unix(date_str);
+    // #513: only consult the upstream-provided `published_at` when configured to
+    // trust upstream dates (an attacker controlling upstream could spoof it).
+    if state.config.server.trust_upstream_dates {
+        // Try download metadata JSON (per-version cached file)
+        let storage_key = format!("terraform/providers/{}/{}/{}/download.json", ns, ptype, ver);
+        if let Ok(data) = state.storage.get(&storage_key).await {
+            if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&data) {
+                if let Some(date_str) = json.get("published_at").and_then(|v| v.as_str()) {
+                    return crate::curation::parse_iso8601_to_unix(date_str);
+                }
             }
         }
     }
 
-    // mtime fallback — only for hosted mode (proxy mtime = cache time)
-    if state.config.terraform.proxy.is_none() {
+    // mtime fallback — NORA's own cache time. Fires for hosted mode (where mtime
+    // ≈ first-publish) and whenever upstream dates are not trusted (#513). In
+    // proxy mode with trust=true it stays disabled (cache time != publish time).
+    if state.config.terraform.proxy.is_none() || !state.config.server.trust_upstream_dates {
         // Try any cached platform-specific metadata
         for suffix in &["linux_amd64.json", "linux_arm64.json", "darwin_amd64.json"] {
             let meta_key = format!("terraform/providers/{}/{}/{}/{}", ns, ptype, ver, suffix);

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -83,6 +83,10 @@ fn build_context(
             public_url: None,
             body_limit_mb: 2048,
             proxy_coalesce: true,
+            // Permissive test fixture: trust upstream dates so existing handler
+            // tests exercise the upstream-date path (prod default is false/secure;
+            // the trust=false path has its own dedicated tests).
+            trust_upstream_dates: true,
         },
         storage: StorageConfig {
             mode: StorageMode::Local,


### PR DESCRIPTION
## Summary
`min_release_age` curation quarantines packages younger than N days (a supply-chain defense), but it derived package age from **upstream-provided** publish dates (`published`/`time`/`created_at`/`upload_time`/`Time`/`published_at`). An attacker controlling or MITM-ing an upstream registry could spoof an old date to bypass the quarantine.

Add `server.trust_upstream_dates` (default **false**, secure — per the security-default posture). When false, all 8 upstream-date extractors (conan/nuget/terraform/npm/pypi/cargo/go/pub_dart) derive age from NORA's own cache mtime instead of the spoofable upstream date — and **never** fall back to the upstream date, preserving fail-closed (no date → Block). docker (`push_timestamp`) and hosted registries already use NORA-side timestamps. Env override: `NORA_TRUST_UPSTREAM_DATES`.

NB: with `false` in proxy mode, age is measured from when NORA first cached the artifact (cache-age), not the real publish date — a long-published package just cached is quarantined for `min_release_age`.

## Test plan
- [x] both modes + fail-closed (conan: trust=true honors upstream date; trust=false uses mtime; uncached → None → Block)
- [x] full test suite green; `clippy -D warnings`; `fmt --check`