### PR TITLE
feat(health): expose upstream circuit-breaker state in /health

### DIFF
--- a/nora-registry/src/circuit_breaker.rs
+++ b/nora-registry/src/circuit_breaker.rs
@@ -32,6 +32,33 @@ impl BreakerState {
             BreakerState::HalfOpen => 2,
         }
     }
+
+    /// Stable string used in the `/health` API. Mirrors the
+    /// `nora_circuit_breaker_state` gauge semantics (0=closed, 1=open,
+    /// 2=half_open) so operators see the same labels in both places.
+    fn as_health_str(self) -> &'static str {
+        match self {
+            BreakerState::Closed => "closed",
+            BreakerState::Open => "open",
+            BreakerState::HalfOpen => "half_open",
+        }
+    }
+}
+
+/// Read-only snapshot of one upstream's circuit-breaker state for the `/health`
+/// API. Built from cached in-memory state only — never triggers a live upstream
+/// probe, so the health endpoint stays fast and non-blocking.
+#[derive(Debug, Clone, serde::Serialize)]
+pub(crate) struct UpstreamHealth {
+    /// Breaker state: `closed` (healthy), `open` (failing fast), or
+    /// `half_open` (probing recovery). The caller reports `disabled` when the
+    /// circuit-breaker feature is off.
+    pub status: &'static str,
+    /// Accumulated consecutive-failure count (resets to 0 on success).
+    pub failure_count: u32,
+    /// Seconds since the most recent recorded failure, or `null` if the
+    /// upstream has not failed since startup.
+    pub last_failure_seconds_ago: Option<u64>,
 }
 
 /// Identifies the probe a caller was allowed to run, so a later
@@ -128,6 +155,30 @@ impl CircuitBreakerRegistry {
                 .with_label_values(&[name])
                 .set(BreakerState::Closed.as_gauge());
         }
+    }
+
+    /// Whether the circuit-breaker feature is enabled (it is disabled by
+    /// default). Used by `/health` to report `disabled` instead of a state.
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.config.enabled
+    }
+
+    /// Read-only health snapshot for `registry` from cached in-memory state.
+    ///
+    /// Never performs a live upstream probe, so it is safe to call from the
+    /// `/health` request path. Returns `None` when no breaker has been recorded
+    /// for `registry` yet (no proxy traffic since startup), which the caller
+    /// renders as a healthy `closed` default. The `last_failure` `Instant` is a
+    /// monotonic clock, so the snapshot reports *seconds ago* rather than a
+    /// wall-clock timestamp.
+    pub(crate) fn health_snapshot(&self, registry: &str) -> Option<UpstreamHealth> {
+        let breakers = self.breakers.read();
+        let breaker = breakers.get(registry)?;
+        Some(UpstreamHealth {
+            status: breaker.state.as_health_str(),
+            failure_count: breaker.failures,
+            last_failure_seconds_ago: breaker.last_failure.map(|t| t.elapsed().as_secs()),
+        })
     }
 
     /// Resolve the failure threshold for a given registry key, checking overrides first.

--- a/nora-registry/src/health.rs
+++ b/nora-registry/src/health.rs
@@ -6,6 +6,7 @@ use serde::Serialize;
 use std::collections::HashMap;
 use utoipa::ToSchema;
 
+use crate::circuit_breaker::UpstreamHealth;
 use crate::AppState;
 
 #[derive(Serialize)]
@@ -15,6 +16,11 @@ pub struct HealthStatus {
     pub uptime_seconds: u64,
     pub storage: StorageHealth,
     pub registries: HashMap<String, String>,
+    /// Per-upstream circuit-breaker state, keyed by registry name. Surfaced so
+    /// operators without Prometheus/Grafana can see which upstreams are
+    /// reachable. Read from cached in-memory state only — the `/health` path
+    /// never performs a live upstream probe (#468).
+    pub upstreams: HashMap<String, UpstreamHealth>,
 }
 
 #[derive(Serialize, ToSchema)]
@@ -48,6 +54,8 @@ async fn health_check(State(state): State<AppState>) -> (StatusCode, Json<Health
         registries.insert(reg.as_str().to_string(), "ok".to_string());
     }
 
