### PR TITLE
docs(llms): address GitHub Code Quality findings on llms.txt

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # NORA
 
-A lightweight, open-source artifact registry. 13 formats in a single < 27 MB binary: Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
+A lightweight, open-source artifact registry. 13 formats in a single binary (< 27 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
 
 > The artifact registry that grows with you. Zero-config to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
 
@@ -198,7 +198,7 @@ cd nora && cargo build --release
 - Language: Rust
 - Platforms: Linux (amd64, arm64). Docker images: Alpine, Astra Linux SE, RED OS
 - Binary name: nora (crate name: nora-registry)
-- Tests: 1200+ (unit + integration + proptest)
+- Tests: comprehensive suite (unit + integration + property-based/proptest)
 - No garbage collector pauses (Rust, not Java/Go)
 - Async I/O with Tokio, Axum web framework
 - SHA256 digest verification on every blob upload


### PR DESCRIPTION
Resolves the 3 GitHub Code Quality findings on `llms.txt`:

- **Binary size clarity** — `< 27 MB binary` → `binary (< 27 MB on disk)` so it isn't confused with the `< 50 MB RAM idle` memory figure.
- **Hardcoded test count** — `1200+` (already stale — the suite is 1474) → a non-numeric description so this LLM-facing doc doesn't drift.
- **Protocol versions (finding 2): kept deliberately.** For an LLM-discovery doc, accurate protocol versions (Docker v2, NuGet v3, Ansible v3, Conan v2) are useful, and the asymmetry is real — Maven/npm/Go/RubyGems have no distinguishing version to add. Stripping precise info to equalize formatting is a net downgrade.