### PR TITLE
perf(index): read size/mtime from listing, drop per-key stat on rebuild

### DIFF
--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -10,7 +10,7 @@
 //! - Single rebuild at a time per registry (rebuild_lock)
 
 use crate::registry_type::RegistryType;
-use crate::storage::Storage;
+use crate::storage::{FileMeta, Storage};
 use crate::ui::components::format_timestamp;
 use crate::validation::ends_with_ci;
 use parking_lot::RwLock;
@@ -244,8 +244,8 @@ impl Default for RepoIndex {
 /// List storage keys under `prefix` for an index rebuild. Returns `None` (not an
 /// empty Vec) when the listing itself fails, so the caller can keep the existing
 /// index dirty and retry rather than caching a falsely-empty result as fresh.
-async fn list_keys(storage: &Storage, prefix: &str) -> Option<Vec<String>> {
-    match storage.list(prefix).await {
+async fn list_keys(storage: &Storage, prefix: &str) -> Option<Vec<(String, FileMeta)>> {
+    match storage.list_with_meta(prefix).await {
         Ok(keys) => Some(keys),
         Err(e) => {
             tracing::warn!(prefix, error = %e, "index rebuild: storage list failed");
@@ -258,7 +258,7 @@ async fn build_docker_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "docker/").await?;
     let mut repos: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if ends_with_ci(key, ".meta.json") {
             continue;
         }
@@ -285,11 +285,9 @@ async fn build_docker_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
             // declared config+layer sizes — a "virtual" size that multi-counts
             // layers shared across tags and ignores real storage, so a 7.2G
             // image tree could be reported as something else entirely (#588).
-            if let Some(meta) = storage.stat(key).await {
-                entry.1 += meta.size;
-                if meta.modified > entry.2 {
-                    entry.2 = meta.modified;
-                }
+            entry.1 += meta.size;
+            if meta.modified > entry.2 {
+                entry.2 = meta.modified;
             }
 
             // Count = number of distinct tags. Each push writes BOTH a
@@ -314,7 +312,7 @@ async fn build_maven_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "maven/").await?;
     let mut repos: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if let Some(rest) = key.strip_prefix("maven/") {
             let parts: Vec<_> = rest.split('/').collect();
             if parts.len() >= 2 {
@@ -330,11 +328,9 @@ async fn build_maven_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
                     entry.0 += 1;
                 }
 
-                if let Some(meta) = storage.stat(key).await {
-                    entry.1 += meta.size;
-                    if meta.modified > entry.2 {
-                        entry.2 = meta.modified;
-                    }
+                entry.1 += meta.size;
+                if meta.modified > entry.2 {
+                    entry.2 = meta.modified;
                 }
             }
         }
@@ -348,7 +344,7 @@ async fn build_npm_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
     // Count tarballs instead of parsing metadata.json (faster than parsing JSON)
-    for key in &keys {
+    for (key, meta) in &keys {
         if let Some(rest) = key.strip_prefix("npm/") {
             // Pattern: npm/{package}/tarballs/{file}.tgz
             // Scoped:  npm/@scope/package/tarballs/{file}.tgz
@@ -364,11 +360,9 @@ async fn build_npm_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
                     let entry = packages.entry(name).or_insert((0, 0, 0));
                     entry.0 += 1;
 
-                    if let Some(meta) = storage.stat(key).await {
-                        entry.1 += meta.size;
-                        if meta.modified > entry.2 {
-                            entry.2 = meta.modified;
-                        }
+                    entry.1 += meta.size;
+                    if meta.modified > entry.2 {
+                        entry.2 = meta.modified;
                     }
                 }
             }
@@ -382,7 +376,7 @@ async fn build_cargo_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "cargo/").await?;
     let mut crates: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if ends_with_ci(key, ".crate") {
             if let Some(rest) = key.strip_prefix("cargo/") {
                 let parts: Vec<_> = rest.split('/').collect();
@@ -391,11 +385,9 @@ async fn build_cargo_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
                     let entry = crates.entry(name).or_insert((0, 0, 0));
                     entry.0 += 1;
 
-                    if let Some(meta) = storage.stat(key).await {
-                        entry.1 += meta.size;
-                        if meta.modified > entry.2 {
-                            entry.2 = meta.modified;
-                        }
+                    entry.1 += meta.size;
+                    if meta.modified > entry.2 {
+                        entry.2 = meta.modified;
                     }
                 }
             }
@@ -409,7 +401,7 @@ async fn build_pypi_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "pypi/").await?;
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if let Some(rest) = key.strip_prefix("pypi/") {
             let parts: Vec<_> = rest.split('/').collect();
             if parts.len() >= 2 {
@@ -422,11 +414,9 @@ async fn build_pypi_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
                     entry.0 += 1;
                 }
 
-                if let Some(meta) = storage.stat(key).await {
-                    entry.1 += meta.size;
-                    if meta.modified > entry.2 {
-                        entry.2 = meta.modified;
-                    }
+                entry.1 += meta.size;
+                if meta.modified > entry.2 {
+                    entry.2 = meta.modified;
                 }
             }
         }
@@ -439,7 +429,7 @@ async fn build_go_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "go/").await?;
     let mut modules: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if let Some(rest) = key.strip_prefix("go/") {
             // Pattern: go/{module}/@v/{version}.zip
             // Count .zip files as versions (authoritative artifacts)
@@ -450,11 +440,9 @@ async fn build_go_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
                     let entry = modules.entry(module.to_string()).or_insert((0, 0, 0));
                     entry.0 += 1;
 
-                    if let Some(meta) = storage.stat(key).await {
-                        entry.1 += meta.size;
-                        if meta.modified > entry.2 {
-                            entry.2 = meta.modified;
-                        }
+                    entry.1 += meta.size;
+                    if meta.modified > entry.2 {
+                        entry.2 = meta.modified;
                     }
                 }
             }
@@ -469,17 +457,15 @@ async fn build_raw_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     // (count, size, modified, is_file)
     let mut groups: HashMap<String, (usize, u64, u64, bool)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if let Some(rest) = key.strip_prefix("raw/") {
             let is_root_file = !rest.contains('/');
             let group = rest.split('/').next().unwrap_or(rest).to_string();
             let entry = groups.entry(group).or_insert((0, 0, 0, is_root_file));
             entry.0 += 1;
-            if let Some(meta) = storage.stat(key).await {
-                entry.1 += meta.size;
-                if meta.modified > entry.2 {
-                    entry.2 = meta.modified;
-                }
+            entry.1 += meta.size;
+            if meta.modified > entry.2 {
+                entry.2 = meta.modified;
             }
         }
     }
@@ -514,7 +500,7 @@ async fn build_generic_index(
     let keys = list_keys(storage, prefix).await?;
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if !key.ends_with(suffix) {
             continue;
         }
@@ -525,11 +511,9 @@ async fn build_generic_index(
             }
             let entry = packages.entry(name).or_insert((0, 0, 0));
             entry.0 += 1;
-            if let Some(meta) = storage.stat(key).await {
-                entry.1 += meta.size;
-                if meta.modified > entry.2 {
-                    entry.2 = meta.modified;
-                }
+            entry.1 += meta.size;
+            if meta.modified > entry.2 {
+                entry.2 = meta.modified;
             }
         }
     }
@@ -543,7 +527,7 @@ async fn build_gems_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "gems/gems/").await?;
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if !key.ends_with(".gem") {
             continue;
         }
@@ -558,11 +542,9 @@ async fn build_gems_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
             }
             let entry = packages.entry(name).or_insert((0, 0, 0));
             entry.0 += 1;
-            if let Some(meta) = storage.stat(key).await {
-                entry.1 += meta.size;
-                if meta.modified > entry.2 {
-                    entry.2 = meta.modified;
-                }
+            entry.1 += meta.size;
+            if meta.modified > entry.2 {
+                entry.2 = meta.modified;
             }
         }
     }
@@ -575,7 +557,7 @@ async fn build_conan_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
     let keys = list_keys(storage, "conan/").await?;
     let mut packages: HashMap<String, (usize, u64, u64)> = HashMap::new();
 
-    for key in &keys {
+    for (key, meta) in &keys {
         if let Some(rest) = key.strip_prefix("conan/") {
             // First segment is the package name
             let name = rest.split('/').next().unwrap_or(rest).to_string();
@@ -584,11 +566,9 @@ async fn build_conan_index(storage: &Storage) -> Option<Vec<RepoInfo>> {
             }
             let entry = packages.entry(name).or_insert((0, 0, 0));
             entry.0 += 1;
-            if let Some(meta) = storage.stat(key).await {
-                entry.1 += meta.size;
-                if meta.modified > entry.2 {
-                    entry.2 = meta.modified;
-                }
+            entry.1 += meta.size;
+            if meta.modified > entry.2 {
+                entry.2 = meta.modified;
             }
         }
     }
@@ -984,5 +964,118 @@ mod tests {
             "size must be on-disk du, not virtual"
         );
         assert!(repos[0].size < 10_000_000, "must not report virtual size");
+    }
+
+    /// #738 A/B: an index rebuild must read size/mtime from the listing
+    /// (`list_with_meta`) and NEVER issue a per-key `stat()` — which on S3 is a
+    /// HEAD per key (N+1). A backend that counts `stat()` calls and serves the
+    /// metadata via `list_with_meta` proves the rebuild does ZERO stats (стало)
+    /// while still computing the correct on-disk size (было = one HEAD per key).
+    #[tokio::test]
+    async fn docker_index_uses_list_with_meta_not_per_key_stat() {
+        use crate::storage::{FileMeta, StorageBackend};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        struct CountingBackend {
+            entries: Vec<(String, FileMeta)>,
+            stat_calls: Arc<AtomicUsize>,
+        }
+
+        #[async_trait::async_trait]
+        impl StorageBackend for CountingBackend {
+            async fn stat(&self, _key: &str) -> Option<FileMeta> {
+                self.stat_calls.fetch_add(1, Ordering::SeqCst);
+                None
+            }
+            async fn list(&self, prefix: &str) -> crate::storage::Result<Vec<String>> {
+                Ok(self
+                    .entries
+                    .iter()
+                    .filter(|(k, _)| k.starts_with(prefix))
+                    .map(|(k, _)| k.clone())
+                    .collect())
+            }
+            async fn list_with_meta(
+                &self,
+                prefix: &str,
+            ) -> crate::storage::Result<Vec<(String, FileMeta)>> {
+                Ok(self
+                    .entries
+                    .iter()
+                    .filter(|(k, _)| k.starts_with(prefix))
+                    .cloned()
+                    .collect())
+            }
+            async fn put(&self, _k: &str, _d: &[u8]) -> crate::storage::Result<()> {
+                Ok(())
+            }
+            async fn get(&self, _k: &str) -> crate::storage::Result<axum::body::Bytes> {
+                Err(crate::storage::StorageError::NotFound)
+            }
+            async fn delete(&self, _k: &str) -> crate::storage::Result<()> {
+                Ok(())
+            }
+            async fn health_check(&self) -> bool {
+                true
+            }
+            async fn total_size(&self) -> u64 {
+                0
+            }
+            fn backend_name(&self) -> &'static str {
+                "counting-test"
+            }
+            async fn put_from_path(
+                &self,
+                _k: &str,
+                _s: &std::path::Path,
+            ) -> crate::storage::Result<()> {
+                Ok(())
+            }
+            async fn get_reader(
+                &self,
+                _k: &str,
+            ) -> crate::storage::Result<(
+                u64,
+                std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
+            )> {
+                Err(crate::storage::StorageError::NotFound)
+            }
+        }
+
+        let stat_calls = Arc::new(AtomicUsize::new(0));
+        let entries = vec![
+            (
+                "docker/library/app/manifests/latest.json".to_string(),
+                FileMeta {
+                    size: 100,
+                    modified: 5,
+                },
+            ),
+            (
+                "docker/library/app/blobs/sha256:lyr".to_string(),
+                FileMeta {
+                    size: 340,
+                    modified: 9,
+                },
+            ),
+        ];
+        let storage = Storage::from_backend(Arc::new(CountingBackend {
+            entries,
+            stat_calls: Arc::clone(&stat_calls),
+        }));
+
+        let repos = build_docker_index(&storage).await.expect("index built");
+
+        // стало: the rebuild made ZERO per-key stat() calls.
+        assert_eq!(
+            stat_calls.load(Ordering::SeqCst),
+            0,
+            "#738: index rebuild must not stat() per key — size/mtime come from list_with_meta"
+        );
+        // Correctness preserved: size = sum of listed sizes (100 + 340), 1 tag.
+        assert_eq!(repos.len(), 1);
+        assert_eq!(repos[0].versions, 1);
+        assert_eq!(repos[0].size, 440);
     }
 }

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -66,6 +66,48 @@ impl LocalStorage {
             }
         }
     }
