### PR TITLE
docs(observability): drop non-existent NORA_METRICS_ENABLED reference

### DIFF
--- a/docs-site/src/content/docs/observability/prometheus-metrics.md
+++ b/docs-site/src/content/docs/observability/prometheus-metrics.md
@@ -112,6 +112,6 @@ scrape_configs:
 
 ## See Also
 
-- [Settings](/configuration/settings/) — `NORA_METRICS_ENABLED` and related options
+- [Settings](/configuration/settings/) — server configuration reference (the `/metrics` endpoint is always enabled)
 - [Circuit Breaker](/configuration/circuit-breaker/) — breaker metrics details
 - [Upgrade Guide](/deployment/upgrade-guide/) — new metrics in v0.9


### PR DESCRIPTION
## Summary

The Prometheus metrics page linked to a `NORA_METRICS_ENABLED` setting in its "See Also" section, but no such variable exists — the `/metrics` endpoint is always mounted and has no enable/disable toggle. Reword the reference so a reader does not look for a setting that isn't there.

## Test plan

- Confirmed no `NORA_METRICS*` env var or metrics-enable config field exists in `nora-registry/src/`.
- Confirmed `/metrics` is mounted unconditionally in `main.rs`.
- Docs-only change; no code paths affected.
