### PR TITLE
ci(coverage): don't fail the gate when the badge update errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,10 @@ jobs:
       - name: Update coverage badge
         # Badge needs the GIST_TOKEN secret and only makes sense for the
         # canonical branch — skip on PRs (incl. forks without secrets).
+        # Cosmetic: a stale/expired GIST_TOKEN (e.g. a 401) must not fail the
+        # Coverage gate — the real fail-under check is the "Run coverage" step.
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        continue-on-error: true
         uses: schneegans/dynamic-badges-action@0e50b8bad39e7e1afd3e4e9c2b7dd145fad07501 # v1.8.0
         with:
           auth: ${{ secrets.GIST_TOKEN }}


### PR DESCRIPTION
## Summary

The **Update coverage badge** step (runs only on push to `main`) authenticates to the gist with `GIST_TOKEN`. An expired/invalid `GIST_TOKEN` returns **401** and failed the whole **Coverage** job — even though coverage itself passed (the tarpaulin `fail-under` floor in the *Run coverage* step succeeded; measured 65.9%).

The badge is cosmetic. Mark the step `continue-on-error: true` so a stale badge secret no longer reds the CI gate. The real coverage gate is unaffected.

## Test plan

- `ci.yml` YAML validated.
- Only the badge step becomes non-fatal; the `fail-under` coverage gate (*Run coverage*) still fails the build on a real coverage drop.
- Note: the badge won't refresh until `GIST_TOKEN` is rotated (separate secret rotation).
