### PR TITLE
refactor(registry): verified code-quality cleanups + metrics-label docs fix

### DIFF
--- a/docs-site/src/content/docs/observability/prometheus-metrics.md
+++ b/docs-site/src/content/docs/observability/prometheus-metrics.md
@@ -16,24 +16,26 @@ curl http://localhost:4000/metrics
 | `nora_http_requests_total` | Counter | `registry`, `method`, `status` | Total HTTP requests processed |
 | `nora_http_request_duration_seconds` | Histogram | `registry`, `method` | Request latency (buckets: 1ms to 10s) |
 
-The `registry` label is derived from the request path:
+The `registry` label is derived from the request path by literal prefix
+match (the first matching prefix wins, top to bottom). The trailing slash is
+significant where shown — e.g. `/go/` matches but `/goblin` does not:
 
-| Path prefix | Label |
-|-------------|-------|
-| `/v2*` | `docker` |
-| `/npm*` | `npm` |
-| `/simple*`, `/packages*` | `pypi` |
-| `/maven2*` | `maven` |
-| `/cargo*` | `cargo` |
-| `/go/*` | `go` |
-| `/raw/*` | `raw` |
-| `/gems/*` | `gems` |
-| `/terraform/*` | `terraform` |
-| `/ansible/*` | `ansible` |
-| `/nuget/*` | `nuget` |
-| `/pub/*` | `pub` |
-| `/conan/*` | `conan` |
-| `/ui*` | `ui` |
+| Path prefix (`starts_with`) | Label |
+|-----------------------------|-------|
+| `/v2` | `docker` |
+| `/npm` | `npm` |
+| `/simple`, `/packages` | `pypi` |
+| `/maven2` | `maven` |
+| `/cargo` | `cargo` |
+| `/go/` | `go` |
+| `/raw/` | `raw` |
+| `/gems/` | `gems` |
+| `/terraform/` | `terraform` |
+| `/ansible/` | `ansible` |
+| `/nuget/` | `nuget` |
+| `/pub/` | `pub` |
+| `/conan/` | `conan` |
+| `/ui` | `ui` |
 | *(other paths)* | `other` |
 
 ## Cache metrics
@@ -114,4 +116,4 @@ scrape_configs:
 
 - [Settings](/configuration/settings/) — server configuration reference (the `/metrics` endpoint is always enabled)
 - [Circuit Breaker](/configuration/circuit-breaker/) — breaker metrics details
