### PR TITLE
feat(i18n): add Chinese (Simplified) translation support

### DIFF
--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -394,12 +394,19 @@ pub fn sidebar_dark_with_registries(
 
 /// Dark theme header with language switcher
 fn header_dark(lang: Lang) -> String {
-    let (en_class, ru_class) = match lang {
+    let (en_class, ru_class, zh_class) = match lang {
         Lang::En => (
             "text-white font-semibold",
             "text-slate-400 hover:text-slate-200",
+            "text-slate-400 hover:text-slate-200",
         ),
         Lang::Ru => (
+            "text-slate-400 hover:text-slate-200",
+            "text-white font-semibold",
+            "text-slate-400 hover:text-slate-200",
+        ),
+        Lang::Zh => (
+            "text-slate-400 hover:text-slate-200",
             "text-slate-400 hover:text-slate-200",
             "text-white font-semibold",
         ),
@@ -424,6 +431,8 @@ fn header_dark(lang: Lang) -> String {
                     <button onclick="setLang('en')" class="px-3 py-1.5 {} transition-colors">EN</button>
                     <span class="text-slate-600">|</span>
                     <button onclick="setLang('ru')" class="px-3 py-1.5 {} transition-colors">RU</button>
+                    <span class="text-slate-600">|</span>
+                    <button onclick="setLang('zh')" class="px-3 py-1.5 {} transition-colors">中文</button>
                 </div>
                 <a href="https://github.com/getnora-io/nora" target="_blank" class="p-2 text-slate-400 hover:text-slate-200 hover:bg-slate-700 rounded-lg">
                     <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -438,7 +447,7 @@ fn header_dark(lang: Lang) -> String {
             </div>
         </header>
     "##,
-        en_class, ru_class
+        en_class, ru_class, zh_class
     )
 }
 

--- a/nora-registry/src/ui/i18n.rs
+++ b/nora-registry/src/ui/i18n.rs
@@ -10,12 +10,20 @@ pub enum Lang {
     #[default]
     En,
     Ru,
+    Zh,
 }
 
 impl Lang {
     pub fn from_str(s: &str) -> Self {
-        match s.to_lowercase().as_str() {
+        let lower = s.to_lowercase();
+        // Match on the primary language subtag, ignoring any region/script
+        // suffix so BCP-47 / POSIX tags ("zh-CN", "zh-Hans", "ru_RU.UTF-8")
+        // resolve the same as their bare code. Simplified Chinese is the only
+        // Chinese variant available, so every "zh*" tag maps to it.
+        let primary = lower.split(['-', '_']).next().unwrap_or(&lower);
+        match primary {
             "ru" | "rus" | "russian" => Lang::Ru,
+            "zh" | "zho" | "chs" | "chinese" => Lang::Zh,
             _ => Lang::En,
         }
     }
@@ -24,6 +32,7 @@ impl Lang {
         match self {
             Lang::En => "en",
             Lang::Ru => "ru",
+            Lang::Zh => "zh",
         }
     }
 }
@@ -143,6 +152,7 @@ pub fn get_translations(lang: Lang) -> &'static Translations {
     match lang {
         Lang::En => &TRANSLATIONS_EN,
         Lang::Ru => &TRANSLATIONS_RU,
+        Lang::Zh => &TRANSLATIONS_ZH,
     }
 }
 
@@ -363,3 +373,149 @@ pub static TRANSLATIONS_RU: Translations = Translations {
     one_file: "1 файл",
     items: "Файлы",
 };
+
+pub static TRANSLATIONS_ZH: Translations = Translations {
+    // Navigation
+    nav_dashboard: "仪表盘",
+    nav_registries: "注册表",
+
+    // Dashboard
+    dashboard_title: "仪表盘",
+    dashboard_subtitle: "所有注册表概览",
+    uptime: "运行时间",
+
+    // Stats
+    stat_downloads: "下载量",
+    stat_uploads: "上传量",
+    stat_artifacts: "制品数",
+    stat_cache_hit: "缓存命中",
+    stat_storage: "存储",
+    stats_since_restart: "自重启以来",
+
+    // Registry cards
+    active: "活跃",
+    artifacts: "制品",
+    size: "大小",
+    downloads: "下载",
+    uploads: "上传",
+
+    // Mount points
+    mount_points: "挂载点",
+    registry: "注册表",
+    mount_path: "挂载路径",
+    proxy_upstream: "代理上游",
+
+    // Activity
+    recent_activity: "最近活动",
+    last_n_events: "最近 20 条事件",
+    time: "时间",
+    action: "操作",
+    artifact: "制品",
+    source: "来源",
+    no_activity: "暂无最近活动",
+
+    // Relative time
+    just_now: "刚刚",
+    min_ago: "分钟前",
+    mins_ago: "分钟前",
+    hour_ago: "小时前",
+    hours_ago: "小时前",
+    day_ago: "天前",
+    days_ago: "天前",
+
+    // Registry pages
+    repositories: "个仓库",
+    search_placeholder: "搜索仓库...",
+    no_repos_found: "未找到仓库",
+    push_first_artifact: "推送您的第一个制品即可在此查看",
+    name: "名称",
+    tags: "标签",
+    versions: "版本",
+    updated: "更新于",
+
+    // Detail pages
+    pull_command: "拉取命令",
+    install_command: "安装命令",
+    maven_dependency: "Maven 依赖",
+    total: "共",
+    created: "创建于",
+    published: "发布于",
+    filename: "文件名",
+    files: "个文件",
+
+    // Bragging footer
+    built_for_speed: "为速度而生",
+    docker_image: "Docker 镜像",
+    cold_start: "冷启动",
+    memory: "内存",
+    registries_count: "注册表",
+    multi_arch: "多架构",
+    zero_config: "零配置",
+    tagline: "纯 Rust 实现。单二进制文件。兼容 OCI。",
+
+    // Token management
+    nav_admin: "管理",
+    nav_tokens: "令牌",
+    token_management: "令牌管理",
+    token_management_subtitle: "创建和管理用于程序化访问的 API 令牌",
+    token_create: "创建令牌",
+    token_revoke: "撤销",
+    token_revoke_confirm: "确定要撤销此令牌吗？",
+    token_description: "描述",
+    token_description_placeholder: "例如 CI/CD 流水线",
+    token_role: "角色",
+    token_ttl: "有效期",
+    token_ttl_days: "天",
+    token_created_success: "令牌创建成功。请立即复制 — 它将不再显示。",
+    token_created_warning: "此令牌将不再显示。请妥善保管。",
+    token_copy: "复制",
+    token_no_tokens: "暂无令牌。创建一个即可开始使用。",
+    token_user: "用户",
+    token_expires: "过期时间",
+    token_last_used: "最后使用",
+    token_never_used: "从未使用",
+
+    // Pagination
+    showing_range: "显示第 {start}-{end} 项，共 {total} 项",
+    showing_all: "显示全部 {count} 项",
+    no_more_items: "此页没有更多项目了",
+    one_file: "1 个文件",
+    items: "文件",
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_resolves_bare_codes() {
+        assert_eq!(Lang::from_str("en"), Lang::En);
+        assert_eq!(Lang::from_str("ru"), Lang::Ru);
+        assert_eq!(Lang::from_str("zh"), Lang::Zh);
+        assert_eq!(Lang::from_str("chinese"), Lang::Zh);
+    }
+
+    #[test]
+    fn from_str_ignores_region_and_script_subtags() {
+        // BCP-47 region/script tags resolve to the primary language.
+        assert_eq!(Lang::from_str("zh-CN"), Lang::Zh);
+        assert_eq!(Lang::from_str("zh-Hans"), Lang::Zh);
+        assert_eq!(Lang::from_str("zh-TW"), Lang::Zh); // only Simplified available
+        assert_eq!(Lang::from_str("ru-RU"), Lang::Ru);
+        assert_eq!(Lang::from_str("ru_RU.UTF-8"), Lang::Ru);
+        assert_eq!(Lang::from_str("en-US"), Lang::En);
+    }
+
+    #[test]
+    fn from_str_defaults_to_english_for_unknown() {
+        assert_eq!(Lang::from_str("fr"), Lang::En);
+        assert_eq!(Lang::from_str(""), Lang::En);
+    }
+
+    #[test]
+    fn code_round_trips_through_from_str() {
+        for lang in [Lang::En, Lang::Ru, Lang::Zh] {
+            assert_eq!(Lang::from_str(lang.code()), lang);
+        }
+    }
+}


### PR DESCRIPTION
Relands #787 by @lihongjie0209 as a signed commit (main requires verified signatures + merge queue, which an external unsigned PR can't satisfy directly).

Same translation, with one addition: language detection normalizes BCP-47 / POSIX tags to their primary subtag, so `zh-CN`, `zh-Hans` and `ru_RU.UTF-8` resolve correctly. Adds unit tests for `Lang::from_str`.

Thanks @lihongjie0209 for the contribution.