### PR TITLE
refactor(activity-log): type the activity registry label as RegistryType

### DIFF
--- a/nora-registry/src/activity_log.rs
+++ b/nora-registry/src/activity_log.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 The NORA Authors
 // SPDX-License-Identifier: MIT
 
+use crate::registry_type::RegistryType;
 use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use serde::Serialize;
@@ -38,12 +39,12 @@ pub struct ActivityEntry {
 }
 
 impl ActivityEntry {
-    pub fn new(action: ActionType, artifact: String, registry: &str, source: &str) -> Self {
+    pub fn new(action: ActionType, artifact: String, registry: RegistryType, source: &str) -> Self {
         Self {
             timestamp: Utc::now(),
             action,
             artifact,
-            registry: registry.to_string(),
+            registry: registry.as_str().to_string(),
             source: source.to_string(),
         }
     }
@@ -124,7 +125,7 @@ mod tests {
         let entry = ActivityEntry::new(
             ActionType::Pull,
             "nginx:latest".to_string(),
-            "docker",
+            crate::registry_type::RegistryType::Docker,
             "LOCAL",
         );
         assert_eq!(entry.action, ActionType::Pull);
@@ -142,7 +143,7 @@ mod tests {
         log.push(ActivityEntry::new(
             ActionType::Push,
             "test:v1".to_string(),
-            "docker",
+            crate::registry_type::RegistryType::Docker,
             "LOCAL",
         ));
         assert!(!log.is_empty());
@@ -156,7 +157,7 @@ mod tests {
             log.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("image:{}", i),
-                "docker",
+                crate::registry_type::RegistryType::Docker,
                 "LOCAL",
             ));
         }
@@ -176,7 +177,7 @@ mod tests {
             log.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("pkg:{}", i),
-                "npm",
+                crate::registry_type::RegistryType::Npm,
                 "PROXY",
             ));
         }
@@ -193,7 +194,7 @@ mod tests {
             log.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("item:{}", i),
-                "cargo",
+                crate::registry_type::RegistryType::Cargo,
                 "CACHE",
             ));
         }
@@ -212,7 +213,7 @@ mod tests {
         log.push(ActivityEntry::new(
             ActionType::Push,
             "one".to_string(),
-            "maven",
+            crate::registry_type::RegistryType::Maven,
             "LOCAL",
         ));
 
@@ -229,7 +230,7 @@ mod tests {
             log.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("x:{}", i),
-                "docker",
+                crate::registry_type::RegistryType::Docker,
                 "LOCAL",
             ));
         }

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -367,7 +367,7 @@ async fn download_tarball(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             filename,
-            "ansible",
+            crate::registry_type::RegistryType::Ansible,
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
@@ -434,7 +434,7 @@ async fn download_tarball(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 filename,
-                "ansible",
+                crate::registry_type::RegistryType::Ansible,
                 "PROXY",
             ));
             state
@@ -600,7 +600,7 @@ async fn proxy_json(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact_name.to_string(),
-                "ansible",
+                crate::registry_type::RegistryType::Ansible,
                 "PROXY",
             ));
             state

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -127,7 +127,7 @@ async fn sparse_index(
             state.activity.push(ActivityEntry::new(
                 ActionType::CacheHit,
                 crate_name.to_string(),
-                "cargo",
+                crate::registry_type::RegistryType::Cargo,
                 "CACHE",
             ));
             return sparse_index_conditional(data.to_vec(), &headers);
@@ -197,7 +197,7 @@ async fn sparse_index(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 crate_name.to_string(),
-                "cargo",
+                crate::registry_type::RegistryType::Cargo,
                 "PROXY",
             ));
             state
@@ -437,7 +437,7 @@ async fn download(
         state.activity.push(ActivityEntry::new(
             ActionType::Pull,
             format!("{}@{}", crate_name, version),
-            "cargo",
+            crate::registry_type::RegistryType::Cargo,
             "LOCAL",
         ));
         state
@@ -525,7 +525,7 @@ async fn download(
             state.activity.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("{}@{}", crate_name, version),
-                "cargo",
+                crate::registry_type::RegistryType::Cargo,
                 "PROXY",
             ));
             state
