### PR TITLE
ci: pin Docker Hub base images to digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 #
 
 # ── Build ──────────────────────────────────────────────────────────────────
-FROM rust:1-alpine3.21 AS builder
+FROM rust:1-alpine3.21@sha256:7dba3db75b0d5861af2e5dcf5b87347411e84403b5c9835be00ef1e72e299d2a AS builder
 
 RUN apk add --no-cache musl-dev
 
@@ -41,7 +41,7 @@ FROM scratch AS binary
 COPY --from=builder /nora /nora
 
 # ── Cross-compile arm64 (runs natively on x86, no QEMU) ──────────────────
-FROM rust:1-alpine3.21 AS cross-arm64
+FROM rust:1-alpine3.21@sha256:7dba3db75b0d5861af2e5dcf5b87347411e84403b5c9835be00ef1e72e299d2a AS cross-arm64
 
 RUN apk add --no-cache musl-dev \
     && wget -qO- https://musl.cc/aarch64-linux-musl-cross.tgz | tar xz -C /opt
@@ -132,7 +132,7 @@ ENTRYPOINT ["/usr/local/bin/nora"]
 CMD ["serve"]
 
 # ── Alpine (default — must be last) ───────────────────────────────────────
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 
 RUN apk upgrade --no-cache \
     && apk add --no-cache ca-certificates \

--- a/deploy/Dockerfile.release
+++ b/deploy/Dockerfile.release
@@ -9,7 +9,7 @@
 #
 # Expects nora-linux-amd64 and nora-linux-arm64 in the build context.
 
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 ARG TARGETARCH
 
 RUN apk upgrade --no-cache \


### PR DESCRIPTION
Clears the Scorecard `PinnedDependenciesID` alerts on Docker Hub base images by pinning them to index digests. Renovate (already configured, `digest` updates auto-merge) keeps them current.

| Alert | File | Image |
|---|---|---|
| #497 | `Dockerfile:15` | `rust:1-alpine3.21` (builder) |
| #492 | `Dockerfile:44` | `rust:1-alpine3.21` (cross-arm64) |
| #352 | `Dockerfile:135` | `alpine:3.21` (Alpine runtime) |
| #493 | `deploy/Dockerfile.release:12` | `alpine:3.21` (release packaging) |

Format is `image:tag@sha256:…` — tag kept for readability and renovate update detection, digest pins the content. Both digests verified to resolve (HTTP 200) and are multi-arch index digests, so the arm64 cross-build still resolves.

### Deliberately left unpinned
- **FSTEC images** (`registry.red-soft.ru/ubi8/ubi-minimal`, `registry.astralinux.ru/.../ubi17` — alerts #398/#399): external registries renovate cannot reach to bump a frozen digest, and tracking the current *certified* image is required for those builds. Pinning would freeze them to an unmaintainable digest. → accepted limitation, not a code change.
- **`tests/smoke.sh:268`** (#23): that line is `npm install chalk` **through NORA itself** — a live smoke test of the npm proxy. Pinning the install defeats the test. → won't-fix.

`apk upgrade` / `microdnf` still pull the latest OS packages at build time, so pinning the base image does not freeze security patches.