### PR TITLE
ci(release): supply the cross-compiled arm64 binary to the native image build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,14 +183,24 @@ jobs:
           echo "Disk after cleanup: $(df -h / | tail -1 | awk '{print $4 " free"}')"
 
   # ── Alpine arm64 — built NATIVELY on a GitHub-hosted arm64 runner (no QEMU). ───
+  # deploy/Dockerfile.release COPYs the pre-built nora-linux-${TARGETARCH}, so this
+  # job pulls the cross-compiled arm64 binary from the build job's artifact into the
+  # context (needs: build). apk now runs natively on arm64 — no emulation, no crash.
   build-image-arm64:
     name: Build alpine image (arm64, native)
     runs-on: ubuntu-24.04-arm
+    needs: build
     permissions:
       contents: read
       packages: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Download cross-compiled binaries into the build context
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: nora-binary-${{ github.run_id }}
+          path: .
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4


### PR DESCRIPTION
## Follow-up to #756

#756 moved the arm64 image build to a native `ubuntu-24.04-arm` runner (fixing the QEMU `apk` crash). The native runner works — checkout/buildx/login all succeed — but the **build step** then failed:

```
#10 ERROR: failed to calculate checksum of ref ...: "/nora-linux-arm64": not found
```

`deploy/Dockerfile.release` packages from **pre-built binaries** (`COPY nora-linux-${TARGETARCH}`, no in-image compile), and the arm64 runner's context had no `nora-linux-arm64` — it's cross-compiled in the `build` job, not on this runner.

## Fix

`build-image-arm64` now:
- `needs: build` (so the cross-compiled binary exists), and
- downloads the `nora-binary-<run_id>` artifact into the context, so the `COPY nora-linux-arm64` resolves.

`apk` still runs natively on the arm64 runner (no emulation). Verified: YAML valid; the build is validated by the next tag run.

Refs #756.