### PR TITLE
fix(auth): token-management authorization (owner-scope + admin-mint cap)

### DIFF
--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -22,6 +22,12 @@ pub use token_routes::{token_routes, TokenListItem, TokenListResponse};
 #[derive(Clone, Debug)]
 pub struct AuthenticatedUser(pub String);
 
+/// The verified role carried in request extensions after successful auth.
+/// Basic-auth (htpasswd) identities have no role concept and are recorded as
+/// `Write` (never admin), so role-gated owner-scope treats them as non-admin.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedRole(pub crate::tokens::Role);
+
 use axum::{
     body::Body,
     extract::{ConnectInfo, State},
@@ -248,6 +254,9 @@ pub async fn auth_middleware(
         request
             .extensions_mut()
             .insert(AuthenticatedUser("anonymous".to_string()));
+        request
+            .extensions_mut()
+            .insert(AuthenticatedRole(crate::tokens::Role::Read));
         return next.run(request).await;
     }
 
@@ -310,6 +319,7 @@ pub async fn auth_middleware(
                         .extensions_mut()
                         .insert(NamespaceAuthority::Unrestricted);
                     request.extensions_mut().insert(AuthenticatedUser(user));
+                    request.extensions_mut().insert(AuthenticatedRole(role));
                     return next.run(request).await;
                 }
                 Err(_) => {
@@ -356,6 +366,9 @@ pub async fn auth_middleware(
                         request
                             .extensions_mut()
                             .insert(AuthenticatedUser(identity.subject.clone()));
+                        request
+                            .extensions_mut()
+                            .insert(AuthenticatedRole(identity.role));
                         return next.run(request).await;
                     }
                     Err(_) => {
@@ -434,6 +447,7 @@ pub async fn auth_middleware(
             request
                 .extensions_mut()
                 .insert(AuthenticatedUser(token_user));
+            request.extensions_mut().insert(AuthenticatedRole(role));
             return next.run(request).await;
         }
         if let Some(ip) = client_ip {
@@ -458,6 +472,9 @@ pub async fn auth_middleware(
     request
         .extensions_mut()
         .insert(AuthenticatedUser(username.to_string()));
+    request
+        .extensions_mut()
+        .insert(AuthenticatedRole(crate::tokens::Role::Write));
     next.run(request).await
 }
 

--- a/nora-registry/src/auth/token_routes.rs
+++ b/nora-registry/src/auth/token_routes.rs
@@ -116,6 +116,24 @@ async fn create_token(
                 .into_response()
         }
     };
+    // Block role self-escalation: an admin token may be minted via this public
+    // route only by an account listed in auth.admin_users. Read/write are
+    // unaffected (GHSA-78cx-cfhm-rgmx).
+    if role == Role::Admin
+        && !state
+            .config
+            .auth
+            .admin_users
+            .iter()
+            .any(|u| u == &req.username)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            "admin role is not permitted for this account; add it to auth.admin_users",
+        )
+            .into_response();
+    }
+
     match token_store.create_token(&req.username, req.ttl_days, req.description, role) {
         Ok(token) => Json(CreateTokenResponse {
             token,

--- a/nora-registry/src/auth/token_routes.rs
+++ b/nora-registry/src/auth/token_routes.rs
@@ -235,6 +235,17 @@ async fn revoke_token(
         }
     };
 
+    // Owner-scope: a self-service caller may revoke only its own tokens. 404 (not
+    // 403) so a non-owner cannot probe which token IDs exist
+    // (GHSA-78cx-cfhm-rgmx — cross-user token revocation).
+    if !token_store
+        .list_tokens(&req.username)
+        .iter()
+        .any(|t| t.file_id == req.hash_prefix)
+    {
+        return (StatusCode::NOT_FOUND, "Token not found").into_response();
+    }
+
     match token_store.revoke_token(&req.hash_prefix) {
         Ok(()) => (StatusCode::OK, "Token revoked").into_response(),
         Err(e) => (StatusCode::NOT_FOUND, e.to_string()).into_response(),

--- a/nora-registry/src/config/auth.rs
+++ b/nora-registry/src/config/auth.rs
@@ -172,6 +172,14 @@ pub struct AuthConfig {
     /// OIDC providers for workload identity (CI/CD zero-secret auth)
     #[serde(default)]
     pub oidc: OidcConfig,
+    /// htpasswd usernames permitted to mint `admin`-role API tokens via the
+    /// public `POST /api/tokens` route. Empty (default) means no account can
+    /// self-mint an admin token there — set this to bootstrap admins. Read and
+    /// write tokens are unaffected (GHSA-78cx-cfhm-rgmx — block role
+    /// self-escalation).
+    /// ENV: NORA_AUTH_ADMIN_USERS=alice,ops
+    #[serde(default)]
+    pub admin_users: Vec<String>,
 }
 
 /// OIDC configuration — multiple providers for workload identity auth.
@@ -330,6 +338,7 @@ impl Default for AuthConfig {
             token_cache_ttl: 300,
             trusted_proxies: TrustedProxies::default_loopback(),
             oidc: OidcConfig::default(),
+            admin_users: Vec::new(),
         }
     }
 }
@@ -353,6 +362,13 @@ impl AuthConfig {
         }
         if let Ok(val) = env::var("NORA_AUTH_TRUSTED_PROXIES") {
             self.trusted_proxies = TrustedProxies::parse(&val);
+        }
+        if let Ok(val) = env::var("NORA_AUTH_ADMIN_USERS") {
+            self.admin_users = val
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
         }
         if let Ok(val) = env::var("NORA_AUTH_OIDC_ENABLED") {
             self.oidc.enabled = val.to_lowercase() == "true" || val == "1";

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -165,6 +165,7 @@ fn build_context(
             token_cache_ttl: 300,
             trusted_proxies: crate::config::TrustedProxies::default_loopback(),
             oidc: crate::config::OidcConfig::default(),
+            admin_users: Vec::new(),
         },
         rate_limit: RateLimitConfig {
             enabled: false,

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -18,9 +18,10 @@ use axum::{
     middleware::Next,
     response::{Html, IntoResponse, Redirect, Response},
     routing::{get, post},
-    Form, Router,
+    Extension, Form, Router,
 };
 
+use crate::auth::{AuthenticatedRole, AuthenticatedUser};
 use api::*;
 use i18n::Lang;
 use templates::*;
@@ -841,12 +842,17 @@ async fn ansible_browse(
 /// Token management page (GET /ui/tokens)
 async fn tokens_page(
     State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(role): Extension<AuthenticatedRole>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let lang = extract_lang_from_headers(&headers);
 
+    // Owner-scope: non-admins see only their own tokens; admins see all
+    // (GHSA-78cx-cfhm-rgmx — cross-user token enumeration).
     let tokens = match &state.tokens {
-        Some(store) => store.list_all_tokens(),
+        Some(store) if role.0.can_admin() => store.list_all_tokens(),
+        Some(store) => store.list_tokens(&user.0),
         None => vec![],
     };
 
@@ -930,12 +936,17 @@ async fn tokens_create(
 /// List tokens HTMX fragment (GET /api/ui/tokens/list)
 async fn tokens_list(
     State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(role): Extension<AuthenticatedRole>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let lang = extract_lang_from_headers(&headers);
 
+    // Owner-scope: non-admins see only their own tokens; admins see all
+    // (GHSA-78cx-cfhm-rgmx — cross-user token enumeration).
     let tokens = match &state.tokens {
-        Some(store) => store.list_all_tokens(),
+        Some(store) if role.0.can_admin() => store.list_all_tokens(),
+        Some(store) => store.list_tokens(&user.0),
         None => vec![],
     };
 
@@ -946,6 +957,8 @@ async fn tokens_list(
 async fn tokens_revoke(
     State(state): State<AppState>,
     Path(file_id): Path<String>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(role): Extension<AuthenticatedRole>,
     headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     // CSRF check
@@ -973,10 +986,27 @@ async fn tokens_revoke(
         }
     };
 
+    // Owner-scope: non-admins may revoke only their own tokens. Return 404 (not
+    // 403) so a non-owner cannot probe which token IDs exist
+    // (GHSA-78cx-cfhm-rgmx — cross-user token revocation).
+    let is_admin = role.0.can_admin();
+    if !is_admin
+        && !store
+            .list_tokens(&user.0)
+            .iter()
+            .any(|t| t.file_id == file_id)
+    {
+        return (StatusCode::NOT_FOUND, Html("Token not found".to_string()));
+    }
+
     match store.revoke_token(&file_id) {
         Ok(()) => {
-            // Return refreshed token list
-            let tokens = store.list_all_tokens();
+            // Return refreshed token list (same owner-scope as the list view)
+            let tokens = if is_admin {
+                store.list_all_tokens()
+            } else {
+                store.list_tokens(&user.0)
+            };
             (
                 StatusCode::OK,
                 Html(render_token_list_fragment(&tokens, lang)),


### PR DESCRIPTION
Fixes the token-management broken access control reported in GHSA-78cx-cfhm-rgmx (CWE-862).

## Changes
- **Owner-scope token list/revoke** — `/ui/tokens`, `/api/ui/tokens`, and the public `/api/tokens/revoke` now scope to the authenticated owner; admins still manage all. A non-owned id returns `404` (not `403`) so callers cannot probe which ids exist. The verified role is carried into request extensions (`AuthenticatedRole`).
- **Admin-mint cap** — `POST /api/tokens` no longer mints an `admin` token for any htpasswd account. **Breaking:** an `admin` token may be minted there only by an account listed in `auth.admin_users` (`NORA_AUTH_ADMIN_USERS`), empty by default. Read and write tokens are unaffected.

## Migration
Set `NORA_AUTH_ADMIN_USERS=<your-admin-user>` before upgrading if you rely on `POST /api/tokens` to create admin tokens.

## Verification
- `cargo test -p nora-registry`: 1407 + 57 + 6 pass; `clippy -D warnings` clean; `fmt --check` clean.
- Live A/B: a write-scoped token can no longer enumerate or revoke another user's admin token (404), and a non-listed account can no longer self-mint an admin token (403).

Follow-up (proper RBAC — dedicated admin route + OIDC role-based admin): #746.
