### PR TITLE
security(curation): enforce namespace isolation on every proxy registry metadata path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - **Partial `config.toml`** — missing `[server]`, `[storage]`, or fields like `host`/`port` no longer prevent startup; serde defaults are applied for all unset values.
 - **Container image no longer overrides `config.toml`** — the image shipped config *values* (`NORA_PUBLIC_URL`, `NORA_PORT`, `NORA_STORAGE_PATH`, `NORA_AUTH_TOKEN_STORAGE`) as baked `ENV`, which silently won over a user-provided `config.toml` (env has the highest precedence in `Config::load`). Defaults now ship as a file (`/etc/nora/config.toml`, loaded via `NORA_CONFIG_PATH`); a bind-mounted `config.toml` takes full effect. Only `NORA_HOST` stays in `ENV` so binding survives a partial mounted config and the container stays reachable (#719).
+- **Namespace isolation now covers every proxy registry's metadata path** — `internal_namespaces` (the dependency-confusion defense, always active) previously gated only the download/tarball path, so a metadata / index / version-list / search request for an internal-namespace package leaked its name upstream on every proxy registry except npm. The guard now runs on the metadata path of PyPI, Cargo, Maven, Go, NuGet, Conan, pub.dev, Terraform, Ansible and RubyGems — and on the NuGet/Conan search query — serving any locally-published or cached copy first and blocking only the genuine upstream fetch (no leak, and no false 403 on a locally-published internal package). The npm TTL-stale metadata refetch is also guarded, closing a residual of #725 (contrib-kit#68).
 
 ## [0.9.4] - 2026-06-13
 

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -371,6 +371,31 @@ pub fn check_namespace_isolation(
     None
 }
 
+/// Predicate: does `name` match a configured internal-namespace pattern?
+///
+/// Side-effect-free companion to [`check_namespace_isolation`] — it does NOT
+/// increment the `blocked` metric or build a [`Response`]. Use it to DECIDE
+/// whether to skip an upstream fetch (dependency-confusion defense) while still
+/// serving a locally-published/cached copy; reserve [`check_namespace_isolation`]
+/// for the branch that actually returns the 403 block, so the metric counts only
+/// client-facing blocks (matching the download path). Returns `false` when no
+/// namespace filter is configured.
+pub fn is_internal_namespace(engine: &CurationEngine, registry: RegistryType, name: &str) -> bool {
+    let Some(ref ns_filter) = engine.namespace_filter else {
+        return false;
+    };
+    let request = FilterRequest {
+        registry,
+        upstream: None,
+        name: name.to_string(),
+        version: None,
+        integrity: None,
+        bypass: false,
+        publish_date: None,
+    };
+    matches!(ns_filter.evaluate(&request), Decision::Block { .. })
+}
+
 /// Extract publish date from file mtime. Used for hosted registries, and — when
 /// `server.trust_upstream_dates = false` — for proxy registries too (#513): the
 /// NORA-cache mtime is NORA-controlled, so it cannot be spoofed by an upstream

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -116,7 +116,7 @@ async fn collection_list(State(state): State<AppState>, RawQuery(raw_query): Raw
         None => "ansible/metadata/collections.json".to_string(),
     };
 
-    proxy_json(&state, &url, "ansible-collections", &cache_key).await
+    proxy_json(&state, &url, "ansible-collections", &cache_key, None).await
 }
 
 // ── Collection detail ──────────────────────────────────────────────────
@@ -139,7 +139,14 @@ async fn collection_detail(
     );
 
     let cache_key = format!("ansible/metadata/{}/{}.json", ns, name);
-    proxy_json(&state, &url, &format!("{}.{}", ns, name), &cache_key).await
+    proxy_json(
+        &state,
+        &url,
+        &format!("{}.{}", ns, name),
+        &cache_key,
+        Some(&format!("{}.{}", ns, name)),
+    )
+    .await
 }
 
 // ── Version listing ────────────────────────────────────────────────────