-- [Upgrade Guide](/deployment/upgrade-guide/) — new metrics in v0.9
+- [Upgrade Guide](/deployment/upgrade-guide/) — metric changes across releases

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -32,6 +32,28 @@ use axum::{
 use sha2::Digest;
 use std::time::Duration;
 
+/// Resolve the effective quarantine mode and TTL for the cargo registry,
+/// falling back to the global curation settings when no cargo-specific
+/// override is configured. Extracted so the two cargo proxy paths stay in sync.
+fn resolve_cargo_quarantine_config(
+    state: &AppState,
+) -> (crate::digest_quarantine::QuarantineMode, i64) {
+    crate::digest_quarantine::resolve_global(
+        state.config.curation.cargo.quarantine.as_ref().or(state
+            .config
+            .curation
+            .quarantine
+            .as_ref()),
+        state
+            .config
+            .curation
+            .cargo
+            .quarantine_ttl
+            .as_deref()
+            .or(state.config.curation.quarantine_ttl.as_deref()),
+    )
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/cargo/index/config.json", get(index_config))
@@ -215,7 +237,7 @@ async fn sparse_index(
             // Upstream unreachable — serve the stale cached index if we have one (graceful).
             if let Some(ref data) = cached {
                 tracing::warn!(
-                    crate_name = crate_name,
+                    crate_name,
                     "Cargo upstream failed, serving stale cached index"
                 );
                 let mut response = sparse_index_conditional(data.to_vec(), &headers);
@@ -230,7 +252,7 @@ async fn sparse_index(
                 ProxyError::NotFound => StatusCode::NOT_FOUND.into_response(),
                 _ => {
                     tracing::debug!(
-                        crate_name = crate_name,
+                        crate_name,
                         error = ?e,
                         "Cargo sparse index upstream error"
                     );
@@ -445,20 +467,7 @@ async fn download(
         state
             .audit
             .log(AuditEntry::new("pull", "api", "", "cargo", ""));
-        let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-            state.config.curation.cargo.quarantine.as_ref().or(state
-                .config
-                .curation
-                .quarantine
-                .as_ref()),
-            state
-                .config
-                .curation
-                .cargo
-                .quarantine_ttl
-                .as_deref()
-                .or(state.config.curation.quarantine_ttl.as_deref()),
-        );
+        let (q_mode, q_secs) = resolve_cargo_quarantine_config(&state);
         if let Some(resp) = crate::digest_quarantine::proxy_gate_dated(
             &state.digest_store,
             "cargo",
@@ -533,20 +542,7 @@ async fn download(
             state
                 .audit
                 .log(AuditEntry::new("proxy_fetch", "api", "", "cargo", ""));
-            let (q_mode, q_secs) = crate::digest_quarantine::resolve_global(
-                state.config.curation.cargo.quarantine.as_ref().or(state
-                    .config
-                    .curation
-                    .quarantine
-                    .as_ref()),
-                state
-                    .config
-                    .curation
-                    .cargo
-                    .quarantine_ttl
-                    .as_deref()
-                    .or(state.config.curation.quarantine_ttl.as_deref()),
-            );
+            let (q_mode, q_secs) = resolve_cargo_quarantine_config(&state);
             if let Some(resp) = crate::digest_quarantine::proxy_gate_dated(
                 &state.digest_store,
                 "cargo",

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -243,7 +243,7 @@ fn build_context(
 
     let bypass_token = config.curation.bypass_token.clone();
     let reloadable = Arc::new(arc_swap::ArcSwap::from_pointee(crate::ReloadableConfig {
-        curation_engine: curation_engine,
+        curation_engine,
         bypass_token,
     }));
 

--- a/nora-registry/src/ui/i18n.rs
+++ b/nora-registry/src/ui/i18n.rs
@@ -20,7 +20,10 @@ impl Lang {
         // suffix so BCP-47 / POSIX tags ("zh-CN", "zh-Hans", "ru_RU.UTF-8")
         // resolve the same as their bare code. Simplified Chinese is the only
         // Chinese variant available, so every "zh*" tag maps to it.
-        let primary = lower.split(['-', '_']).next().unwrap_or(&lower);
+        let primary = lower
+            .split(['-', '_'])
+            .next()
+            .expect("str::split always yields at least one segment");
         match primary {
             "ru" | "rus" | "russian" => Lang::Ru,
             "zh" | "zho" | "chs" | "chinese" => Lang::Zh,


### PR DESCRIPTION
Applies the verified-correct subset of the GitHub "AI findings" code-quality suggestions, each checked against the code (the rejected/incorrect ones are left out).

## Changes
- **cargo**: extract the duplicated quarantine mode/TTL resolution (cargo override → global curation fallback) into `resolve_cargo_quarantine_config`, used by both proxy paths; use `tracing` field-init shorthand for `crate_name` in the two upstream-failure log lines.
- **test_helpers**: field-init shorthand for `curation_engine` in `ReloadableConfig`.
- **ui/i18n**: `expect()` the infallible `split` in language-tag detection instead of an unreachable `unwrap_or` fallback.
- **docs(observability)**: document the Prometheus `registry` label as a literal `starts_with` prefix table (trailing slash shown where load-bearing, first-match-wins noted) instead of ambiguous glob notation.

No behavior change. The quarantine helper preserves the exact `(QuarantineMode, i64)` semantics; the tracing/field shorthands and the `expect` are byte-identical at runtime.

## Why the docs change
The registry-label table mixed `/v2*` and `/go/*` notation, which misrepresented `detect_registry()` (`nora-registry/src/metrics.rs`): it matches a literal prefix via `starts_with`, with a load-bearing trailing slash for go/raw/gems/terraform/ansible/nuget/pub/conan — e.g. `/goblin` does **not** match `/go/` (unit tests pin `detect_registry("/goblin/...") == "other"`). Reading the patterns as `/go*` would be wrong; this supersedes #789, which standardized to `/go*` and is closed.

## Verification
- `cargo fmt --check`, `cargo clippy -p nora-registry -- -D warnings`: clean
- `cargo test -p nora-registry`: 1434 + 6 doctests, 0 failed
- A/B parity vs the prior build (i18n language detection, cargo endpoints, `/metrics` registry labels): identical; the `/go/` vs `/goblin` label semantics confirmed on live `/metrics`.
