### PR TITLE
docs(readme): note NORA_HOST/NORA_PUBLIC_URL for exposing the binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ curl -fsSL https://github.com/getnora-io/nora/releases/latest/download/nora-linu
 chmod +x nora && ./nora
 ```
 
+`./nora` listens on `127.0.0.1:4000`. To expose it on a network, set the bind
+address and the public URL clients should use for download links:
+
+```bash
+NORA_HOST=0.0.0.0 NORA_PUBLIC_URL=https://registry.example.com ./nora
+```
+
 ### Kubernetes (Helm)
 
 ```bash


### PR DESCRIPTION
## What

The Quick Start Binary section ended at `chmod +x nora && ./nora`, which only covers local use — the binary binds to `127.0.0.1:4000` by default, so nothing told users how to serve it on a network.

## Change

Add a short note plus example showing the bind address and public URL clients need for download links:

```bash
NORA_HOST=0.0.0.0 NORA_PUBLIC_URL=https://registry.example.com ./nora
```

This matches the startup validation, which already requires `NORA_PUBLIC_URL` when the host is a wildcard (otherwise clients get unreachable URLs in Cargo/PyPI/npm/NuGet/Terraform responses). The Docker image bakes `public_url` so `docker run` stays zero-config; the bare binary did not surface the requirement anywhere in the README.