+    let upstreams = build_upstreams(&state);
+
     let health = HealthStatus {
         status: status.to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -58,6 +66,7 @@ async fn health_check(State(state): State<AppState>) -> (StatusCode, Json<Health
             total_size_bytes: total_size,
         },
         registries,
+        upstreams,
     };
 
     let status_code = if storage_reachable {
@@ -79,6 +88,42 @@ async fn readiness_check(State(state): State<AppState>) -> StatusCode {
 
 async fn check_storage_reachable(state: &AppState) -> bool {
     state.storage.health_check().await
+}
+
+/// Build the per-upstream circuit-breaker view for the `/health` response.
+///
+/// One entry per enabled registry, keyed by registry name. The state is read
+/// from the circuit breaker's cached in-memory snapshot — this never performs a
+/// live upstream probe, so `/health` stays fast and non-blocking (#468).
+///
+/// A registry with no recorded breaker yet (no proxy traffic since startup, or
+/// the breaker is keyed differently — e.g. Docker keys per upstream URL)
+/// defaults to a healthy `closed` state. When the circuit-breaker feature is
+/// disabled (the default), every entry reports `disabled`.
+fn build_upstreams(state: &AppState) -> HashMap<String, UpstreamHealth> {
+    let cb_enabled = state.circuit_breaker.is_enabled();
+    let mut upstreams = HashMap::new();
+    for reg in state.enabled_registries.iter() {
+        let key = reg.as_str();
+        let entry = if !cb_enabled {
+            UpstreamHealth {
+                status: "disabled",
+                failure_count: 0,
+                last_failure_seconds_ago: None,
+            }
+        } else {
+            state
+                .circuit_breaker
+                .health_snapshot(key)
+                .unwrap_or(UpstreamHealth {
+                    status: "closed",
+                    failure_count: 0,
+                    last_failure_seconds_ago: None,
+                })
+        };
+        upstreams.insert(key.to_string(), entry);
+    }
+    upstreams
 }
 
 #[cfg(test)]
@@ -183,5 +228,72 @@ mod tests {
         );
         // Others should still be present
         assert!(registries.contains_key("maven"));
+    }
+
+    /// #468: `/health` exposes an `upstreams` section, one entry per enabled
+    /// registry. With the circuit breaker off (the default) every entry is
+    /// reported as `disabled` rather than omitted.
+    #[tokio::test]
+    async fn test_health_upstreams_present_disabled_by_default() {
+        let ctx = create_test_context();
+        let response = send(&ctx.app, Method::GET, "/health", "").await;
+        let body = body_bytes(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let upstreams = json
+            .get("upstreams")
+            .expect("health response must have an upstreams section")
+            .as_object()
+            .unwrap();
+        assert!(upstreams.contains_key("npm"));
+        assert_eq!(
+            upstreams["npm"]["status"], "disabled",
+            "breaker off by default → upstream status should be 'disabled'"
+        );
+        assert_eq!(upstreams["npm"]["failure_count"], 0);
+    }
+
+    /// #468: when the circuit breaker is enabled and has not yet seen traffic,
+    /// an upstream defaults to the healthy `closed` state.
+    #[tokio::test]
+    async fn test_health_upstreams_closed_when_enabled_no_traffic() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.circuit_breaker.enabled = true;
+        });
+        let response = send(&ctx.app, Method::GET, "/health", "").await;
+        let body = body_bytes(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let upstreams = json.get("upstreams").unwrap().as_object().unwrap();
+        assert_eq!(upstreams["pypi"]["status"], "closed");
+    }
+
+    /// #468: a tripped breaker surfaces as `open` with the failure count, read
+    /// from cached state (no live probe in the request path).
+    #[tokio::test]
+    async fn test_health_upstreams_open_breaker_surfaced() {
+        use crate::circuit_breaker::ProbeToken;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.circuit_breaker.enabled = true;
+            cfg.circuit_breaker.failure_threshold = 2;
+            cfg.circuit_breaker.reset_timeout = 3600;
+        });
+
+        // Trip the npm breaker into Open via the cached state directly.
+        ctx.state
+            .circuit_breaker
+            .record_failure("npm", ProbeToken::BACKGROUND);
+        ctx.state
+            .circuit_breaker
+            .record_failure("npm", ProbeToken::BACKGROUND);
+
+        let response = send(&ctx.app, Method::GET, "/health", "").await;
+        let body = body_bytes(response).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let npm = &json.get("upstreams").unwrap()["npm"];
+        assert_eq!(npm["status"], "open", "tripped breaker should report open");
+        assert_eq!(npm["failure_count"], 2);
+        // pypi never failed → still closed
+        assert_eq!(json["upstreams"]["pypi"]["status"], "closed");
     }
 }

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -123,6 +123,7 @@ use crate::AppState;
             HealthResponse,
             StorageHealth,
             RegistriesHealth,
