### PR TITLE
fix(config): registry proxy serde-default diverged from Default impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [Unreleased]
+
+### Fixed
+- **A present-but-empty `[<registry>]` table now keeps the default upstream** — npm/pypi `proxy` and maven/docker `proxies`/`upstreams` used a bare `#[serde(default)]` that deserialized to `None`/`[]`, diverging from the `Default` impl's real upstream. Writing `[npm]` (or `[pypi]`/`[maven]`/`[docker]`) in `config.toml` to set, say, a timeout — without restating the proxy key — silently disabled proxying for that registry, while omitting the table entirely kept the upstream. The serde field-default is now single-sourced with the `Default` impl, and a guard test asserts this for every registry section so the class cannot recur. **Behavior change:** if you relied on a present-but-proxy-less table to run a registry local-only (air-gapped), set the proxy env var to empty instead — `NORA_NPM_PROXY=""`, `NORA_PYPI_PROXY=""`, `NORA_MAVEN_PROXIES=""`, `NORA_DOCKER_PROXIES=""`.
+
 ## [0.9.5] - 2026-06-19
 
 ### Security

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -1398,6 +1398,30 @@ mod tests {
         assert_eq!(from_empty_cfg.server, ServerConfig::default());
     }
 
+    /// A registry table present in config.toml WITHOUT a `proxy` key must yield
+    /// the SAME upstream as omitting the table entirely. Otherwise a user who
+    /// writes `[npm]` (e.g. just to set a timeout) silently loses the default
+    /// upstream and proxying breaks. This was wrong for npm/pypi: their `proxy`
+    /// field used a bare `#[serde(default)]` (→ None) that diverged from their
+    /// `Default` impl (Some(registry)). The existing guard above only covers
+    /// ServerConfig/StorageConfig, so the drift went unnoticed.
+    #[test]
+    fn registry_proxy_present_table_matches_omitted_table() {
+        let omitted: Config = toml::from_str("").unwrap();
+
+        let npm_present: Config = toml::from_str("[npm]\nenabled = true\n").unwrap();
+        assert_eq!(
+            npm_present.npm.proxy, omitted.npm.proxy,
+            "[npm] without a proxy key must default to the same upstream as omitting [npm]"
+        );
+
+        let pypi_present: Config = toml::from_str("[pypi]\nenabled = true\n").unwrap();
+        assert_eq!(
+            pypi_present.pypi.proxy, omitted.pypi.proxy,
+            "[pypi] without a proxy key must default to the same upstream as omitting [pypi]"
+        );
+    }
+
     /// The config shipped in the container image (deploy/config.docker.toml,
     /// loaded via NORA_CONFIG_PATH) must be valid for THIS struct and yield the
     /// intended container defaults — so the image is zero-config out of the box

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -1369,57 +1369,58 @@ mod tests {
         assert_eq!(config.storage.mode, StorageMode::Local);
     }
 