@@ -785,7 +785,7 @@ async fn publish(
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
         artifact,
-        "cargo",
+        crate::registry_type::RegistryType::Cargo,
         "LOCAL",
     ));
     state.repo_index.invalidate("cargo");

--- a/nora-registry/src/registry/conan.rs
+++ b/nora-registry/src/registry/conan.rs
@@ -172,7 +172,7 @@ async fn search(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("search:{}", query),
-                "conan",
+                crate::registry_type::RegistryType::Conan,
                 "PROXY",
             ));
             with_json(text.into_bytes())
@@ -428,7 +428,7 @@ async fn recipe_file_download(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
-            "conan",
+            crate::registry_type::RegistryType::Conan,
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
@@ -494,7 +494,7 @@ async fn recipe_file_download(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
-                "conan",
+                crate::registry_type::RegistryType::Conan,
                 "PROXY",
             ));
             state
@@ -838,7 +838,7 @@ async fn package_file_download(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
-            "conan",
+            crate::registry_type::RegistryType::Conan,
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
@@ -906,7 +906,7 @@ async fn package_file_download(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
-                "conan",
+                crate::registry_type::RegistryType::Conan,
                 "PROXY",
             ));
             state
@@ -1019,7 +1019,7 @@ async fn fetch_and_cache_json(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact.to_string(),
-                "conan",
+                crate::registry_type::RegistryType::Conan,
                 "PROXY",
             ));
             state
