### PR TITLE
fix(curation): quarantine all proxy registries; min-age defers (#741)

### DIFF
--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -634,6 +634,52 @@ impl Config {
                 "curation.on_failure=\"open\" is not implemented and would silently degrade to fail-closed. Remove the setting or set on_failure=\"closed\" explicitly. This field will be removed in v0.9".to_string(),
             );
         }
+        // min_release_age on a proxy registry needs a date source or a quarantine,
+        // else it produces NO age control. min-age judges the REAL upstream
+        // release age; with an unknown date it DEFERS (Skip) to digest-quarantine
+        // rather than fail-closed-blocking every download (#741,
+        // curation-minage-real-age-defer). To keep that deferral from being a
+        // silent fail-open, refuse a config where min_release_age is set on an
+        // enabled proxy registry yet neither a trusted date source
+        // (server.trust_upstream_dates) nor an active quarantine is configured.
+        {
+            use crate::digest_quarantine::QuarantineMode;
+            let q_on =
+                |q: &Option<QuarantineMode>| matches!(q, Some(m) if *m != QuarantineMode::Off);
+            let quarantine_active = q_on(&self.curation.quarantine)
+                || q_on(&self.curation.npm.quarantine)
+                || q_on(&self.curation.pypi.quarantine)
+                || q_on(&self.curation.cargo.quarantine)
+                || q_on(&self.curation.go.quarantine)
+                || q_on(&self.curation.maven.quarantine)
+                || q_on(&self.curation.gems.quarantine)
+                || q_on(&self.curation.terraform.quarantine)
+                || q_on(&self.curation.ansible.quarantine)
+                || q_on(&self.curation.nuget.quarantine)
+                || q_on(&self.curation.pub_dart.quarantine)
+                || q_on(&self.curation.conan.quarantine);
+            let any_enabled_proxy = (self.pypi.enabled
+                && (self.pypi.proxy.is_some() || !self.pypi.proxies.is_empty()))
+                || (self.npm.enabled && self.npm.proxy.is_some())
+                || (self.cargo.enabled && self.cargo.proxy.is_some())
+                || (self.gems.enabled && self.gems.proxy.is_some())
+                || (self.maven.enabled && !self.maven.proxies.is_empty())
+                || (self.nuget.enabled && self.nuget.proxy.is_some())
+                || (self.go.enabled && self.go.proxy.is_some())
+                || (self.conan.enabled && self.conan.proxy.is_some())
+                || (self.pub_dart.enabled && self.pub_dart.proxy.is_some())
+                || (self.terraform.enabled && self.terraform.proxy.is_some())
+                || (self.ansible.enabled && self.ansible.proxy.is_some());
+            if self.curation.min_release_age.is_some()
+                && !self.server.trust_upstream_dates
+                && !quarantine_active
+                && any_enabled_proxy
+            {
+                errors.push(
+                    "curation.min_release_age is set with an enabled proxy registry but no age control would be active: an upstream publish date is unsigned/spoofable (and absent on several registries), so min-release-age cannot verify the real release age and defers. Set server.trust_upstream_dates=true (trust the upstream's date) OR enable curation.quarantine=\"observe\"|\"enforce\" (unspoofable first-seen hold). (#741)".to_string(),
+                );
+            }
+        }
 
         // 9. Docker upstream prefix validation
         {
@@ -2023,6 +2069,62 @@ mod tests {
         assert!(
             errors.iter().any(|e| e.contains("allowlist_path")),
             "enforce without allowlist should be an error"
+        );
+    }
+
+    #[test]
+    fn test_validate_minage_proxy_without_date_source_or_quarantine_rejected() {
+        // min_release_age on an enabled proxy registry with neither
+        // trust_upstream_dates nor an active quarantine = no age control would be
+        // active => rejected (curation-minage-real-age-defer, #741).
+        let mut config = Config::default();
+        config.npm.enabled = true;
+        config.npm.proxy = Some("https://registry.npmjs.org".to_string());
+        config.curation.min_release_age = Some("7d".to_string());
+        config.server.trust_upstream_dates = false;
+        config.curation.quarantine = None;
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("no age control would be active")),
+            "min-age on a proxy with neither trust nor quarantine must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_validate_minage_proxy_with_quarantine_ok() {
+        // Escape hatch 1: an active quarantine is the unspoofable age control.
+        let mut config = Config::default();
+        config.npm.enabled = true;
+        config.npm.proxy = Some("https://registry.npmjs.org".to_string());
+        config.curation.min_release_age = Some("7d".to_string());
+        config.server.trust_upstream_dates = false;
+        config.curation.quarantine = Some(crate::digest_quarantine::QuarantineMode::Enforce);
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.contains("no age control would be active")),
+            "an active quarantine should satisfy the age-control requirement"
+        );
+    }
+
+    #[test]
+    fn test_validate_minage_proxy_with_trust_ok() {
+        // Escape hatch 2: trusting the upstream's date enables real-age control.
+        let mut config = Config::default();
+        config.npm.enabled = true;
+        config.npm.proxy = Some("https://registry.npmjs.org".to_string());
+        config.curation.min_release_age = Some("7d".to_string());
+        config.server.trust_upstream_dates = true;
+        config.curation.quarantine = None;
+        let (_, errors) = config.validate_with_config_path(None);
+        assert!(
+            !errors
+                .iter()
+                .any(|e| e.contains("no age control would be active")),
+            "trust_upstream_dates should satisfy the age-control requirement"
         );
     }
 

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -634,14 +634,15 @@ impl Config {
                 "curation.on_failure=\"open\" is not implemented and would silently degrade to fail-closed. Remove the setting or set on_failure=\"closed\" explicitly. This field will be removed in v0.9".to_string(),
             );
         }