-    /// Invariant: the field-level `#[serde(default)]` path and the `Default` impl
-    /// must produce identical values. `Config` derives `Default` (so `Config::default()`
-    /// is compiler-generated from each field's `Default`), leaving the `default_*`
-    /// helpers as the single root; the only way a default can drift is a
-    /// `serde(default = ...)` helper diverging from a type's `Default` impl — this
-    /// test fails loudly if that ever happens.
-    #[test]
-    fn test_serde_defaults_match_default_impl() {
-        // [server]: derived PartialEq gives exhaustive, future-field-proof coverage.
-        let from_empty: ServerConfig = toml::from_str("").unwrap();
-        assert_eq!(from_empty, ServerConfig::default());
-
-        // [storage]: ProtectedString does not implement PartialEq, so compare the
-        // comparable fields explicitly and assert the secret fields stay unset.
-        let s: StorageConfig = toml::from_str("").unwrap();
-        let d = StorageConfig::default();
-        assert_eq!(s.mode, d.mode);
-        assert_eq!(s.path, d.path);
-        assert_eq!(s.s3_url, d.s3_url);
-        assert_eq!(s.bucket, d.bucket);
-        assert_eq!(s.s3_region, d.s3_region);
-        assert!(s.s3_access_key.is_none() && d.s3_access_key.is_none());
-        assert!(s.s3_secret_key.is_none() && d.s3_secret_key.is_none());
-
-        // And the whole-Config fallback agrees with deserializing an empty file.
-        let from_empty_cfg: Config = toml::from_str("").unwrap();
-        assert_eq!(from_empty_cfg.server, ServerConfig::default());
+    /// Assert that a config section's field-level serde-default path equals its
+    /// `Default` impl — i.e. writing `[section]` with no keys behaves the same as
+    /// omitting the section entirely. A bare `#[serde(default)]` on an `Option`
+    /// field yields `None`, which silently diverges from a `Default` impl that
+    /// returns `Some(..)` (the npm/pypi proxy bug). Comparison via
+    /// `serde_json::Value` tolerates `ProtectedString` secrets (`skip_serializing`
+    /// → absent on both sides) and auto-covers future fields.
+    fn assert_serde_default_eq_default<T>(section: &str)
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + Default,
+    {
+        let from_empty: T = toml::from_str("").unwrap_or_else(|e| {
+            panic!(
+                "[{section}] empty table must deserialize — every field needs a serde default: {e}"
+            )
+        });
+        assert_eq!(
+            serde_json::to_value(&from_empty).unwrap(),
+            serde_json::to_value(T::default()).unwrap(),
+            "[{section}]: serde field-defaults diverge from the Default impl — a present-but-empty \
+             [{section}] table behaves differently from omitting the section",
+        );
     }
 
-    /// A registry table present in config.toml WITHOUT a `proxy` key must yield
-    /// the SAME upstream as omitting the table entirely. Otherwise a user who
-    /// writes `[npm]` (e.g. just to set a timeout) silently loses the default
-    /// upstream and proxying breaks. This was wrong for npm/pypi: their `proxy`
-    /// field used a bare `#[serde(default)]` (→ None) that diverged from their
-    /// `Default` impl (Some(registry)). The existing guard above only covers
-    /// ServerConfig/StorageConfig, so the drift went unnoticed.
+    /// Invariant (whole class, not just the leaves that were caught): for EVERY
+    /// config section, the field-level `#[serde(default)]` path and the `Default`
+    /// impl must agree, so `[section]` with no keys == omitting `[section]`. The
+    /// only way to drift is a `serde(default = ...)`/`Default` mismatch — this
+    /// fails loudly if it ever happens. Previously this only covered
+    /// server/storage, which let the npm/pypi `proxy` divergence through.
     #[test]
-    fn registry_proxy_present_table_matches_omitted_table() {
-        let omitted: Config = toml::from_str("").unwrap();
+    fn test_serde_defaults_match_default_impl() {
+        assert_serde_default_eq_default::<ServerConfig>("server");
+        assert_serde_default_eq_default::<StorageConfig>("storage");
+        // All 13 registries — this is where the proxy-default class lives.
+        assert_serde_default_eq_default::<MavenConfig>("maven");
+        assert_serde_default_eq_default::<NpmConfig>("npm");
+        assert_serde_default_eq_default::<PypiConfig>("pypi");
+        assert_serde_default_eq_default::<DockerConfig>("docker");
+        assert_serde_default_eq_default::<GoConfig>("go");
+        assert_serde_default_eq_default::<CargoConfig>("cargo");
+        assert_serde_default_eq_default::<RawConfig>("raw");
+        assert_serde_default_eq_default::<GemsConfig>("gems");
+        assert_serde_default_eq_default::<TerraformConfig>("terraform");
+        assert_serde_default_eq_default::<AnsibleConfig>("ansible");
+        assert_serde_default_eq_default::<NugetConfig>("nuget");
+        assert_serde_default_eq_default::<PubDartConfig>("pub_dart");
+        assert_serde_default_eq_default::<ConanConfig>("conan");
 
-        let npm_present: Config = toml::from_str("[npm]\nenabled = true\n").unwrap();
-        assert_eq!(
-            npm_present.npm.proxy, omitted.npm.proxy,
-            "[npm] without a proxy key must default to the same upstream as omitting [npm]"
-        );
-
-        let pypi_present: Config = toml::from_str("[pypi]\nenabled = true\n").unwrap();
-        assert_eq!(
-            pypi_present.pypi.proxy, omitted.pypi.proxy,
-            "[pypi] without a proxy key must default to the same upstream as omitting [pypi]"
-        );
+        // Whole-Config fallback agrees with deserializing an empty file.
+        let from_empty_cfg: Config = toml::from_str("").unwrap();
+        assert_eq!(from_empty_cfg.server, ServerConfig::default());
     }
 
     /// The config shipped in the container image (deploy/config.docker.toml,

--- a/nora-registry/src/config/registry/docker.rs
+++ b/nora-registry/src/config/registry/docker.rs
@@ -44,7 +44,7 @@ pub struct DockerConfig {
     /// `allow` (default) = fall through to first upstream; `deny` = reject with 403.
     #[serde(default)]
     pub default_action: DefaultAction,
-    #[serde(default)]
+    #[serde(default = "default_docker_upstreams")]
     pub upstreams: Vec<DockerUpstream>,
 }
 
@@ -97,6 +97,19 @@ fn default_docker_metadata_ttl() -> i64 {
     -1
 }
 
+/// Default Docker upstream. Single source for the serde field-default and the
+/// `Default` impl so a present-but-empty `[docker]` table keeps the upstream
+/// instead of silently going local-only (the npm/pypi `#[serde(default)]`
+/// divergence class — a bare default on a `Vec` yields an empty list).
+fn default_docker_upstreams() -> Vec<DockerUpstream> {
+    vec![DockerUpstream {
+        url: "https://registry-1.docker.io".to_string(),
+        auth: None,
+        namespace: None,
+        prefix: None,
+    }]
+}
+
 impl Default for DockerConfig {
     fn default() -> Self {
         Self {
@@ -106,12 +119,7 @@ impl Default for DockerConfig {
             metadata_ttl: -1,
             serve_stale: true,
             default_action: DefaultAction::default(),
-            upstreams: vec![DockerUpstream {
-                url: "https://registry-1.docker.io".to_string(),
-                auth: None,
-                namespace: None,
-                prefix: None,
-            }],
+            upstreams: default_docker_upstreams(),
         }
     }
 }

--- a/nora-registry/src/config/registry/maven.rs
+++ b/nora-registry/src/config/registry/maven.rs
@@ -9,7 +9,7 @@ use std::env;
 pub struct MavenConfig {
     #[serde(default = "super::super::default_true")]
     pub enabled: bool,
-    #[serde(default)]
+    #[serde(default = "default_maven_proxies")]
     pub proxies: Vec<MavenProxyEntry>,
     #[serde(default = "super::super::default_timeout")]
     pub proxy_timeout: u64,
@@ -57,13 +57,21 @@ impl MavenProxyEntry {
     }
 }
 
+/// Default Maven upstream. Single source for the serde field-default and the
+/// `Default` impl so a present-but-empty `[maven]` table keeps the upstream
+/// instead of silently going local-only (the npm/pypi `#[serde(default)]`
+/// divergence class — a bare default on a `Vec` yields an empty list).
+fn default_maven_proxies() -> Vec<MavenProxyEntry> {
+    vec![MavenProxyEntry::Simple(
+        "https://repo1.maven.org/maven2".to_string(),
+    )]
+}
+
 impl Default for MavenConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            proxies: vec![MavenProxyEntry::Simple(
-                "https://repo1.maven.org/maven2".to_string(),
-            )],
+            proxies: default_maven_proxies(),
             proxy_timeout: 30,
             checksum_verify: true,
             immutable_releases: true,

--- a/nora-registry/src/config/registry/npm.rs
+++ b/nora-registry/src/config/registry/npm.rs
@@ -9,7 +9,7 @@ use std::env;
 pub struct NpmConfig {
     #[serde(default = "super::super::default_true")]
     pub enabled: bool,
-    #[serde(default)]
+    #[serde(default = "default_npm_proxy")]
     pub proxy: Option<String>,
     #[serde(default, skip_serializing)]
     pub proxy_auth: Option<ProtectedString>,
@@ -26,11 +26,19 @@ pub struct NpmConfig {
     pub revalidate: bool,
 }
 
+/// Default npm upstream. Single source for both the serde field-default and the
+/// `Default` impl, so the "table present without `proxy`" path and the "table
+/// omitted" path produce the same upstream (they diverged before — `#[serde(default)]`
+/// on an `Option` yields `None`, silently disabling proxying when `[npm]` is present).
+fn default_npm_proxy() -> Option<String> {
+    Some("https://registry.npmjs.org".to_string())
+}
+
 impl Default for NpmConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            proxy: Some("https://registry.npmjs.org".to_string()),
+            proxy: default_npm_proxy(),
             proxy_auth: None,
             proxy_timeout: 30,
             metadata_ttl: 300,

--- a/nora-registry/src/config/registry/pypi.rs
+++ b/nora-registry/src/config/registry/pypi.rs
@@ -11,7 +11,7 @@ pub struct PypiConfig {
     pub enabled: bool,
     /// Single upstream — retained for back-compat (`NORA_PYPI_PROXY`, old TOML).
     /// Used only when `proxies` is empty; see [`PypiConfig::upstreams`].
-    #[serde(default)]
+    #[serde(default = "default_pypi_proxy")]
     pub proxy: Option<String>,
     #[serde(default, skip_serializing)]
     pub proxy_auth: Option<ProtectedString>,
@@ -56,11 +56,19 @@ impl PypiProxyEntry {
     }
 }
 
+/// Default PyPI upstream. Single source for both the serde field-default and the
+/// `Default` impl so the "table present without `proxy`" and "table omitted" paths
+/// agree (`#[serde(default)]` on an `Option` yields `None`, which silently dropped
+/// the upstream when `[pypi]` was present).
+fn default_pypi_proxy() -> Option<String> {
+    Some("https://pypi.org/simple/".to_string())
+}
+
 impl Default for PypiConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            proxy: Some("https://pypi.org/simple/".to_string()),
+            proxy: default_pypi_proxy(),
             proxy_auth: None,
             proxies: Vec::new(),
             proxy_timeout: 30,

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -969,8 +969,8 @@ mod tests {
     /// #738 A/B: an index rebuild must read size/mtime from the listing
     /// (`list_with_meta`) and NEVER issue a per-key `stat()` — which on S3 is a
     /// HEAD per key (N+1). A backend that counts `stat()` calls and serves the
-    /// metadata via `list_with_meta` proves the rebuild does ZERO stats (стало)
-    /// while still computing the correct on-disk size (было = one HEAD per key).
+    /// metadata via `list_with_meta` proves the rebuild now does ZERO stats
+    /// while still computing the correct on-disk size (the old path did one HEAD per key).
     #[tokio::test]
     async fn docker_index_uses_list_with_meta_not_per_key_stat() {
         use crate::storage::{FileMeta, StorageBackend};
@@ -1067,7 +1067,7 @@ mod tests {
 
         let repos = build_docker_index(&storage).await.expect("index built");
 
-        // стало: the rebuild made ZERO per-key stat() calls.
+        // After the fix: the rebuild made ZERO per-key stat() calls.
         assert_eq!(
             stat_calls.load(Ordering::SeqCst),
             0,


### PR DESCRIPTION
## What

A `config.toml` registry table present **without** its proxy key silently disabled proxying, while omitting the table entirely kept the upstream. The `proxy`/`proxies`/`upstreams` fields used a bare `#[serde(default)]` (→ `None`/`[]`) that diverged from the `Default` impl's real upstream.

Affected: `npm.proxy`, `pypi.proxy`, `maven.proxies`, `docker.upstreams`. (`gems`/`cargo`/`go`/`terraform`/`ansible`/`nuget`/`pub`/`conan` already used `#[serde(default = "default_*_proxy")]` and were correct.)

## Change

- Single-source each default via a helper (`default_npm_proxy()`, …, `default_maven_proxies()`, `default_docker_upstreams()`) used by **both** the serde field-default and the `Default` impl.
- Extend `test_serde_defaults_match_default_impl` to assert, for **every** config section (server, storage, all 13 registries), that a present-but-empty `[section]` table equals omitting it — compared via `serde_json::Value` so secrets and future fields are covered. This closes the class: any future divergence fails the test. (Extending the guard is what surfaced `maven`/`docker`.)

## Behavior change

A present-but-proxy-less `[npm]`/`[pypi]`/`[maven]`/`[docker]` table now uses the default upstream. To run a registry local-only (air-gapped), set its proxy env var empty: `NORA_NPM_PROXY=""`, `NORA_PYPI_PROXY=""`, `NORA_MAVEN_PROXIES=""`, `NORA_DOCKER_PROXIES=""`. Documented in CHANGELOG.

## Verification

`cargo clippy -- -D warnings` clean; full suite **1473 tests** pass, including the comprehensive guard.