@@ -1106,7 +1106,7 @@ async fn fetch_and_cache_immutable_json(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact.to_string(),
-                "conan",
+                crate::registry_type::RegistryType::Conan,
                 "PROXY",
             ));
             state

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1213,7 +1213,7 @@ async fn download_blob(
         state.activity.push(ActivityEntry::new(
             ActionType::Pull,
             format!("{}@{}", name, &digest[..19.min(digest.len())]),
-            "docker",
+            crate::registry_type::RegistryType::Docker,
             "LOCAL",
         ));
         let stream = ReaderStream::new(VerifyingReader::new(reader, &digest));
@@ -1296,7 +1296,7 @@ async fn download_blob(
                     state.activity.push(ActivityEntry::new(
                         ActionType::ProxyFetch,
                         format!("{}@{}", try_name, &digest[..19.min(digest.len())]),
-                        "docker",
+                        crate::registry_type::RegistryType::Docker,
                         "PROXY",
                     ));
 
@@ -1773,7 +1773,7 @@ async fn upload_blob(
             state.activity.push(ActivityEntry::new(
                 ActionType::Push,
                 format!("{}@{}", name, &digest[..19.min(digest.len())]),
-                "docker",
+                crate::registry_type::RegistryType::Docker,
                 "LOCAL",
             ));
             state.repo_index.invalidate("docker");
@@ -1834,7 +1834,7 @@ async fn try_fetch_and_cache(
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     format!("{}:{}", name, reference),
-                    "docker",
+                    crate::registry_type::RegistryType::Docker,
                     "PROXY",
                 ));
 
@@ -2164,7 +2164,7 @@ fn serve_cached_manifest(
     state.activity.push(ActivityEntry::new(
         ActionType::Pull,
         format!("{}:{}", name, reference),
-        "docker",
+        crate::registry_type::RegistryType::Docker,
         "LOCAL",
     ));
 
@@ -2338,7 +2338,7 @@ async fn put_manifest(
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
         format!("{}:{}", name, reference),
-        "docker",
+        crate::registry_type::RegistryType::Docker,
         "LOCAL",
     ));
     state.audit.log(AuditEntry::new(

--- a/nora-registry/src/registry/gems.rs
+++ b/nora-registry/src/registry/gems.rs
@@ -78,7 +78,7 @@ async fn fetch_index(state: &AppState, filename: &str) -> Response {
                 state.activity.push(ActivityEntry::new(
                     ActionType::CacheHit,
                     filename.to_string(),
-                    "gems",
+                    crate::registry_type::RegistryType::Gems,
                     "CACHE",
                 ));
                 return with_binary(data.to_vec(), "application/gzip");
@@ -106,7 +106,7 @@ async fn fetch_index(state: &AppState, filename: &str) -> Response {
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 filename.to_string(),
-                "gems",
+                crate::registry_type::RegistryType::Gems,
                 "PROXY",
             ));
             state
@@ -199,7 +199,7 @@ async fn compact_index(
                 state.activity.push(ActivityEntry::new(
                     ActionType::CacheHit,
                     name.clone(),
-                    "gems",
+                    crate::registry_type::RegistryType::Gems,
                     "CACHE",
                 ));
                 return with_text(data.to_vec());
@@ -284,7 +284,7 @@ async fn compact_index(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 name,
-                "gems",
+                crate::registry_type::RegistryType::Gems,
                 "PROXY",
             ));
             state
@@ -474,7 +474,7 @@ async fn download_gem(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
-            "gems",
+            crate::registry_type::RegistryType::Gems,
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
@@ -535,7 +535,7 @@ async fn download_gem(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
-                "gems",
+                crate::registry_type::RegistryType::Gems,
                 "PROXY",
             ));
             state
@@ -635,7 +635,7 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             artifact,
-            "gems",
+            crate::registry_type::RegistryType::Gems,
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
@@ -699,7 +699,7 @@ async fn download_gemspec(State(state): State<AppState>, Path(filename): Path<St
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
-                "gems",
+                crate::registry_type::RegistryType::Gems,
                 "PROXY",
             ));
             state

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -162,7 +162,7 @@ async fn handle(
             state.activity.push(ActivityEntry::new(
                 ActionType::CacheHit,
                 format_artifact(&module_encoded, &file),
-                "go",
+                crate::registry_type::RegistryType::Go,
                 "CACHE",
             ));
             // Quarantine only the .zip module archive (the artifact). The
@@ -287,7 +287,7 @@ async fn handle(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format_artifact(&module_encoded, &file),
-                "go",
+                crate::registry_type::RegistryType::Go,
                 "PROXY",
             ));
             state

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -316,7 +316,7 @@ async fn download(
             state.activity.push(ActivityEntry::new(
                 ActionType::CacheHit,
                 artifact_name.clone(),
-                "maven",
+                crate::registry_type::RegistryType::Maven,
                 "CACHE",
             ));
             state
@@ -425,7 +425,7 @@ async fn download(
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     artifact_name,
-                    "maven",
+                    crate::registry_type::RegistryType::Maven,
                     "PROXY",
                 ));
                 state
@@ -632,7 +632,7 @@ async fn upload(
             state.activity.push(ActivityEntry::new(
                 ActionType::Push,
                 artifact_name,
-                "maven",
+                crate::registry_type::RegistryType::Maven,
                 "LOCAL",
             ));
             state.repo_index.invalidate("maven");
@@ -664,7 +664,7 @@ async fn upload(
                 state.activity.push(ActivityEntry::new(
                     ActionType::Push,
                     artifact_name,
-                    "maven",
+                    crate::registry_type::RegistryType::Maven,
                     "LOCAL",
                 ));
                 state.repo_index.invalidate("maven");

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -309,7 +309,7 @@ async fn handle_request(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             package_name,
-            "npm",
+            crate::registry_type::RegistryType::Npm,
             "CACHE",
         ));
         state
@@ -387,7 +387,7 @@ async fn handle_request(
                     state.activity.push(ActivityEntry::new(
                         ActionType::ProxyFetch,
                         package_name,
-                        "npm",
+                        crate::registry_type::RegistryType::Npm,
                         "PROXY",
                     ));
                     state
@@ -804,7 +804,7 @@ async fn handle_publish(
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
         package_name,
-        "npm",
+        crate::registry_type::RegistryType::Npm,
         "LOCAL",
     ));
     state.repo_index.invalidate("npm");

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -209,7 +209,7 @@ async fn service_index(State(state): State<AppState>) -> Response {
     state.activity.push(ActivityEntry::new(
         ActionType::CacheHit,
         "service-index".to_string(),
-        "nuget",
+        crate::registry_type::RegistryType::Nuget,
         "LOCAL",
     ));
 
@@ -287,7 +287,7 @@ async fn search_query(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("search?{}", qs.chars().take(50).collect::<String>()),
-                "nuget",
+                crate::registry_type::RegistryType::Nuget,
                 "PROXY",
             ));
             with_json(rewritten.into_bytes())
@@ -380,7 +380,7 @@ async fn autocomplete_query(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("autocomplete?{}", qs.chars().take(50).collect::<String>()),
-                "nuget",
+                crate::registry_type::RegistryType::Nuget,
                 "PROXY",
             ));
             with_json(rewritten.into_bytes())
@@ -545,7 +545,7 @@ async fn registration_index(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 id_lower.clone(),
-                "nuget",
+                crate::registry_type::RegistryType::Nuget,
                 "PROXY",
             ));
             state
@@ -671,7 +671,7 @@ async fn registration_page(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/page/{}/{}", id_lower, lower, upper),
-                "nuget",
+                crate::registry_type::RegistryType::Nuget,
                 "PROXY",
             ));
 
@@ -816,7 +816,7 @@ async fn version_list(state: AppState, id: &str) -> Response {
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/versions", id_lower),
-                "nuget",
+                crate::registry_type::RegistryType::Nuget,
                 "PROXY",
             ));
             state