@@ -176,6 +183,7 @@ async fn version_list(
         &url,
         &format!("{}.{}/versions", ns, name),
         &cache_key,
+        Some(&format!("{}.{}", ns, name)),
     )
     .await
 }
@@ -220,6 +228,7 @@ async fn version_detail(
         &url,
         &format!("{}.{} v{}", ns, name, ver),
         &cache_key,
+        Some(&format!("{}.{}", ns, name)),
     )
     .await
 }
@@ -351,7 +360,13 @@ async fn download_tarball(
 ///
 /// `cache_key` is the storage path for the cached response (e.g.
 /// `ansible/metadata/community/general.json`).
-async fn proxy_json(state: &AppState, url: &str, artifact_name: &str, cache_key: &str) -> Response {
+async fn proxy_json(
+    state: &AppState,
+    url: &str,
+    artifact_name: &str,
+    cache_key: &str,
+    package_name: Option<&str>,
+) -> Response {
     let base_url = nora_base_url(state);
     let upstream = upstream_url(state);
 
@@ -368,6 +383,32 @@ async fn proxy_json(state: &AppState, url: &str, artifact_name: &str, cache_key:
                 let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
                 return with_json(rewritten.into_bytes());
             }
+        }
+    }
+
+    // #68 namespace isolation: an internal-namespace collection's metadata must never
+    // be fetched upstream (dependency confusion). Serve any local copy (fresh path
+    // returned above), else block — never proxy. (collection_list passes None: the
+    // catalog index has no single package name to gate.)
+    if let Some(pkg) = package_name {
+        if crate::curation::is_internal_namespace(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Ansible,
+            pkg,
+        ) {
+            if let Some(ref data) = cached_data {
+                state.metrics.record_download("ansible");
+                state.metrics.record_cache_hit("ansible");
+                let text = String::from_utf8_lossy(data);
+                let rewritten = rewrite_ansible_urls(&text, &upstream, &base_url);
+                return with_json(rewritten.into_bytes());
+            }
+            return crate::curation::check_namespace_isolation(
+                &state.curation().curation_engine,
+                crate::curation::RegistryType::Ansible,
+                pkg,
+            )
+            .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
         }
     }
 

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -134,6 +134,27 @@ async fn sparse_index(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace crate must never be revalidated
+    // or fetched upstream (dependency confusion). Serve any local index (hosted or
+    // cached) without contacting upstream; block only when nothing is published
+    // locally. The fresh-cache fast path above already returned a fresh copy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Cargo,
+        &crate_name,
+    ) {
+        if let Some(ref data) = cached {
+            state.metrics.record_cache_hit("cargo");
+            return sparse_index_conditional(data.to_vec(), &headers);
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Cargo,
+            &crate_name,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     // Revalidate / fetch from upstream (no cache, or the cached index is stale).
     let proxy_url = match &state.config.cargo.proxy {
         Some(url) => url.clone(),
@@ -232,6 +253,16 @@ async fn get_metadata(State(state): State<AppState>, Path(crate_name): Path<Stri
 
     if let Ok(data) = state.storage.get(&key).await {
         return (StatusCode::OK, data).into_response();
+    }
+
+    // #68 namespace isolation: a locally-published internal crate was served above;
+    // an internal name with no local copy must not be fetched upstream.
+    if let Some(response) = crate::curation::check_namespace_isolation(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Cargo,
+        &crate_name,
+    ) {
+        return response;
     }
 
     // Proxy fetch metadata from upstream

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -120,6 +120,16 @@ async fn search(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
+    // #68 namespace isolation: never forward a search term matching an internal
+    // namespace upstream (dependency confusion) — return an empty result set.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &query,
+    ) {
+        return with_json(br#"{"results":[]}"#.to_vec());
+    }
+
     let proxy_url = upstream_url(&state);
     // Percent-encode query for upstream
     let encoded_query: String = query
@@ -201,6 +211,27 @@ async fn recipe_latest(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace recipe must never be fetched
+    // upstream (dependency confusion). Serve any local copy (the fresh path returned
+    // above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &name,
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_hit("conan");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Conan,
+            &name,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let proxy_url = upstream_url(&state);
     let url = format!(
         "{}/v2/conans/{}/latest",
@@ -233,6 +264,27 @@ async fn recipe_revisions(
                 return with_json(data.to_vec());
             }
         }
+    }
+
+    // #68 namespace isolation: an internal-namespace recipe must never be fetched
+    // upstream (dependency confusion). Serve any local copy (the fresh path returned
+    // above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &name,
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_hit("conan");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Conan,
+            &name,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
     }
 
     let proxy_url = upstream_url(&state);
@@ -268,6 +320,16 @@ async fn recipe_file_list(
         state.metrics.record_download("conan");
         state.metrics.record_cache_hit("conan");
         return with_json(data.to_vec());
+    }
+
+    // #68 namespace isolation: a cached internal recipe's file list was served above;
+    // an internal name with no local copy must not be fetched upstream.
+    if let Some(response) = crate::curation::check_namespace_isolation(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &name,
+    ) {
+        return response;
     }
 
     let proxy_url = upstream_url(&state);
@@ -449,6 +511,27 @@ async fn package_latest(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace package must never be fetched
+    // upstream (dependency confusion). Serve any local copy (the fresh path returned
+    // above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &name,
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_hit("conan");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Conan,
+            &name,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let proxy_url = upstream_url(&state);
     let url = format!(
         "{}/v2/conans/{}/revisions/{}/packages/{}/latest",
@@ -501,6 +584,27 @@ async fn package_revisions(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace package must never be fetched
+    // upstream (dependency confusion). Serve any local copy (the fresh path returned
+    // above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &name,
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("conan");
+            state.metrics.record_cache_hit("conan");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Conan,
+            &name,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let proxy_url = upstream_url(&state);
     let url = format!(
         "{}/v2/conans/{}/revisions/{}/packages/{}/revisions",
@@ -549,6 +653,16 @@ async fn package_file_list(
         state.metrics.record_download("conan");
         state.metrics.record_cache_hit("conan");
         return with_json(data.to_vec());
+    }
+
+    // #68 namespace isolation: a cached internal package's file list was served above;
+    // an internal name with no local copy must not be fetched upstream.
+    if let Some(response) = crate::curation::check_namespace_isolation(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Conan,
+        &name,
+    ) {
+        return response;
     }
 
     let proxy_url = upstream_url(&state);

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -474,6 +474,16 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
         return with_binary(data.to_vec(), "application/octet-stream");
     }
 
+    // #68 namespace isolation: a cached internal gem's spec was served above; an
+    // internal name with no local copy must not be fetched upstream.
+    if let Some(response) = crate::curation::check_namespace_isolation(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Gems,
+        &name,
+    ) {
+        return response;
+    }
+
     let proxy_url = upstream_url(&state);
     let url = format!(
         "{}/quick/Marshal.4.8/{}.gemspec.rz",

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -169,6 +169,30 @@ async fn handle(
         return StatusCode::BAD_REQUEST.into_response();
     }
 
+    // #68 namespace isolation: an internal-namespace module must never be fetched
+    // upstream (dependency confusion). The fresh-cache fast path above already served
+    // a fresh copy; here, serve any stale cached copy rather than re-proxying, and
+    // block only when nothing is cached — never proxy. (The .zip artifact path also
+    // runs check_download.)
+    let module_path =
+        decode_module_path(&module_encoded).unwrap_or_else(|_| module_encoded.clone());
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Go,
+        &module_path,
+    ) {
+        if let Some(ref data) = cached {
+            state.metrics.record_cache_hit("go");
+            return with_content_type(data.to_vec(), content_type, is_mutable);
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Go,
+            &module_path,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let upstream_url = format!(
         "{}/{}",
         proxy_url.trim_end_matches('/'),

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -220,6 +220,37 @@ async fn download(
         }
     }
 
+    // #68 namespace isolation: the maven-metadata.xml (ArtifactMeta) path is not
+    // covered by the VersionFile check_download above. An internal group:artifact's
+    // metadata must never be fetched upstream (dependency confusion): serve any local
+    // copy (deployed/cached metadata; the fresh path already returned above) and block
+    // only when nothing is hosted locally — never proxy.
+    if let MavenPathKind::ArtifactMeta {
+        group_path,
+        artifact_id,
+        ..
+    } = classify_path(&path)
+    {
+        let maven_name = format!("{}:{}", group_path.replace('/', "."), artifact_id);
+        if crate::curation::is_internal_namespace(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Maven,
+            &maven_name,
+        ) {
+            if let Some(ref data) = cached {
+                state.metrics.record_download("maven");
+                state.metrics.record_cache_hit("maven");
+                return with_content_type(&path, data.clone()).into_response();
+            }
+            return crate::curation::check_namespace_isolation(
+                &state.curation().curation_engine,
+                crate::curation::RegistryType::Maven,
+                &maven_name,
+            )
+            .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+        }
+    }
+
     for proxy in &state.config.maven.proxies {
         let url = format!("{}/{}", proxy.url().trim_end_matches('/'), path);
 

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -16,6 +16,10 @@ mod pypi;
 mod raw;
 pub(crate) mod terraform;
 
+// Cross-registry regression suite for namespace isolation on metadata paths (contrib-kit#68).
+#[cfg(test)]
+mod ns_isolation_metadata_tests;
+
 pub use ansible::routes as ansible_routes;
 pub use cargo_registry::routes as cargo_routes;
 pub use conan::routes as conan_routes;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -199,6 +199,18 @@ async fn handle_request(
             let ttl = state.config.npm.metadata_ttl;
             if let Some(meta) = state.storage.stat(&key).await {
                 if !crate::cache_ttl::is_within_ttl(meta.modified, ttl) {
+                    // #68 namespace isolation: a stale internal-namespace package must
+                    // NOT be revalidated upstream (dependency confusion) — refetch_metadata
+                    // proxies the name. Serve the cached copy already in hand instead; an
+                    // internal package is owned/hosted locally, never upstream-refreshed.
+                    // (The cache-miss proxy path is guarded separately below.)
+                    if crate::curation::is_internal_namespace(
+                        &state.curation().curation_engine,
+                        crate::curation::RegistryType::Npm,
+                        &package_name,
+                    ) {
+                        return with_content_type(false, data).into_response();
+                    }
                     // Single-flight: when a popular packument expires and a CI
                     // fleet stampedes the same key, one request revalidates
                     // upstream and the rest serve its in-memory result (#595).

--- a/nora-registry/src/registry/ns_isolation_metadata_tests.rs
+++ b/nora-registry/src/registry/ns_isolation_metadata_tests.rs
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+
+//! Cross-registry regression suite for namespace isolation on METADATA paths
+//! (contrib-kit#68).
+//!
+//! Namespace isolation (`internal_namespaces`, the dependency-confusion defense,
+//! "always active" — issue #185) historically gated only the download/artifact
+//! path via `check_download`. Every proxy registry's metadata / index / version-list
+//! / search path proxied upstream UNGATED, leaking internal package names. PR #725
+//! fixed npm only.
+//!
+//! These tests pin the invariant for EVERY registry:
+//! 1. an internal-namespace package's metadata with no local copy is BLOCKED (403),
+//!    never proxied upstream;
+//! 2. a locally-published internal package's metadata is still SERVED (200) — the
+//!    guard must come after the local/cache serve, never blocking a local copy;
+//! 3. a non-internal package is NOT blocked (proxies / 404s normally);
+//! 4. a search query matching an internal pattern is NOT forwarded upstream.
+//!
+//! NB the test harness MERGES registry routers at the root (no per-registry nest),
+//! so pypi lives at `/simple/...`; and several registries default to `enabled:false`,
+//! so each test turns its registry on explicitly.
+
+#![cfg(test)]
+#![allow(clippy::unwrap_used)]
+
+use crate::test_helpers::{body_bytes, create_test_context_with_config, send};
+use axum::http::{Method, StatusCode};
+
+/// Connection-refused sentinel: if a guard is missing, the handler would try this
+/// upstream and fail with a proxy error (≠ 403), exposing the leak path.
+const BLACKHOLE: &str = "http://127.0.0.1:1";
+
+// ── pypi: package_versions — serve local-only before gating the upstream merge ──
+
+#[tokio::test]
+async fn pypi_internal_metadata_blocked_not_proxied() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.pypi.proxy = Some(BLACKHOLE.to_string());
+    });
+    // Internal name, no local copy → 403 (never the BLACKHOLE upstream).
+    let resp = send(&ctx.app, Method::GET, "/simple/internalpkg/", "").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn pypi_internal_locally_published_served_hole5() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.pypi.proxy = Some(BLACKHOLE.to_string());
+    });
+    // A locally-published internal wheel must still be listed: the guard skips the
+    // upstream merge but the local-only serve still answers.
+    ctx.state
+        .storage
+        .put(
+            "pypi/internalpkg/internalpkg-1.0-py3-none-any.whl",
+            b"wheel-bytes",
+        )
+        .await
+        .unwrap();
+    let resp = send(&ctx.app, Method::GET, "/simple/internalpkg/", "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "locally-published internal package must be served, not 403"
+    );
+    let body = String::from_utf8(body_bytes(resp).await.to_vec()).unwrap();
+    assert!(
+        body.contains("internalpkg-1.0-py3-none-any.whl"),
+        "listing must contain the locally-published file"
+    );
+}
+
+#[tokio::test]
+async fn pypi_public_metadata_not_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        // no proxy, no local → a non-internal name resolves to 404, NOT a 403 block.
+    });
+    let resp = send(&ctx.app, Method::GET, "/simple/publicpkg/", "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "a non-internal package must not be namespace-blocked"
+    );
+}
+
+// ── maven: maven-metadata.xml (ArtifactMeta) ────────────────────────────────
+
+#[tokio::test]
+async fn maven_internal_metadata_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["com.internal.**".to_string()];
+        c.maven.proxies = vec![];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/maven2/com/internal/lib/maven-metadata.xml",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── nuget: version list + search ────────────────────────────────────────────
+
+#[tokio::test]
+async fn nuget_internal_version_list_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.nuget.enabled = true;
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/nuget/v3/flatcontainer/internalpkg/index.json",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn nuget_internal_search_not_forwarded() {
+    let ctx = create_test_context_with_config(|c| {
+        c.nuget.enabled = true;
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.nuget.proxy = Some(BLACKHOLE.to_string());
+        c.nuget.serve_stale = false; // without the guard, the BLACKHOLE failure → 503
+    });
+    // Searching an exact internal name must serve the local index, never forward it.
+    let resp = send(&ctx.app, Method::GET, "/nuget/v3/query?q=internalpkg", "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "internal search term must be served locally, not forwarded to upstream"
+    );
+}
+
+// ── conan: recipe metadata + search ─────────────────────────────────────────
+
+#[tokio::test]
+async fn conan_internal_recipe_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.conan.enabled = true;
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/conan/v2/conans/internalpkg/1.0/user/channel/latest",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn conan_internal_search_not_forwarded() {
+    let ctx = create_test_context_with_config(|c| {
+        c.conan.enabled = true;
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/conan/v2/conans/search?q=internalpkg",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = String::from_utf8(body_bytes(resp).await.to_vec()).unwrap();
+    assert!(
+        body.contains("\"results\""),
+        "internal search must return an empty result set, not forward upstream"
+    );
+}
+
+// ── pub_dart: version metadata ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn pubdart_internal_version_metadata_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.pub_dart.enabled = true;
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/pub/api/packages/internalpkg/versions/1.0.0",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── terraform: provider versions ────────────────────────────────────────────
+
+#[tokio::test]
+async fn terraform_internal_provider_versions_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.terraform.enabled = true;
+        c.curation.internal_namespaces = vec!["acme/**".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/terraform/v1/providers/acme/aws/versions",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── ansible: collection detail (shared proxy_json helper) ───────────────────
+
+#[tokio::test]
+async fn ansible_internal_collection_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.ansible.enabled = true;
+        c.curation.internal_namespaces = vec!["acme.**".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/ansible/v3/collections/acme/internal/",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── gems: gemspec (per-package metadata) ────────────────────────────────────
+
+#[tokio::test]
+async fn gems_internal_gemspec_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.gems.enabled = true;
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+    });
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/gems/quick/Marshal.4.8/internalgem-1.0.gemspec.rz",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+// ── go: module metadata (@v/list) ───────────────────────────────────────────
+
+#[tokio::test]
+async fn go_internal_metadata_blocked() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.go.proxy = Some(BLACKHOLE.to_string()); // go 404s without a proxy before the guard
+    });
+    let resp = send(&ctx.app, Method::GET, "/go/internal.corp/lib/@v/list", "").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn go_internal_stale_cached_served() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.go.proxy = Some(BLACKHOLE.to_string());
+        c.go.metadata_ttl = 0; // @v/list is mutable; ttl=0 → "not fresh" → reaches the guard
+    });
+    // A cached internal module's mutable version list must be served (stale), never
+    // re-proxied to the BLACKHOLE upstream (serve cached first, then block).
+    ctx.state
+        .storage
+        .put("go/internal.corp/lib/@v/list", b"v1.0.0\n")
+        .await
+        .unwrap();
+    let resp = send(&ctx.app, Method::GET, "/go/internal.corp/lib/@v/list", "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "cached internal go module must be served stale, not re-proxied (Shape B)"
+    );
+}
+
+// ── npm: PR #725 residual — TTL-stale refetch must not re-proxy an internal pkg ──
+
+#[tokio::test]
+async fn npm_internal_stale_not_refetched() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.npm.proxy = Some(BLACKHOLE.to_string());
+        c.npm.metadata_ttl = 0; // every pull is "stale" → would trigger refetch_metadata
+        c.npm.serve_stale = false; // without the guard, the failed refetch → 502
+    });
+    // A locally-published internal packument whose cache is "stale" must be served
+    // from the local copy, NOT re-fetched upstream (the #725 residual leak).
+    ctx.state
+        .storage
+        .put(
+            "npm/internalpkg/metadata.json",
+            br#"{"name":"internalpkg","versions":{}}"#,
+        )
+        .await
+        .unwrap();
+    let resp = send(&ctx.app, Method::GET, "/npm/internalpkg", "").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "stale internal packument must serve cached copy, not re-proxy (PR #725 residual)"
+    );
+    let body = String::from_utf8(body_bytes(resp).await.to_vec()).unwrap();
+    assert!(body.contains("internalpkg"));
+}

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -244,6 +244,25 @@ async fn search_query(
         return with_json(data);
     }
 
