### PR TITLE
ci(release): harden nfpm install against transient CDN failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,6 +344,9 @@ jobs:
       contents: read
 
     strategy:
+      # One package format failing (e.g. a flaky tool download) must not cancel
+      # the other three — each row is independent.
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
@@ -379,9 +382,25 @@ jobs:
 
       - name: Install nfpm
         run: |
+          set -o pipefail
           NFPM_VERSION=2.46.3
+          # Prefer a matching nfpm already on the runner (persistent self-hosted
+          # box) — avoids a per-release fetch from the GitHub release CDN, which
+          # has no SLA and has hung mid-stream on transient network blips.
+          if command -v nfpm >/dev/null 2>&1 && nfpm --version 2>/dev/null | grep -q "$NFPM_VERSION"; then
+            echo "using pre-installed nfpm at $(command -v nfpm)"
+            nfpm --version
+            exit 0
+          fi
+          # Fallback: fetch the pinned release, hardened against transient CDN
+          # failures (retries on connection/HTTP errors, bounded timeouts,
+          # pipefail so a truncated download fails the step instead of feeding
+          # tar an empty stream).
           mkdir -p "$RUNNER_TEMP/bin"
-          curl -sfL "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" | tar xz -C "$RUNNER_TEMP/bin" nfpm
+          curl -fSL --retry 5 --retry-all-errors --retry-delay 3 \
+            --connect-timeout 15 --max-time 120 \
+            "https://github.com/goreleaser/nfpm/releases/download/v${NFPM_VERSION}/nfpm_${NFPM_VERSION}_Linux_x86_64.tar.gz" \
+            | tar xz -C "$RUNNER_TEMP/bin" nfpm
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
           "$RUNNER_TEMP/bin/nfpm" --version
 


### PR DESCRIPTION
The `v0.9.5` release run failed at **Package (rpm-arm64) → Install nfpm**, not in the image build. The native arm64 image build (#756/#757) succeeded; this is a separate, pre-existing fragility in package assembly.

## Root cause

The step fetched the pinned nfpm release from the GitHub release CDN on every package build with a bare:

```bash
curl -sfL ".../nfpm_2.46.3_Linux_x86_64.tar.gz" | tar xz -C "$RUNNER_TEMP/bin" nfpm
```

No retries, no timeouts, no `pipefail`. On the failed run, that CDN stalled mid-stream for ~5 minutes, then the truncated stream reached tar as an empty file:

```
gzip: stdin: unexpected end of file
tar: Child returned status 1
```

`curl -s` hid the stall, and without `pipefail` the curl failure was only surfaced via tar. `fail-fast` (default) then cancelled the other three package formats. Egress to the CDN was verified healthy again minutes later (HTTP 200, 1.2s) — a transient blip, not a persistent block.

## Fix

- **Prefer an nfpm already on the runner** (the package job runs on the persistent self-hosted runner) when its version matches the pin — eliminates the per-release network fetch entirely.
- **Hardened fallback download**: `--retry 5 --retry-all-errors --retry-delay 3 --connect-timeout 15 --max-time 120` and `set -o pipefail`, so a truncated stream fails the step loudly instead of silently feeding tar an empty file.
- **`fail-fast: false`** on the package matrix — one format flaking no longer cancels the other three independent rows.

Pin (`2.46.3`) and the build/sign/upload steps are unchanged. Image build and binaries are untouched; this only affects Linux package (deb/rpm) assembly.

## Verify
- `bash -n` + `shellcheck -S warning` clean on the step script.
- YAML parses; 7 jobs intact; `fail-fast: false` lands under `package`.

After merge, re-tag `v0.9.5` onto the merge commit for one clean release run.