### PR TITLE
refactor: hoist outbound User-Agent into a compile-time const

### DIFF
--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -362,6 +362,10 @@ fn log_outbound_proxy() {
     }
 }
 
+/// User-Agent sent by all outbound HTTP clients. Compile-time `&'static str`
+/// via `concat!`/`env!` — no per-call heap allocation.
+const USER_AGENT: &str = concat!("nora/", env!("CARGO_PKG_VERSION"));
+
 /// Build HTTP client with optional custom CA certificate support.
 ///
 /// When `timeout` is `Some`, a default request timeout is set on the client
@@ -374,8 +378,7 @@ fn build_http_client(
     timeout: Option<std::time::Duration>,
     no_proxy: bool,
 ) -> reqwest::Client {
-    let mut builder =
-        reqwest::ClientBuilder::new().user_agent(format!("nora/{}", env!("CARGO_PKG_VERSION")));
+    let mut builder = reqwest::ClientBuilder::new().user_agent(USER_AGENT);
 
     if let Some(t) = timeout {
         builder = builder.timeout(t);


### PR DESCRIPTION
## What

`build_http_client` built the outbound `User-Agent` with
`format!("nora/{}", env!("CARGO_PKG_VERSION"))` on every call, allocating a
`String` each time. Replace it with a `&'static str` const built via
`concat!`/`env!`, evaluated at compile time — no per-call heap allocation.

## Why

The User-Agent is a fixed value; there is no reason to re-allocate it. The
emitted header is byte-for-byte identical, so behavior is unchanged.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p nora-registry` — 1497 passed, 0 failed (1 ignored)