+    // #68 namespace isolation: never forward a search term that matches an internal
+    // namespace upstream (dependency confusion) — serve local results only.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Nuget,
+        &query,
+    ) {
+        let data = local_search_results(
+            &state,
+            &query,
+            skip,
+            take,
+            prerelease,
+            sem_ver_level.as_deref(),
+        )
+        .await;
+        return with_json(data);
+    }
+
     // Try upstream with short timeout (UX-critical path)
     let qs = raw_query.0.unwrap_or_default();
     let url = format!("{}?{}", state.config.nuget.search_service, qs);
@@ -308,6 +327,24 @@ async fn autocomplete_query(
 
     // No upstream proxy configured → local autocomplete from cache
     if state.config.nuget.proxy.is_none() {
+        let data = local_autocomplete_results(
+            &state,
+            &query,
+            skip,
+            take,
+            prerelease,
+            sem_ver_level.as_deref(),
+        )
+        .await;
+        return with_json(data);
+    }
+
+    // #68 namespace isolation: don't forward an internal-namespace autocomplete term.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Nuget,
+        &query,
+    ) {
         let data = local_autocomplete_results(
             &state,
             &query,
@@ -561,6 +598,29 @@ async fn registration_page(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace package's registration must
+    // never be fetched upstream (dependency confusion). Serve any local copy
+    // (hosted/cached; the fresh path returned above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Nuget,
+        &id_lower,
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("nuget");
+            state.metrics.record_cache_hit("nuget");
+            let text = String::from_utf8_lossy(data);
+            let rewritten = rewrite_registration_urls(&text, &upstream, &base_url);
+            return with_json_gzip(rewritten.into_bytes());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Nuget,
+            &id_lower,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let url = format!(
         "{}/v3/registration5-gz-semver2/{}/page/{}/{}.json",
         upstream.trim_end_matches('/'),
@@ -646,6 +706,26 @@ async fn version_list(state: AppState, id: &str) -> Response {
                 return with_json(data.to_vec());
             }
         }
+    }
+
+    // #68 namespace isolation: serve any local version list for an internal package,
+    // else block — never fetch upstream (dependency confusion).
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Nuget,
+        &id_lower,
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("nuget");
+            state.metrics.record_cache_hit("nuget");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Nuget,
+            &id_lower,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
     }
 
     let proxy_url = upstream_url(&state);

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -287,6 +287,25 @@ async fn version_metadata(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace package's version metadata must
+    // never be fetched upstream (dependency confusion). Serve any local copy (fresh
+    // path returned above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::PubDart,
+        &package,
+    ) {
+        if let Some(ref data) = cached_data {
+            return pub_json_response(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::PubDart,
+            &package,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let Some(proxy_url) = &state.config.pub_dart.proxy else {
         return StatusCode::NOT_FOUND.into_response();
     };
@@ -346,6 +365,25 @@ async fn package_advisories(
                 return pub_json_response(data.to_vec());
             }
         }
+    }
+
+    // #68 namespace isolation: an internal-namespace package's advisories must never
+    // be fetched upstream (dependency confusion). Serve any local copy (fresh path
+    // returned above), else block — never proxy.
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::PubDart,
+        &package,
+    ) {
+        if let Some(ref data) = cached_data {
+            return pub_json_response(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::PubDart,
+            &package,
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
     }
 
     let Some(proxy_url) = &state.config.pub_dart.proxy else {

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -166,9 +166,20 @@ async fn package_versions(
     // the upstream order: the first upstream that lists a file wins (local files
     // win over all upstreams). One upstream's failure or open breaker must not
     // sink the others — skip it and serve the merge of what answered.
+    // #68 namespace isolation: an internal-namespace package must never be fetched
+    // upstream (dependency confusion). Skip the upstream merge entirely; a locally
+    // published copy is still served from the local-only branch below, and an
+    // internal name with no local copy is blocked (never proxied). Computed without
+    // the `blocked` metric — the metric fires only on the actual block path below.
+    let is_internal = crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::PyPI,
+        &normalized,
+    );
+
     let upstreams = state.config.pypi.upstreams();
     let mut circuit_open = false;
-    if !upstreams.is_empty() {
+    if !is_internal && !upstreams.is_empty() {
         let mut upstream_files: Vec<FileEntry> = Vec::new();
         for up in &upstreams {
             let url = format!("{}/{}/", up.url().trim_end_matches('/'), normalized);
@@ -211,6 +222,19 @@ async fn package_versions(
         } else {
             versions_html_response(&normalized, &local_files, &base_url)
         };
+    }
+
+    // #68: an internal-namespace package with no local copy is blocked, never
+    // proxied — return the namespace 403 (the only pypi metadata path that
+    // increments the blocked metric).
+    if is_internal {
+        if let Some(response) = crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::PyPI,
+            &normalized,
+        ) {
+            return response;
+        }
     }
 
     // No upstream result and no local copy: a tripped breaker means the upstream is

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -130,6 +130,28 @@ async fn provider_versions(
         }
     }
 
+    // #68 namespace isolation: an internal-namespace provider's version list must
+    // never be fetched upstream (dependency confusion). Serve any local copy (fresh
+    // path returned above), else block — never proxy. Name form matches the existing
+    // provider check_download: "{ns}/{ptype}".
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Terraform,
+        &format!("{}/{}", ns, ptype),
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("terraform");
+            state.metrics.record_cache_hit("terraform");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Terraform,
+            &format!("{}/{}", ns, ptype),
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+    }
+
     let proxy_url = upstream_url(&state);
     let url = format!(
         "{}/v1/providers/{}/{}/versions",
@@ -391,6 +413,27 @@ async fn module_versions(
                 return with_json(data.to_vec());
             }
         }
+    }
+
+    // #68 namespace isolation: an internal-namespace module's version list must never
+    // be fetched upstream (dependency confusion). Serve any local copy (fresh path
+    // returned above), else block — never proxy. Module name form: "{ns}/{name}/{provider}".
+    if crate::curation::is_internal_namespace(
+        &state.curation().curation_engine,
+        crate::curation::RegistryType::Terraform,
+        &format!("{}/{}/{}", ns, name, provider),
+    ) {
+        if let Some(ref data) = cached_data {
+            state.metrics.record_download("terraform");
+            state.metrics.record_cache_hit("terraform");
+            return with_json(data.to_vec());
+        }
+        return crate::curation::check_namespace_isolation(
+            &state.curation().curation_engine,
+            crate::curation::RegistryType::Terraform,
+            &format!("{}/{}/{}", ns, name, provider),
+        )
+        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
     }
 
     let proxy_url = upstream_url(&state);


### PR DESCRIPTION
## Problem

`internal_namespaces` (the dependency-confusion defense, always active per #185) gated only the **download** path via `check_download`. Every proxy registry's **metadata / index / version-list / search** path proxied upstream **ungated** — so a request for an internal-namespace package leaked its name to the public upstream. PR #725 fixed npm only.

## Fix

Add a namespace guard to the metadata path of **PyPI, Cargo, Maven, Go, NuGet, Conan, Pub, Terraform, Ansible and RubyGems**, plus the **NuGet/Conan search query**. Each guard:

- serves any **locally-published or cached** copy first, then blocks only the genuine upstream fetch — so a locally-published internal package is still served (200) while an internal name is **never proxied**;
- uses a new side-effect-free predicate `is_internal_namespace` for the merge / serve-stale paths (avoids a false 403 on a local copy — the freshness model means a mutable index is "not fresh" with `metadata_ttl=0` on a proxy+host instance, so a naive guard would 403 a freshly-published internal package);
- also covers the **npm TTL-stale `refetch_metadata`** path, closing a residual of #725 (a stale internal packument was re-proxied before the existing guard).

Name forms match each registry's existing `check_download` (Maven `group:artifact`, Terraform `ns/type`, Ansible `ns.name`, etc.).

## Tests

`nora-registry/src/registry/ns68_metadata_isolation.rs` — 15-case cross-registry suite: internal-blocked / locally-published-served / non-internal-proxies / search-not-forwarded / npm-stale-not-reproxied. Full suite green (`cargo test -p nora-registry`).

**Live e2e on a real binary + logging mock upstream** confirmed old-vs-new: the pre-fix build forwarded the internal name upstream 3× (pypi metadata + npm stale-refetch); this build forwards only public names, blocks internal, and still serves locally-published internal packages.

## Scope / follow-ups (tracked, not silent)

- **Docs:** the guard's effectiveness depends on the operator's glob form — dotted/pathed names need `prefix.**` / `prefix/**`, not a single `*`. Filed as #731.
- **Inverse property (separate, pre-existing):** three `check_download` metadata paths (nuget `registration_index`, pub_dart `package_listing`, gems `compact_index`) and all **download** paths 403 a locally-cached internal package *before* serving it (`check_download` runs the always-on namespace filter pre-serve). That is the "serve-local vs block-all" design question — pre-existing, systemic, and **not** this leak invariant (those paths still block upstream = no leak). Tracked separately.
