### PR TITLE
fix(docker): keep deploy/config.docker.toml in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,8 @@ fuzz/
 coverage/
 data/
 deploy/
+# but keep the baked container config the image stages COPY (#719)
+!deploy/config.docker.toml
 dist/
 docs-ru/
 docs-site/


### PR DESCRIPTION
The root `.dockerignore` excludes `deploy/`, but the image stages `COPY deploy/config.docker.toml` (#719), so the v0.9.5 multi-platform release build failed with `"deploy/config.docker.toml": not found` ([run 27840699274](https://github.com/getnora-io/nora/actions/runs/27840699274)). Un-ignore that one file; the rest of `deploy/` stays excluded. Verified: with the fix the COPY resolves; reverting it reproduces the exact error.