+
+    /// Like [`Self::list_files_sync`] but also captures size/mtime from each
+    /// file's metadata during the walk, so callers do not need a follow-up
+    /// `stat()` per key (#738). Uses `std::fs::metadata` (symlink-following) to
+    /// match the semantics of [`StorageBackend::stat`].
+    fn list_files_with_meta_sync(
+        dir: &PathBuf,
+        base: &PathBuf,
+        prefix: &str,
+        results: &mut Vec<(String, FileMeta)>,
+    ) {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                let Ok(metadata) = std::fs::metadata(&path) else {
+                    continue;
+                };
+                if metadata.is_file() {
+                    if let Ok(rel_path) = path.strip_prefix(base) {
+                        let key = rel_path.to_string_lossy().replace('\\', "/");
+                        if key.starts_with(prefix) || prefix.is_empty() {
+                            let modified = metadata
+                                .modified()
+                                .ok()
+                                .and_then(|m| m.duration_since(std::time::UNIX_EPOCH).ok())
+                                .map(|d| d.as_secs())
+                                .unwrap_or(0);
+                            results.push((
+                                key,
+                                FileMeta {
+                                    size: metadata.len(),
+                                    modified,
+                                },
+                            ));
+                        }
+                    }
+                } else if metadata.is_dir() {
+                    Self::list_files_with_meta_sync(&path, base, prefix, results);
+                }
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -158,6 +200,22 @@ impl StorageBackend for LocalStorage {
                 Self::list_files_sync(&base, &base, &prefix, &mut results);
             }
             results.sort();
+            results
+        })
+        .await
+        .map_err(|e| StorageError::Io(format!("list task panicked: {e}")))
+    }
+
+    async fn list_with_meta(&self, prefix: &str) -> Result<Vec<(String, FileMeta)>> {
+        let base = self.base_path.clone();
+        let prefix = prefix.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let mut results = Vec::new();
+            if base.exists() {
+                Self::list_files_with_meta_sync(&base, &base, &prefix, &mut results);
+            }
+            results.sort_by(|a, b| a.0.cmp(&b.0));
             results
         })
         .await

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -91,6 +91,23 @@ pub trait StorageBackend: Send + Sync {
     async fn delete(&self, key: &str) -> Result<()>;
     async fn list(&self, prefix: &str) -> Result<Vec<String>>;
     async fn stat(&self, key: &str) -> Option<FileMeta>;
+    /// List keys under `prefix` together with their size/mtime.
+    ///
+    /// Returns the metadata the listing already carries instead of forcing a
+    /// per-key `stat()` — an extra HEAD per key on S3 (#738). The default impl
+    /// falls back to `list()` + per-key `stat()`, so backends that do not
+    /// override stay correct; Local and S3 override to reuse the metadata the
+    /// listing itself produces.
+    async fn list_with_meta(&self, prefix: &str) -> Result<Vec<(String, FileMeta)>> {
+        let keys = self.list(prefix).await?;
+        let mut out = Vec::with_capacity(keys.len());
+        for key in keys {
+            if let Some(meta) = self.stat(&key).await {
+                out.push((key, meta));
+            }
+        }
+        Ok(out)
+    }
     async fn health_check(&self) -> bool;
     /// Total size of all stored artifacts in bytes
     async fn total_size(&self) -> u64;
@@ -432,6 +449,20 @@ impl Storage {
         Ok(keys
             .into_iter()
             .filter(|k| !k.starts_with(".nora-"))
+            .collect())
+    }
+
+    /// List keys under `prefix` with their size/mtime, applying the same
+    /// `.nora-` internal-file filter as [`list`]. Backends carry the metadata
+    /// from the listing itself, avoiding a per-key `stat()` (#738).
+    pub async fn list_with_meta(&self, prefix: &str) -> Result<Vec<(String, FileMeta)>> {
+        if !prefix.is_empty() {
+            validate_storage_key(prefix)?;
+        }
+        let entries = self.inner.list_with_meta(prefix).await?;
+        Ok(entries
+            .into_iter()
+            .filter(|(k, _)| !k.starts_with(".nora-"))
             .collect())
     }
 

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -154,6 +154,39 @@ impl StorageBackend for S3Storage {
             .collect())
     }
 