@@ -938,7 +938,7 @@ async fn flatcontainer_download(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             format!("{}/{}", id_lower, filename),
-            "nuget",
+            crate::registry_type::RegistryType::Nuget,
             "CACHE",
         ));
 
@@ -1028,7 +1028,7 @@ async fn flatcontainer_download(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}", id_lower, filename),
-                "nuget",
+                crate::registry_type::RegistryType::Nuget,
                 "PROXY",
             ));
             state

--- a/nora-registry/src/registry/pub_dart.rs
+++ b/nora-registry/src/registry/pub_dart.rs
@@ -529,7 +529,7 @@ async fn download_archive(
         state.activity.push(ActivityEntry::new(
             ActionType::Pull,
             format!("{}@{}", package, version),
-            "pub",
+            crate::registry_type::RegistryType::PubDart,
             "LOCAL",
         ));
         state
@@ -616,7 +616,7 @@ async fn download_archive(
             state.activity.push(ActivityEntry::new(
                 ActionType::Pull,
                 format!("{}@{}", package, version),
-                "pub",
+                crate::registry_type::RegistryType::PubDart,
                 "PROXY",
             ));
             state

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -343,7 +343,7 @@ async fn download_file(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             format!("{}/{}", name, filename),
-            "pypi",
+            crate::registry_type::RegistryType::PyPI,
             "CACHE",
         ));
         state
@@ -434,7 +434,7 @@ async fn download_file(
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     format!("{}/{}", name, filename),
-                    "pypi",
+                    crate::registry_type::RegistryType::PyPI,
                     "PROXY",
                 ));
                 state
