### PR TITLE
test(fuzz): add URL-leak fuzz target + assertion for the npm rewrite

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -41,3 +41,8 @@ doc = false
 name = "fuzz_config_toml"
 path = "fuzz_targets/fuzz_config_toml.rs"
 doc = false
+
+[[bin]]
+name = "fuzz_url_leak"
+path = "fuzz_targets/fuzz_url_leak.rs"
+doc = false

--- a/fuzz/fuzz_targets/fuzz_url_leak.rs
+++ b/fuzz/fuzz_targets/fuzz_url_leak.rs
@@ -1,0 +1,30 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+#![no_main]
+//! URL-leak fuzz target (#385): a proxy-response rewrite must never leak the
+//! configured upstream host into client-facing output. Feeds arbitrary npm
+//! metadata bytes to `rewrite_tarball_urls` and asserts the exact configured
+//! upstream URL never survives the rewrite — the #439 byte-level safety-net is
+//! supposed to replace every occurrence, so any survivor (or a panic) is a
+//! finding. Run: `cargo +nightly fuzz run fuzz_url_leak`.
+use libfuzzer_sys::fuzz_target;
+use nora_registry::npm_fuzz::rewrite_tarball_urls;
+
+// RFC 6761 reserved `.invalid` TLD: never a real registry, so any surviving
+// occurrence is rewrite-produced, not a fixture coincidence. The nora base is
+// sentinel-free so a match is unambiguous. Scope: the EXACT configured upstream
+// URL (what the rewrite is given); scheme/case variants are a separate concern.
+const UPSTREAM: &str = "https://upstream-host.invalid";
+const NORA_BASE: &str = "http://nora.test";
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(out) = rewrite_tarball_urls(data, NORA_BASE, UPSTREAM) {
+        let leaked = out
+            .windows(UPSTREAM.len())
+            .any(|w| w == UPSTREAM.as_bytes());
+        assert!(
+            !leaked,
+            "upstream URL leaked into rewritten npm metadata (#385)"
+        );
+    }
+});

--- a/nora-registry/src/lib.rs
+++ b/nora-registry/src/lib.rs
@@ -90,6 +90,42 @@ pub mod npm_fuzz {
         result.extend_from_slice(&data[start..]);
         result
     }
+
+    #[cfg(test)]
+    mod url_leak_tests {
+        //! #385: a rewrite must never leak the configured upstream host into
+        //! client-facing output. The fuzz target `fuzz_url_leak` explores this;
+        //! these deterministic cases enforce it on every CI run (there is no
+        //! fuzz CI job, so this is the front-loop guard).
+        use super::rewrite_tarball_urls;
+
+        const UPSTREAM: &str = "https://upstream-host.invalid";
+        const NORA: &str = "http://nora.test";
+
+        #[test]
+        fn tarball_rewrite_drops_upstream_host() {
+            let meta = br#"{"versions":{"1.0.0":{"dist":{"tarball":"https://upstream-host.invalid/p/-/p-1.0.0.tgz"}}}}"#;
+            let out = rewrite_tarball_urls(meta, NORA, UPSTREAM).expect("valid json");
+            let out = String::from_utf8(out).expect("json is utf-8");
+            assert!(!out.contains(UPSTREAM), "upstream host leaked: {out}");
+            assert!(
+                out.contains("http://nora.test/npm/p/-/p-1.0.0.tgz"),
+                "tarball not rewritten to nora base: {out}"
+            );
+        }
+
+        #[test]
+        fn byte_safety_net_scrubs_upstream_outside_dist() {
+            // An upstream URL hidden in a non-`dist` field must still be removed
+            // by the #439 byte-level safety-net before the client sees it.
+            let meta = br#"{"_note":"mirror of https://upstream-host.invalid/x","versions":{}}"#;
+            let out = rewrite_tarball_urls(meta, NORA, UPSTREAM).expect("valid json");
+            assert!(
+                !String::from_utf8_lossy(&out).contains(UPSTREAM),
+                "byte safety-net let the upstream host through"
+            );
+        }
+    }
 }
 
 /// Re-export PyPI HTML parsing for fuzz targets


### PR DESCRIPTION
## Summary
Add a `fuzz_url_leak` cargo-fuzz target asserting the npm metadata rewrite never leaks the configured upstream host into client-facing output (`rewrite_tarball_urls` + its #439 byte-level safety-net must replace every occurrence of the exact upstream URL). Uses an RFC 6761 `.invalid` sentinel host so a surviving match is unambiguous. The existing `fuzz_npm_metadata` target only asserted panic-freedom; this adds the **no-leak invariant**.

Since there is no fuzz CI job, also adds deterministic unit tests (`npm_fuzz::url_leak_tests`) so the invariant runs on every CI build, not only under the fuzzer.

Scope: covers the npm rewrite reachable from the fuzz lib. The terraform/nuget/ansible/pub_dart rewrites are private to the binary crate (not lib-exported), so fuzzing them needs `*_fuzz` mirror modules — a follow-up.

## Test plan
- [x] `cargo +nightly fuzz run fuzz_url_leak` — 1.04M runs, no leak/panic
- [x] unit tests pass; `clippy -D warnings`; `fmt --check`