+            UpstreamHealthSchema,
             DashboardResponse,
             GlobalStats,
             RegistryCardStats,
@@ -158,6 +159,23 @@ pub struct HealthResponse {
     pub storage: StorageHealth,
     /// Registry health status
     pub registries: RegistriesHealth,
+    /// Per-upstream circuit-breaker state, keyed by registry name. Read from
+    /// cached state — `/health` never performs a live upstream probe.
+    pub upstreams: std::collections::HashMap<String, UpstreamHealthSchema>,
+}
+
+/// Circuit-breaker state for a single upstream registry, as surfaced in
+/// `/health`.
+#[derive(Serialize, ToSchema)]
+pub struct UpstreamHealthSchema {
+    /// `closed` (healthy), `open` (failing fast), `half_open` (probing
+    /// recovery), or `disabled` (circuit breaker turned off).
+    pub status: String,
+    /// Consecutive-failure count (resets to 0 on a successful fetch).
+    pub failure_count: u32,
+    /// Seconds since the most recent recorded failure, or `null` if the
+    /// upstream has not failed since startup.
+    pub last_failure_seconds_ago: Option<u64>,
 }
 
 #[derive(Serialize, ToSchema)]


### PR DESCRIPTION
## Summary

Surfaces per-upstream circuit-breaker state in the `/health` API so operators without Prometheus/Grafana can see which upstream registries are reachable. Until now this data was only available via the `nora_circuit_breaker_state` Prometheus gauge.

A new `upstreams` section is added to the `/health` response, one entry per enabled registry:

```json
{
  "status": "healthy",
  "registries": { "npm": "ok", ... },
  "upstreams": {
    "npm": { "status": "open", "failure_count": 5, "last_failure_seconds_ago": 12 },
    "pypi": { "status": "closed", "failure_count": 0, "last_failure_seconds_ago": null }
  }
}
```

- `status` mirrors the gauge labels: `closed` (healthy), `open` (failing fast), `half_open` (probing recovery), or `disabled` when the circuit-breaker feature is off (the default).
- The state is read from the circuit breaker's cached in-memory snapshot. `/health` never performs a live upstream probe, so it stays fast and non-blocking.
- A registry with no recorded breaker yet (no proxy traffic since startup) defaults to a healthy `closed`.
- The OpenAPI `HealthResponse` schema is updated to match.

### Notes / scope

- The circuit breaker stores `last_failure` as a monotonic `Instant`, so this reports **seconds since last failure** rather than a wall-clock RFC3339 timestamp. Wall-clock `last_success_at` / `last_failure_at`, the upstream `url`, `serving_stale`, and the UI status dots from the original proposal are deferred — they require adding `SystemTime` tracking and URL association to the breaker's write path, which is a larger follow-up. This PR delivers the API half cleanly.
- Docker keys its breaker per upstream URL (`docker:<url>`), so the bare `docker` entry reports the healthy default rather than a per-URL state; documented in the code.

## Test plan

- `cargo fmt -p nora-registry -- --check` — clean
- `cargo clippy --package nora-registry -- -D warnings` — clean
- `cargo test -p nora-registry` — 1419 passed
- New tests in `health.rs`:
  - `test_health_upstreams_present_disabled_by_default` — section present, `disabled` when breaker off
  - `test_health_upstreams_closed_when_enabled_no_traffic` — healthy `closed` default
  - `test_health_upstreams_open_breaker_surfaced` — tripped breaker reports `open` + failure count, read from cached state

Closes #468