### PR TITLE
security: prevent script injection in post-release gate, pin toolchain

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -21,8 +21,10 @@ jobs:
 
       - name: Extract version from triggering tag
         id: ver
+        env:
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          TAG="${{ github.event.workflow_run.head_branch }}"
+          TAG="${HEAD_BRANCH}"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
 
       - name: Install cosign


### PR DESCRIPTION
Two fixes for open CodeQL code-scanning alerts on `main`. Both findings predate these commits; this PR clears them.

### 1. Script injection in Post-Release Gate (CodeQL critical)
`post-release.yml` interpolated `${{ github.event.workflow_run.head_branch }}` directly into a `run:` shell step:

```yaml
run: |
  TAG="${{ github.event.workflow_run.head_branch }}"   # untrusted -> shell
```

`Release` triggers on `push: tags: ['v*']`, so `head_branch` is the tag name — attacker-influenced input. A crafted tag name could inject arbitrary commands into the runner (CWE-94). Fixed by passing the value through `env:` and reading the inert shell variable, the GitHub-recommended remediation:

```yaml
env:
  HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
run: |
  TAG="${HEAD_BRANCH}"
```

No behavior change for well-formed `v*` tags.

### 2. Unpinned action ref in benchmarks (pinned-dependencies)
`benchmarks.yml` was the only workflow still using the mutable `dtolnay/rust-toolchain@stable` ref. The other six call sites (`ci.yml` ×5, `kani.yml`) already pin commit `631a55b` (`# stable`). Pinned to the same SHA for supply-chain consistency.

### Validation
- `actionlint` 1.7.12 (the version CI runs) clean on both files.
- YAML parses; `${{ }}` no longer appears inside any `run:` block.
- Scope limited to two workflow files; no application code touched.