@@ -627,7 +627,7 @@ async fn upload(
     state.activity.push(ActivityEntry::new(
         ActionType::Push,
         artifact,
-        "pypi",
+        crate::registry_type::RegistryType::PyPI,
         "LOCAL",
     ));
     state.repo_index.invalidate("pypi");

--- a/nora-registry/src/registry/raw.rs
+++ b/nora-registry/src/registry/raw.rs
@@ -92,9 +92,12 @@ async fn download(
     match state.storage.get_verified(&key).await {
         Ok(outcome) => {
             state.metrics.record_download("raw");
-            state
-                .activity
-                .push(ActivityEntry::new(ActionType::Pull, path, "raw", "LOCAL"));
+            state.activity.push(ActivityEntry::new(
+                ActionType::Pull,
+                path,
+                crate::registry_type::RegistryType::Raw,
+                "LOCAL",
+            ));
             state
                 .audit
                 .log(AuditEntry::new("pull", "api", "", "raw", ""));
@@ -262,9 +265,12 @@ async fn upload(
             state
                 .audit
                 .log(AuditEntry::new("push", "api", &path, "raw", ""));
-            state
-                .activity
-                .push(ActivityEntry::new(ActionType::Push, path, "raw", "LOCAL"));
+            state.activity.push(ActivityEntry::new(
+                ActionType::Push,
+                path,
+                crate::registry_type::RegistryType::Raw,
+                "LOCAL",
+            ));
             state.repo_index.invalidate("raw");
             StatusCode::CREATED.into_response()
         }
@@ -285,7 +291,7 @@ async fn do_overwrite(state: &AppState, key: &str, path: &str, body: &[u8]) -> R
             state.activity.push(ActivityEntry::new(
                 ActionType::Push,
                 path.to_string(),
-                "raw",
+                crate::registry_type::RegistryType::Raw,
                 "LOCAL",
             ));
             state

--- a/nora-registry/src/registry/terraform.rs
+++ b/nora-registry/src/registry/terraform.rs
@@ -177,7 +177,7 @@ async fn provider_versions(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}", ns, ptype),
-                "terraform",
+                crate::registry_type::RegistryType::Terraform,
                 "PROXY",
             ));
             state
@@ -312,7 +312,7 @@ async fn provider_download_meta(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 artifact,
-                "terraform",
+                crate::registry_type::RegistryType::Terraform,
                 "PROXY",
             ));
             state
@@ -375,7 +375,7 @@ async fn provider_download_binary(
         state.activity.push(ActivityEntry::new(
             ActionType::CacheHit,
             path.clone(),
-            "terraform",
+            crate::registry_type::RegistryType::Terraform,
             "CACHE",
         ));
         let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
@@ -435,7 +435,7 @@ async fn provider_download_binary(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 path,
-                "terraform",
+                crate::registry_type::RegistryType::Terraform,
                 "PROXY",
             ));
             state
@@ -556,7 +556,7 @@ async fn module_versions(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}/{}", ns, name, provider),
-                "terraform",
+                crate::registry_type::RegistryType::Terraform,
                 "PROXY",
             ));
             state
@@ -639,7 +639,7 @@ async fn module_download(
                 state.activity.push(ActivityEntry::new(
                     ActionType::ProxyFetch,
                     format!("{}/{}/{} v{}", ns, name, provider, ver),
-                    "terraform",
+                    crate::registry_type::RegistryType::Terraform,
                     "PROXY",
                 ));
 
@@ -766,7 +766,7 @@ async fn module_source_download(
             state.activity.push(ActivityEntry::new(
                 ActionType::ProxyFetch,
                 format!("{}/{}/{} v{}", ns, name, provider, ver),
-                "terraform",
+                crate::registry_type::RegistryType::Terraform,
                 "PROXY",
             ));
 


### PR DESCRIPTION
## Summary
`ActivityEntry::new` took the registry as a bare `&str`; ~65 call sites across the 13 handlers hardcoded a string literal (`"npm"`, `"docker"`, …). A typo silently produced a mislabeled activity entry / dashboard row with no compile error — the stringly-typed class behind #765.

Now the constructor takes `registry: RegistryType` and call sites pass the typed variant. The struct field stays `String` (set via `RegistryType::as_str()`), so serialized output is unchanged (`"npm"`). Mistyping or adding a registry variant is now a compile error.

## Test plan
- All 68 call sites converted; `cargo build` clean (the compiler is the checklist — no leftover `&str`, no invalid variant).
- Full suite green (1416 + 57 + 6, 0 failed); `fmt` / `clippy -D warnings` clean.
- `entry.registry` serialization unchanged (`RegistryType::Docker.as_str() == "docker"`), asserted by `test_activity_entry_new`.

`source` left as `&str` (a `Source` enum is a possible follow-up).

Closes #767.