-        // min_release_age on a proxy registry needs a date source or a quarantine,
-        // else it produces NO age control. min-age judges the REAL upstream
-        // release age; with an unknown date it DEFERS (Skip) to digest-quarantine
-        // rather than fail-closed-blocking every download (#741,
-        // curation-minage-real-age-defer). To keep that deferral from being a
-        // silent fail-open, refuse a config where min_release_age is set on an
-        // enabled proxy registry yet neither a trusted date source
-        // (server.trust_upstream_dates) nor an active quarantine is configured.
+        // min_release_age on a proxy registry requires an active quarantine. On the
+        // proxy path the upstream publish date is unsigned/spoofable AND, for most
+        // registries, not resolvable at all (the date-bearing upstream metadata is
+        // not cached at the curation point — the same root cause as #741), so
+        // min-age DEFERS (Skip). server.trust_upstream_dates yields a real date only
+        // where the registry caches one (npm); for pypi/cargo/nuget/gems/… it stays
+        // None and min-age silently does nothing — so trust is NOT a sufficient age
+        // control, only the unspoofable quarantine is. Refuse min-age on an enabled
+        // proxy without a quarantine (curation-minage-real-age-defer, #741).
         {
             use crate::digest_quarantine::QuarantineMode;
             let q_on =
@@ -670,13 +671,9 @@ impl Config {
                 || (self.pub_dart.enabled && self.pub_dart.proxy.is_some())
                 || (self.terraform.enabled && self.terraform.proxy.is_some())
                 || (self.ansible.enabled && self.ansible.proxy.is_some());
-            if self.curation.min_release_age.is_some()
-                && !self.server.trust_upstream_dates
-                && !quarantine_active
-                && any_enabled_proxy
-            {
+            if self.curation.min_release_age.is_some() && !quarantine_active && any_enabled_proxy {
                 errors.push(
-                    "curation.min_release_age is set with an enabled proxy registry but no age control would be active: an upstream publish date is unsigned/spoofable (and absent on several registries), so min-release-age cannot verify the real release age and defers. Set server.trust_upstream_dates=true (trust the upstream's date) OR enable curation.quarantine=\"observe\"|\"enforce\" (unspoofable first-seen hold). (#741)".to_string(),
+                    "curation.min_release_age is set with an enabled proxy registry but no age control would be active: on the proxy path an upstream publish date is unsigned/spoofable and is not resolved for most registries, so min-release-age silently does nothing without a quarantine. Enable curation.quarantine=\"observe\"|\"enforce\" (the unspoofable first-seen age control). server.trust_upstream_dates enhances min-release-age with real upstream dates where a registry caches one (e.g. npm) but is NOT a substitute for the quarantine. (#741)".to_string(),
                 );
             }
         }
@@ -2111,8 +2108,11 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_minage_proxy_with_trust_ok() {
-        // Escape hatch 2: trusting the upstream's date enables real-age control.
+    fn test_validate_minage_proxy_trust_alone_still_rejected() {
+        // trust_upstream_dates is NOT a sufficient substitute for the quarantine: it
+        // yields a real date only where a registry caches one (npm); for pypi/cargo/
+        // nuget/gems/… publish_date stays None and min-age silently does nothing, so
+        // min-age on a proxy still requires an active quarantine. (#741)
         let mut config = Config::default();
         config.npm.enabled = true;
         config.npm.proxy = Some("https://registry.npmjs.org".to_string());
@@ -2121,10 +2121,10 @@ mod tests {
         config.curation.quarantine = None;
         let (_, errors) = config.validate_with_config_path(None);
         assert!(
-            !errors
+            errors
                 .iter()
                 .any(|e| e.contains("no age control would be active")),
-            "trust_upstream_dates should satisfy the age-control requirement"
+            "trust alone (no quarantine) must still be rejected — trust is not a substitute"
         );
     }
 

--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -1134,23 +1134,17 @@ impl ProxyFilter for MinReleaseAgeFilter {
         };
 
         let Some(publish_ts) = request.publish_date else {
-            // Fail-closed: an unknown publish date must NOT bypass an active
-            // quarantine. Curation is fail-closed by design — the config layer
-            // rejects on_failure="open" — so this filter, the one place that
-            // defers on missing data, must not be the lone fail-open hole. If the
-            // quarantine is disabled for this registry (threshold 0) there is
-            // nothing to enforce, so defer to the next filter.
-            return if threshold > 0 {
-                Decision::Block {
-                    rule: "min-release-age".to_string(),
-                    reason: format!(
-                        "publish date unknown — cannot verify the {} minimum age; blocked fail-closed",
-                        label,
-                    ),
-                }
-            } else {
-                Decision::Skip
-            };
+            // Defer to digest-quarantine — the unspoofable first-seen holder
+            // (curation-quarantine-uniform). An unknown upstream publish date is
+            // not min-release-age's to hold: this filter judges the REAL release
+            // age and can only do so with a trusted date. The "hold new/unknown"
+            // duty belongs to digest-quarantine, which keys on the content digest
+            // and NORA's own clock (no upstream date needed). Config validation
+            // guarantees an age control (trust_upstream_dates OR an active
+            // quarantine) is configured whenever min_release_age is set on a proxy
+            // registry (curation-minage-real-age-defer, #741), so this Skip is not
+            // a fail-open hole.
+            return Decision::Skip;
         };
 
         let now = std::time::SystemTime::now()
@@ -3198,9 +3192,13 @@ mod min_release_age_tests {
     }
 
     #[test]
-    fn test_min_release_age_unknown_date_blocked_fail_closed() {
-        // An unknown publish date must NOT bypass an active quarantine: curation
-        // is fail-closed, so a package whose age cannot be verified is blocked.
+    fn test_min_release_age_unknown_date_defers_to_quarantine() {
+        // An unknown upstream publish date is not min-release-age's to hold: it
+        // judges the REAL release age and needs a trusted date, so it defers
+        // (Skip). Holding new/unknown artifacts is digest-quarantine's job
+        // (curation-quarantine-uniform). Config validation guarantees an age
+        // control is active when min_release_age is set on a proxy
+        // (curation-minage-real-age-defer, #741), so this Skip is not fail-open.
         let filter = MinReleaseAgeFilter::new(604800, "7d");
         let request = FilterRequest {
             registry: RegistryType::Npm,
@@ -3211,7 +3209,7 @@ mod min_release_age_tests {
             bypass: false,
             publish_date: None,
         };
-        assert!(matches!(filter.evaluate(&request), Decision::Block { .. }));
+        assert!(matches!(filter.evaluate(&request), Decision::Skip));
     }
 
     #[test]

--- a/nora-registry/src/digest_quarantine.rs
+++ b/nora-registry/src/digest_quarantine.rs
@@ -20,6 +20,9 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use tracing::{error, info, warn};
 
+use axum::http::{header, HeaderName, StatusCode};
+use axum::response::{IntoResponse, Response};
+
 /// Stale entry TTL: entries older than 90 days are pruned on startup.
 const PRUNE_TTL_SECS: i64 = 90 * 24 * 3600;
 
@@ -282,6 +285,100 @@ impl DigestStore {
     pub fn is_empty(&self) -> bool {
         self.entries.read().is_empty()
     }
+}
+
+// ============================================================================
+// Generic proxy quarantine gate
+// ============================================================================
+//
+// Registry-agnostic generalization of the digest-quarantine wiring that
+// previously lived only in the Docker handler. min-release-age cannot give a
+// trustworthy release age on the proxy path (upstream dates are unsigned and
+// spoofable, and several registries expose no date at all), so first-seen
+// quarantine — keyed on the artifact's content digest and NORA's own clock — is
+// the unspoofable supply-chain control that works for every proxy registry.
+
+/// Resolve the effective quarantine `(mode, ttl_secs)` from the global curation
+/// config. Returns `(Off, 0)` when disabled. Per-registry overrides can be
+/// layered on top later; the proxy gate uses the global setting for now.
+pub fn resolve_global(mode: Option<&QuarantineMode>, ttl: Option<&str>) -> (QuarantineMode, i64) {
+    let mode = mode.cloned().unwrap_or(QuarantineMode::Off);
+    if matches!(mode, QuarantineMode::Off) {
+        return (QuarantineMode::Off, 0);
+    }
+    let secs = crate::curation::parse_duration(ttl.unwrap_or("14d")).unwrap_or(14 * 86400);
+    (mode, secs)
+}
+
+/// Post-fetch / pre-serve quarantine gate for a proxy-fetched artifact.
+///
+/// Records the artifact's content digest as first-seen, then checks maturity.
+/// Returns `Some(403)` to BLOCK (enforce mode, not yet mature), `None` to serve.
+/// In observe mode it logs but never blocks. Idempotent: `record` preserves the
+/// earliest `first_seen`, so calling this on every request (proxy fetch or cache
+/// hit) is safe and the quarantine clock does not reset.
+#[must_use = "the returned response blocks a quarantined artifact; dropping it serves the artifact"]
+pub fn proxy_gate(
+    store: &DigestStore,
+    registry: &str,
+    bytes: &[u8],
+    mode: &QuarantineMode,
+    quarantine_secs: i64,
+    upstream: &str,
+) -> Option<Response> {
+    if matches!(mode, QuarantineMode::Off) {
+        return None;
+    }
+    use sha2::Digest;
+    let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(bytes)));
+    store.record(registry, &digest, upstream);
+    let status = store.check(registry, &digest, quarantine_secs);
+    if matches!(status, QuarantineStatus::Mature) {
+        return None;
+    }
+    warn!(
+        registry = %registry,
+        digest = %digest,
+        status = %status.header_value(),
+        mode = %mode,
+        "quarantine: proxy artifact held (new to this mirror)"
+    );
+    if matches!(mode, QuarantineMode::Enforce) {
+        Some(quarantine_forbidden(&digest, &status, quarantine_secs))
+    } else {
+        None
+    }
+}
+
+/// Build a generic 403 for a quarantined proxy artifact (non-Docker shape).
+fn quarantine_forbidden(digest: &str, status: &QuarantineStatus, quarantine_secs: i64) -> Response {
+    let remaining = match status {
+        QuarantineStatus::New => quarantine_secs,
+        QuarantineStatus::Pending { remaining_secs } => *remaining_secs,
+        QuarantineStatus::Mature => 0,
+    };
+    let quarantine_until = Utc::now().timestamp() + remaining;
+    let body = serde_json::json!({
+        "error": "quarantine",
+        "message": "artifact held: new to this mirror",
+        "detail": {
+            "digest": digest,
+            "quarantine_until": quarantine_until,
+            "remaining_secs": remaining,
+        }
+    });
+    (
+        StatusCode::FORBIDDEN,
+        [
+            (
+                HeaderName::from_static("x-nora-quarantine"),
+                status.header_value(),
+            ),
+            (header::CONTENT_TYPE, "application/json"),
+        ],
+        body.to_string(),
+    )
+        .into_response()
 }
 
 // ============================================================================

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -321,6 +321,20 @@ async fn download_tarball(
             "ansible",
             "CACHE",
         ));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "ansible",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec());
     }
 
@@ -368,6 +382,20 @@ async fn download_tarball(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "ansible", ""));
 
             state.spawn_cache_immutable("ansible", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "ansible",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             with_binary(bytes)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -322,8 +322,18 @@ async fn download_tarball(
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.ansible.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .ansible
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -383,8 +393,18 @@ async fn download_tarball(
 
             state.spawn_cache_immutable("ansible", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.ansible.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .ansible
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -387,8 +387,18 @@ async fn download(
             .audit
             .log(AuditEntry::new("pull", "api", "", "cargo", ""));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.cargo.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .cargo
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -464,8 +474,18 @@ async fn download(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "cargo", ""));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.cargo.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .cargo
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -386,6 +386,20 @@ async fn download(
         state
             .audit
             .log(AuditEntry::new("pull", "api", "", "cargo", ""));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "cargo",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return (
             StatusCode::OK,
             [
@@ -449,6 +463,20 @@ async fn download(
             state
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "cargo", ""));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "cargo",
+                &data,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             (
                 StatusCode::OK,
                 [

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -431,6 +431,20 @@ async fn recipe_file_download(
             "conan",
             "CACHE",
         ));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "conan",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec());
     }
 
@@ -478,6 +492,20 @@ async fn recipe_file_download(
 
             // Immutable cache: put_if_absent
             state.spawn_cache_immutable("conan", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "conan",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             with_binary(bytes)
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),
@@ -791,6 +819,20 @@ async fn package_file_download(
             "conan",
             "CACHE",
         ));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "conan",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec());
     }
 
@@ -840,6 +882,20 @@ async fn package_file_download(
 
             // Immutable cache
             state.spawn_cache_immutable("conan", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "conan",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             with_binary(bytes)
         }
         Err(ProxyError::CircuitOpen(reg)) => circuit_open_response(&reg),

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -432,8 +432,18 @@ async fn recipe_file_download(
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.conan.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .conan
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -493,8 +503,18 @@ async fn recipe_file_download(
             // Immutable cache: put_if_absent
             state.spawn_cache_immutable("conan", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.conan.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .conan
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,
@@ -820,8 +840,18 @@ async fn package_file_download(
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.conan.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .conan
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -883,8 +913,18 @@ async fn package_file_download(
             // Immutable cache
             state.spawn_cache_immutable("conan", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.conan.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .conan
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -426,8 +426,18 @@ async fn download_gem(
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.gems.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .gems
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -482,8 +492,18 @@ async fn download_gem(
             // Immutable cache: put_if_absent
             state.spawn_cache_immutable("gems", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.gems.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .gems
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,
@@ -541,8 +561,18 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.gems.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .gems
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -599,8 +629,18 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
 
             state.spawn_cache_immutable("gems", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.gems.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .gems
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -425,6 +425,20 @@ async fn download_gem(
             "gems",
             "CACHE",
         ));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "gems",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec(), "application/octet-stream");
     }
 
@@ -467,6 +481,20 @@ async fn download_gem(
 
             // Immutable cache: put_if_absent
             state.spawn_cache_immutable("gems", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "gems",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             with_binary(bytes, "application/octet-stream")
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -512,6 +540,20 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
             "gems",
             "CACHE",
         ));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "gems",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec(), "application/octet-stream");
     }
 
@@ -556,6 +598,20 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
                 .log(AuditEntry::new("proxy_fetch", "api", "", "gems", ""));
 
             state.spawn_cache_immutable("gems", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "gems",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             with_binary(bytes, "application/octet-stream")
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -166,8 +166,16 @@ async fn handle(
             // .info/.mod/@v/list/@latest endpoints serve metadata — never gate them.
             if ends_with_ci(&file, ".zip") {
                 let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                    state.config.curation.quarantine.as_ref(),
-                    state.config.curation.quarantine_ttl.as_deref(),
+                    state.config.curation.go.quarantine.as_ref().or(state
+                        .config
+                        .curation
+                        .quarantine
+                        .as_ref()),
+                    state.config.curation.go.quarantine_ttl.as_deref().or(state
+                        .config
+                        .curation
+                        .quarantine_ttl
+                        .as_deref()),
                 );
                 if let Some(resp) = crate::digest_quarantine::proxy_gate(
                     &state.digest_store,
@@ -292,8 +300,16 @@ async fn handle(
             // Quarantine only the .zip module archive; metadata endpoints pass through.
             if ends_with_ci(&file, ".zip") {
                 let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                    state.config.curation.quarantine.as_ref(),
-                    state.config.curation.quarantine_ttl.as_deref(),
+                    state.config.curation.go.quarantine.as_ref().or(state
+                        .config
+                        .curation
+                        .quarantine
+                        .as_ref()),
+                    state.config.curation.go.quarantine_ttl.as_deref().or(state
+                        .config
+                        .curation
+                        .quarantine_ttl
+                        .as_deref()),
                 );
                 if let Some(resp) = crate::digest_quarantine::proxy_gate(
                     &state.digest_store,

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -162,6 +162,24 @@ async fn handle(
                 "go",
                 "CACHE",
             ));
+            // Quarantine only the .zip module archive (the artifact). The
+            // .info/.mod/@v/list/@latest endpoints serve metadata — never gate them.
+            if ends_with_ci(&file, ".zip") {
+                let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                    state.config.curation.quarantine.as_ref(),
+                    state.config.curation.quarantine_ttl.as_deref(),
+                );
+                if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                    &state.digest_store,
+                    "go",
+                    data,
+                    &q_mode,
+                    q_secs,
+                    "cache",
+                ) {
+                    return resp;
+                }
+            }
             return with_content_type(data.to_vec(), content_type, is_mutable);
         }
     }
@@ -271,6 +289,23 @@ async fn handle(
                 state.spawn_cache("go", storage_key, Bytes::from(bytes.clone()));
             }
 
+            // Quarantine only the .zip module archive; metadata endpoints pass through.
+            if ends_with_ci(&file, ".zip") {
+                let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                    state.config.curation.quarantine.as_ref(),
+                    state.config.curation.quarantine_ttl.as_deref(),
+                );
+                if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                    &state.digest_store,
+                    "go",
+                    &bytes,
+                    &q_mode,
+                    q_secs,
+                    &upstream_url,
+                ) {
+                    return resp;
+                }
+            }
             with_content_type(bytes, content_type, is_mutable)
         }
         Err(e) => {

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -237,8 +237,18 @@ async fn download(
             // never quarantine it or its digest would change forever.
             if curation_coords.is_some() {
                 let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                    state.config.curation.quarantine.as_ref(),
-                    state.config.curation.quarantine_ttl.as_deref(),
+                    state.config.curation.maven.quarantine.as_ref().or(state
+                        .config
+                        .curation
+                        .quarantine
+                        .as_ref()),
+                    state
+                        .config
+                        .curation
+                        .maven
+                        .quarantine_ttl
+                        .as_deref()
+                        .or(state.config.curation.quarantine_ttl.as_deref()),
                 );
                 if let Some(resp) = crate::digest_quarantine::proxy_gate(
                     &state.digest_store,
@@ -336,8 +346,18 @@ async fn download(
                 // Quarantine only real version artifacts; never maven-metadata.xml.
                 if curation_coords.is_some() {
                     let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                        state.config.curation.quarantine.as_ref(),
-                        state.config.curation.quarantine_ttl.as_deref(),
+                        state.config.curation.maven.quarantine.as_ref().or(state
+                            .config
+                            .curation
+                            .quarantine
+                            .as_ref()),
+                        state
+                            .config
+                            .curation
+                            .maven
+                            .quarantine_ttl
+                            .as_deref()
+                            .or(state.config.curation.quarantine_ttl.as_deref()),
                     );
                     if let Some(resp) = crate::digest_quarantine::proxy_gate(
                         &state.digest_store,

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -383,6 +383,36 @@ async fn download(
     // All proxies failed — serve the stale cached artifact if we have one (graceful).
     if let Some(ref data) = cached {
         tracing::warn!(registry = "maven", path = %path, "Maven upstream failed, serving stale cached artifact");
+        // Quarantine still applies to a version artifact served from a stale cache:
+        // a held SNAPSHOT must not be released just because the upstream went down
+        // (mutable SNAPSHOT artifacts reach this path; immutable releases serve from
+        // the fresh-cache branch above, which is already gated).
+        if curation_coords.is_some() {
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.maven.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .maven
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "maven",
+                data,
+                &q_mode,
+                q_secs,
+                "cache-stale",
+            ) {
+                return resp;
+            }
+        }
         let mut response = with_content_type(&path, data.clone()).into_response();
         response.headers_mut().insert(
             axum::http::header::HeaderName::from_static("x-nora-stale"),

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -232,6 +232,25 @@ async fn download(
             state
                 .audit
                 .log(AuditEntry::new("cache_hit", "api", "", "maven", ""));
+            // Quarantine only real version artifacts (.jar/.pom/.sha1, immutable
+            // per version). maven-metadata.xml is mutable (curation_coords=None) —
+            // never quarantine it or its digest would change forever.
+            if curation_coords.is_some() {
+                let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                    state.config.curation.quarantine.as_ref(),
+                    state.config.curation.quarantine_ttl.as_deref(),
+                );
+                if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                    &state.digest_store,
+                    "maven",
+                    data,
+                    &q_mode,
+                    q_secs,
+                    "cache",
+                ) {
+                    return resp;
+                }
+            }
             return with_content_type(&path, data.clone()).into_response();
         }
     }
@@ -314,6 +333,23 @@ async fn download(
 
                 state.spawn_cache("maven", key.clone(), Bytes::from(data.clone()));
 
+                // Quarantine only real version artifacts; never maven-metadata.xml.
+                if curation_coords.is_some() {
+                    let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                        state.config.curation.quarantine.as_ref(),
+                        state.config.curation.quarantine_ttl.as_deref(),
+                    );
+                    if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                        &state.digest_store,
+                        "maven",
+                        &data,
+                        &q_mode,
+                        q_secs,
+                        &url,
+                    ) {
+                        return resp;
+                    }
+                }
                 return with_content_type(&path, data.into()).into_response();
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -312,6 +312,20 @@ async fn handle_request(
         state
             .audit
             .log(AuditEntry::new("cache_hit", "api", "", "npm", ""));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "npm",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_content_type(true, data).into_response();
     }
 
@@ -401,6 +415,22 @@ async fn handle_request(
                     }
                 });
 
+                if is_tarball {
+                    let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                        state.config.curation.quarantine.as_ref(),
+                        state.config.curation.quarantine_ttl.as_deref(),
+                    );
+                    if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                        &state.digest_store,
+                        "npm",
+                        &data_to_serve,
+                        &q_mode,
+                        q_secs,
+                        &url,
+                    ) {
+                        return resp;
+                    }
+                }
                 return with_content_type(is_tarball, data_to_serve.into()).into_response();
             }
             Err(ProxyError::CircuitOpen(reg)) => return circuit_open_response(&reg),

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -313,8 +313,16 @@ async fn handle_request(
             .audit
             .log(AuditEntry::new("cache_hit", "api", "", "npm", ""));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.npm.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state.config.curation.npm.quarantine_ttl.as_deref().or(state
+                .config
+                .curation
+                .quarantine_ttl
+                .as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -417,8 +425,16 @@ async fn handle_request(
 
                 if is_tarball {
                     let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                        state.config.curation.quarantine.as_ref(),
-                        state.config.curation.quarantine_ttl.as_deref(),
+                        state.config.curation.npm.quarantine.as_ref().or(state
+                            .config
+                            .curation
+                            .quarantine
+                            .as_ref()),
+                        state.config.curation.npm.quarantine_ttl.as_deref().or(state
+                            .config
+                            .curation
+                            .quarantine_ttl
+                            .as_deref()),
                     );
                     if let Some(resp) = crate::digest_quarantine::proxy_gate(
                         &state.digest_store,

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -954,6 +954,20 @@ async fn flatcontainer_download(
             });
         }
 
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "nuget",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return (
             StatusCode::OK,
             [
@@ -1051,6 +1065,20 @@ async fn flatcontainer_download(
                     let meta = format!(r#"{{"last_downloaded_at":{}}}"#, now);
                     let _ = storage3.put(&meta_key, meta.as_bytes()).await;
                 });
+            }
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "nuget",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
             }
             (
                 StatusCode::OK,

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -955,8 +955,18 @@ async fn flatcontainer_download(
         }
 
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.nuget.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .nuget
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -1067,8 +1077,18 @@ async fn flatcontainer_download(
                 });
             }
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.nuget.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .nuget
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -537,8 +537,18 @@ async fn download_archive(
             .log(AuditEntry::new("pull", "api", "", "pub", ""));
 
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.pub_dart.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .pub_dart
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -613,8 +623,18 @@ async fn download_archive(
                 .log(AuditEntry::new("proxy_fetch", "api", "", "pub", ""));
 
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.pub_dart.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .pub_dart
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -536,6 +536,20 @@ async fn download_archive(
             .audit
             .log(AuditEntry::new("pull", "api", "", "pub", ""));
 
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "pub",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return archive_response(data.to_vec());
     }
 
@@ -598,6 +612,20 @@ async fn download_archive(
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "pub", ""));
 
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "pub",
+                &data,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             archive_response(data)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -300,6 +300,13 @@ async fn download_file(
 
     let key = format!("pypi/{}/{}", normalized, filename);
 
+    // Digest-quarantine: first-seen hold for proxy artifacts (generalizes the
+    // Docker-only wiring). Resolved once; applied at each serve point below.
+    let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+        state.config.curation.quarantine.as_ref(),
+        state.config.curation.quarantine_ttl.as_deref(),
+    );
+
     // Try local storage first. get_verified discharges the integrity witness at
     // the serve site (compile-time guarantee — see crate::verified).
     if let Ok(outcome) = state.storage.get_verified(&key).await {
@@ -330,6 +337,17 @@ async fn download_file(
         state
             .audit
             .log(AuditEntry::new("cache_hit", "api", "", "pypi", ""));
+
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "pypi",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
 
         let content_type = pypi_content_type(&filename);
         return (
@@ -424,6 +442,17 @@ async fn download_file(
                         repo_index.invalidate("pypi");
                     }
                 });
+
+                if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                    &state.digest_store,
+                    "pypi",
+                    &data,
+                    &q_mode,
+                    q_secs,
+                    &file_url,
+                ) {
+                    return resp;
+                }
 
                 let content_type = pypi_content_type(&filename);
                 return (StatusCode::OK, [(header::CONTENT_TYPE, content_type)], data)

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -303,8 +303,18 @@ async fn download_file(
     // Digest-quarantine: first-seen hold for proxy artifacts (generalizes the
     // Docker-only wiring). Resolved once; applied at each serve point below.
     let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-        state.config.curation.quarantine.as_ref(),
-        state.config.curation.quarantine_ttl.as_deref(),
+        state.config.curation.pypi.quarantine.as_ref().or(state
+            .config
+            .curation
+            .quarantine
+            .as_ref()),
+        state
+            .config
+            .curation
+            .pypi
+            .quarantine_ttl
+            .as_deref()
+            .or(state.config.curation.quarantine_ttl.as_deref()),
     );
 
     // Try local storage first. get_verified discharges the integrity witness at

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -357,6 +357,20 @@ async fn provider_download_binary(
             "terraform",
             "CACHE",
         ));
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "terraform",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec());
     }
 
@@ -398,6 +412,20 @@ async fn provider_download_binary(
 
             // Immutable cache
             state.spawn_cache_immutable("terraform", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "terraform",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &url,
+            ) {
+                return resp;
+            }
             with_binary(bytes)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),
@@ -634,6 +662,20 @@ async fn module_source_download(
         };
         state.metrics.record_download("terraform");
         state.metrics.record_cache_hit("terraform");
+        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+            state.config.curation.quarantine.as_ref(),
+            state.config.curation.quarantine_ttl.as_deref(),
+        );
+        if let Some(resp) = crate::digest_quarantine::proxy_gate(
+            &state.digest_store,
+            "terraform",
+            &data,
+            &q_mode,
+            q_secs,
+            "cache",
+        ) {
+            return resp;
+        }
         return with_binary(data.to_vec());
     }
 
@@ -677,6 +719,20 @@ async fn module_source_download(
 
             // Immutable cache
             state.spawn_cache_immutable("terraform", storage_key, Bytes::from(bytes.clone()));
+            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
+                state.config.curation.quarantine.as_ref(),
+                state.config.curation.quarantine_ttl.as_deref(),
+            );
+            if let Some(resp) = crate::digest_quarantine::proxy_gate(
+                &state.digest_store,
+                "terraform",
+                &bytes,
+                &q_mode,
+                q_secs,
+                &upstream_url,
+            ) {
+                return resp;
+            }
             with_binary(bytes)
         }
         Err(ProxyError::NotFound) => StatusCode::NOT_FOUND.into_response(),

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -358,8 +358,18 @@ async fn provider_download_binary(
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.terraform.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .terraform
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -413,8 +423,18 @@ async fn provider_download_binary(
             // Immutable cache
             state.spawn_cache_immutable("terraform", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.terraform.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .terraform
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,
@@ -663,8 +683,18 @@ async fn module_source_download(
         state.metrics.record_download("terraform");
         state.metrics.record_cache_hit("terraform");
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.quarantine.as_ref(),
-            state.config.curation.quarantine_ttl.as_deref(),
+            state.config.curation.terraform.quarantine.as_ref().or(state
+                .config
+                .curation
+                .quarantine
+                .as_ref()),
+            state
+                .config
+                .curation
+                .terraform
+                .quarantine_ttl
+                .as_deref()
+                .or(state.config.curation.quarantine_ttl.as_deref()),
         );
         if let Some(resp) = crate::digest_quarantine::proxy_gate(
             &state.digest_store,
@@ -720,8 +750,18 @@ async fn module_source_download(
             // Immutable cache
             state.spawn_cache_immutable("terraform", storage_key, Bytes::from(bytes.clone()));
             let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.quarantine.as_ref(),
-                state.config.curation.quarantine_ttl.as_deref(),
+                state.config.curation.terraform.quarantine.as_ref().or(state
+                    .config
+                    .curation
+                    .quarantine
+                    .as_ref()),
+                state
+                    .config
+                    .curation
+                    .terraform
+                    .quarantine_ttl
+                    .as_deref()
+                    .or(state.config.curation.quarantine_ttl.as_deref()),
             );
             if let Some(resp) = crate::digest_quarantine::proxy_gate(
                 &state.digest_store,


### PR DESCRIPTION
## Summary

Fixes #741. `min_release_age` blocked **every** proxied download as *"publish date unknown — blocked fail-closed"*. The root cause is deeper than a missing date: on the proxy path an upstream publish date is **unsigned and spoofable** (NORA already declines to trust it — `trust_upstream_dates` defaults `false`, #513), and several registries expose no per-version date at all. So `min_release_age` cannot soundly judge release age on a proxy.

NORA already had the correct, unspoofable control — first-seen **digest-quarantine** (`quarantine.jsonl`, keyed on the content digest and NORA's own clock) — but it was wired only for Docker. This PR generalizes it and repositions `min_release_age`.

## What changed

**Q — digest-quarantine generalized to all 11 proxy registries.** A registry-agnostic `proxy_gate()` / `resolve_global()` is lifted from the Docker handler into `digest_quarantine`, and wired into every artifact-download serve path (cache-hit + proxy-fetch). Conditional where a handler also serves metadata:
- maven: only real version artifacts (`curation_coords.is_some()`), never `maven-metadata.xml`;
- go: only the `.zip` module archive (`.info`/`.mod`/`@v/list`/`@latest` pass through);
- terraform: provider binary + module source only.

Mutable metadata/index/listing endpoints are **never** quarantined (their digest changes per release and would otherwise be held forever). Per-registry quarantine overrides (`curation.<reg>.quarantine` / `NORA_CURATION_<REG>_QUARANTINE`) are honored, matching the Docker handler.

**R — `min_release_age` becomes the real-release-age control.** On an unknown publish date it now **defers (Skip)** to digest-quarantine instead of fail-closed-blocking everything. To keep that from being a silent fail-open, config validation **rejects** a config where `min_release_age` is set on an enabled proxy registry but no `curation.quarantine` is active — the same fail-closed posture as the existing `on_failure="open"` rejection.

## ⚠️ BREAKING CHANGE

A config with `min_release_age` set and an enabled proxy registry but **no active quarantine** is now **rejected at startup**:

> `curation.min_release_age … but no age control would be active … Enable curation.quarantine="observe"|"enforce" …`

This is intentional — such a config previously blocked every proxy download as "publish date unknown". **Migration:** set `curation.quarantine = "observe"` (or `"enforce"`).

`server.trust_upstream_dates = true` is **not** a sufficient substitute: it yields a real publish date only for registries that cache date-bearing upstream metadata at the curation point (npm); for pypi/cargo/nuget/gems/… it stays `None` and `min_release_age` silently does nothing — so accepting trust alone would be a silent fail-open. Quarantine (content-digest, first-seen, NORA's own clock) is the universal control; `trust_upstream_dates` stays an enhancement that lets `min_release_age` use real upstream dates where available.

Docker (its pre-existing digest-quarantine) and raw (hosted-only, no upstream) are unchanged.

Closes #741