+    async fn list_with_meta(&self, prefix: &str) -> Result<Vec<(String, FileMeta)>> {
+        let encoded = encode_s3_key(prefix);
+        let prefix_path = Path::from(encoded);
+        let list_prefix = if prefix.is_empty() {
+            None
+        } else {
+            Some(&prefix_path)
+        };
+
+        let objects: Vec<_> = self
+            .store
+            .list(list_prefix)
+            .try_collect()
+            .await
+            .map_err(|e| StorageError::Network(e.to_string()))?;
+
+        // The LIST response already carries size/last_modified — reuse it
+        // instead of issuing a HEAD per key (#738).
+        Ok(objects
+            .into_iter()
+            .map(|meta| {
+                let modified = meta.last_modified.timestamp().try_into().unwrap_or(0u64);
+                (
+                    decode_s3_key(meta.location.as_ref()),
+                    FileMeta {
+                        size: meta.size,
+                        modified,
+                    },
+                )
+            })
+            .collect())
+    }
+
     async fn stat(&self, key: &str) -> Option<FileMeta> {
         let encoded = encode_s3_key(key);
         let path = Path::from(encoded);


### PR DESCRIPTION
## What

Index rebuild walked `storage.list()` and then issued a separate `storage.stat()` per key to read size/mtime. On S3 `stat()` is a `HEAD`, so a rebuild of N objects cost `1 LIST + N HEADs`, all under the per-registry rebuild lock — the first reader after an invalidation (UI dashboard, tag/version listing, admin reindex) blocked for the whole serialized round-trips.

## Change

Add `StorageBackend::list_with_meta()` with a **default impl** that falls back to `list()` + per-key `stat()` (so every backend stays correct). Local and S3 override it to reuse the size/mtime the directory walk / LIST response already carries — zero extra HEADs. `repo_index`'s 13 builders consume the `(key, meta)` tuple directly instead of a per-key `stat()`.

Additive trait method, so `gc`/`retention`/`backup`/`mirror`/handlers keep using `list()`. The `.nora-` internal-file filter is applied to `list_with_meta()` identically.

## Verification

- `cargo clippy -- -D warnings` clean; full suite **1473 tests pass**, including the exact on-disk-size/count `repo_index` assertions.
- New test (`docker_index_uses_list_with_meta_not_per_key_stat`): a counting backend proves a rebuild makes **0** per-key `stat()` calls.
- End-to-end against a MinIO S3 backend (50 npm tarballs, `mc admin trace`): a rebuild went from **`1 ListObjectsV2 + 50 HeadObject`** to **`1 ListObjectsV2 + 0 HeadObject`** — identical 50-package output.

Closes #738
