### PR TITLE
refactor(verified): eliminate the last production unwrap() (doctest → expect)

### DIFF
--- a/nora-registry/src/verified.rs
+++ b/nora-registry/src/verified.rs
@@ -259,7 +259,8 @@ impl<T> GateOutcome<T> {
 /// use nora_registry::verified::{verified_body, Blob, Verified};
 /// // sha256("abc")
 /// let digest = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
-/// let blob = Blob::<Verified, _>::verify(b"abc".to_vec(), digest).unwrap();
+/// let blob = Blob::<Verified, _>::verify(b"abc".to_vec(), digest)
+///     .expect("abc hashes to the digest above");
 /// assert_eq!(verified_body(blob), b"abc".to_vec());
 /// ```
 ///


### PR DESCRIPTION
## Summary
The issue's premise was stale. The canonical count (arch-predict — excludes `*test*` files and `#[cfg(test)]` blocks) was already **1, not 60**, and that 1 was a `.unwrap()` in a `///` **doctest** example in `verified.rs`, not runtime code.

Converted it to `.expect("abc hashes to the digest above")` — which documents the guaranteed invariant (the digest is `sha256("abc")`, verified) per the issue's own guidance for guaranteed invariants. Production `unwrap()` count is now **0**, clearing arch-predict's zero-tolerance budget.

## Test plan
- Doctest still passes (`cargo test --doc verified`).
- arch-predict: **"Zero unwrap() in production code"**.
- Full suite green (1416 + 57 + 6, 0 failed); `fmt` / `clippy -D warnings` / `typos` clean.
- No runtime behavior change (doc-comment example only).

Closes #372.