### PR TITLE
chore(clippy): lint test and bench targets under -D warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy --package nora-registry -- -D warnings
+        run: cargo clippy --package nora-registry --all-targets -- -D warnings
 
       - name: Run tests
         run: cargo test --package nora-registry

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ fmt:
 	$(CARGO) fmt --check
 
 clippy:
-	$(CARGO) clippy -- -D warnings
+	$(CARGO) clippy --all-targets -- -D warnings
 
 test:
 	$(CARGO) test --lib --bin nora

--- a/nora-registry/benches/parsing.rs
+++ b/nora-registry/benches/parsing.rs
@@ -1,7 +1,8 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use nora_registry::validation::{
     validate_digest, validate_docker_name, validate_docker_reference, validate_storage_key,
 };
+use std::hint::black_box;
 
 fn bench_validation(c: &mut Criterion) {
     let mut group = c.benchmark_group("validation");

--- a/nora-registry/src/lib.rs
+++ b/nora-registry/src/lib.rs
@@ -1,5 +1,24 @@
 #![deny(clippy::unwrap_used)]
 #![forbid(unsafe_code)]
+// Test code is linted under `--all-targets` but is not held to the production
+// restriction/style lints: `.unwrap()`/`.expect()` are idiomatic in tests, and
+// the small style nits (redundant clone/field names, `>= x + 1`, etc.) are not
+// worth contorting assertions over. Scoped to `cfg(test)` so production keeps
+// the strict profile (incl. the workspace `redundant_clone = deny`).
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::redundant_clone,
+        clippy::int_plus_one,
+        clippy::field_reassign_with_default,
+        clippy::unnecessary_get_then_check,
+        clippy::single_match,
+        clippy::redundant_field_names,
+        clippy::len_zero,
+        clippy::items_after_test_module
+    )
+)]
 //! NORA Registry — library interface for fuzzing and testing
 
 pub mod validation;

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -3,6 +3,22 @@
 #![deny(clippy::unwrap_used)]
 #![forbid(unsafe_code)]
 #![warn(clippy::large_stack_frames, clippy::large_futures)]
+// Test code is linted under `--all-targets` but is not held to the production
+// restriction/style lints (see lib.rs for rationale). Scoped to `cfg(test)`.
+#![cfg_attr(
+    test,
+    allow(
+        clippy::unwrap_used,
+        clippy::redundant_clone,
+        clippy::int_plus_one,
+        clippy::field_reassign_with_default,
+        clippy::unnecessary_get_then_check,
+        clippy::single_match,
+        clippy::redundant_field_names,
+        clippy::len_zero,
+        clippy::items_after_test_module
+    )
+)]
 mod activity_log;
 mod admin;
 mod audit;


### PR DESCRIPTION
Runs the clippy gate with `--all-targets` (Makefile + CI) so `#[cfg(test)]` modules and benches are held to `-D warnings`. They were silently unlinted — which is how a `redundant_field_names` slipped into `test_helpers` on main.

## Changes
- `Makefile` + `.github/workflows/ci.yml`: `clippy … -D warnings` → `clippy --all-targets … -D warnings`.
- `lib.rs` + `main.rs`: a `cfg(test)`-scoped `allow(...)` for the production restriction/style lints (`unwrap_used`, `redundant_clone`, `int_plus_one`, `field_reassign_with_default`, `single_match`, `len_zero`, `redundant_field_names`, `items_after_test_module`, `unnecessary_get_then_check`). `.unwrap()`/`.expect()` are idiomatic in tests and the style nits aren't worth contorting assertions over. **Production keeps the strict profile** — the workspace `redundant_clone = deny` and the crate-root `deny(unwrap_used)` still apply to non-test code.
- `benches/parsing.rs`: use `std::hint::black_box` (criterion's re-export is deprecated).

This cleared 92 `unwrap_used` + 17 deprecated `black_box` + ~18 style nits, all in test/bench code; production was already clean.

## Verification
- `cargo clippy --all-targets -- -D warnings`: green (the new gate command)
- `cargo fmt --check`: clean
- `cargo test -p nora-registry`: all pass
