### PR TITLE
docs: fix curation feature list and integrity-verify claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [full documentation](https://getnora.dev) for all registries.
 
 - **Web UI** — dashboard with search, browse, i18n (EN/RU)
 - **Proxy & Cache** — transparent proxy to upstream registries with local cache
-- **Curation** — blocklist, allowlist, namespace isolation, integrity verification, min-release-age filter
+- **Curation** — blocklist, allowlist, namespace isolation, integrity verification, min-release-age filter, digest quarantine
 - **Token RBAC** — read/write/admin roles, expiry tracking, deferred last_used flush
 - **Mirror CLI** — offline sync for air-gapped environments (`nora mirror`)
 - **Backup & Restore** — `nora backup` / `nora restore`

--- a/llms.txt
+++ b/llms.txt
@@ -113,7 +113,7 @@ NORA is a multi-protocol artifact registry written in Rust. It serves Docker ima
 - 13 registry protocols: Docker Registry v2, Maven, npm, PyPI (PEP 503/691), Cargo sparse index (RFC 2789), Go module proxy, Raw files, RubyGems, Terraform, Ansible Galaxy (v3), NuGet (v3), Pub (Dart/Flutter), Conan (v2 revisions)
 - Helm OCI charts via the Docker/OCI endpoint — `helm push`/`pull` work out of the box
 - Transparent upstream proxy with local cache for Docker Hub, GHCR, Maven Central, npmjs.org, PyPI, rubygems.org, registry.terraform.io, galaxy.ansible.com, api.nuget.org, pub.dev, ConanCenter
-- Curation layer: blocklist, allowlist, namespace isolation, integrity verification (SHA256/SHA512). Modes: off, audit, enforce. CLI: `nora curation validate`, `nora curation explain`
+- Curation layer: blocklist, allowlist, namespace isolation, integrity verification (SHA256), digest quarantine. Modes: off, audit, enforce. CLI: `nora curation validate`, `nora curation explain`
 - Dynamic registry loading: enable/disable registries via config or env vars (`NORA_*_ENABLED`)
 - S3 storage backend (AWS S3, Ceph RGW, any S3-compatible) with migration CLI
 - Web UI with dashboard, search, browse, i18n (English and Russian)


### PR DESCRIPTION
Part of #713 — the half that lives in the code repo's public-facing files.

- **README.md** — add "digest quarantine" to the curation feature list (`digest_quarantine.rs` ships but was omitted).
- **llms.txt** — curation integrity verification is **SHA256-only** (`curation.rs` computes `sha2::Sha256`, `sha256:<hex>`), not SHA256/SHA512; also added digest quarantine for parity. (Left the curation modes `off/audit/enforce` — those are correct.)

Pairs with the nora-docs PR covering the ansible/audit-log half of #713; close #713 after both merge.

Refs #713
