### PR TITLE
refactor(storage): type StorageError::Io as #[from] std::io::Error

### DIFF
--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -1051,9 +1051,9 @@ mod tests {
                 ])
             }
             async fn get(&self, _key: &str) -> StorageResult<Bytes> {
-                Err(StorageError::Io(
-                    "injected transient read error".to_string(),
-                ))
+                Err(StorageError::Io(std::io::Error::other(
+                    "injected transient read error",
+                )))
             }
             async fn put(&self, _key: &str, _data: &[u8]) -> StorageResult<()> {
                 panic!("regenerate must abort before writing a truncated index");

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -22,12 +22,8 @@ static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64:
 /// cannot be fsync'd means durability is not guaranteed, so we return Err.
 async fn sync_parent_dir(path: &Path) -> Result<()> {
     if let Some(parent) = path.parent() {
-        let dir = fs::File::open(parent)
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
-        dir.sync_all()
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
+        let dir = fs::File::open(parent).await?;
+        dir.sync_all().await?;
     }
     Ok(())
 }
@@ -117,9 +113,7 @@ impl StorageBackend for LocalStorage {
 
         // Create parent directories
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+            fs::create_dir_all(parent).await?;
         }
 
         // Atomic write: create temp file in same directory, write, rename.
@@ -130,21 +124,11 @@ impl StorageBackend for LocalStorage {
         let seq = TMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let tmp = path.with_extension(format!("tmp.{}.{}", std::process::id(), seq));
         let write_result: Result<()> = async {
-            let mut file = fs::File::create(&tmp)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
-            file.write_all(data)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
-            file.flush()
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
-            file.sync_all()
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
-            fs::rename(&tmp, &path)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+            let mut file = fs::File::create(&tmp).await?;
+            file.write_all(data).await?;
+            file.flush().await?;
+            file.sync_all().await?;
+            fs::rename(&tmp, &path).await?;
             // Durability: make the rename's directory entry survive power-loss.
             sync_parent_dir(&path).await?;
             Ok(())
@@ -163,14 +147,12 @@ impl StorageBackend for LocalStorage {
             if e.kind() == std::io::ErrorKind::NotFound {
                 StorageError::NotFound
             } else {
-                StorageError::Io(e.to_string())
+                StorageError::Io(e)
             }
         })?;
 
         let mut buffer = Vec::new();
-        file.read_to_end(&mut buffer)
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
+        file.read_to_end(&mut buffer).await?;
 
         Ok(Bytes::from(buffer))
     }
@@ -182,7 +164,7 @@ impl StorageBackend for LocalStorage {
             if e.kind() == std::io::ErrorKind::NotFound {
                 StorageError::NotFound
             } else {
-                StorageError::Io(e.to_string())
+                StorageError::Io(e)
             }
         })?;
 
@@ -203,7 +185,7 @@ impl StorageBackend for LocalStorage {
             results
         })
         .await
-        .map_err(|e| StorageError::Io(format!("list task panicked: {e}")))
+        .map_err(|e| StorageError::Io(std::io::Error::other(format!("list task panicked: {e}"))))
     }
 
     async fn list_with_meta(&self, prefix: &str) -> Result<Vec<(String, FileMeta)>> {
@@ -219,7 +201,7 @@ impl StorageBackend for LocalStorage {
             results
         })
         .await
-        .map_err(|e| StorageError::Io(format!("list task panicked: {e}")))
+        .map_err(|e| StorageError::Io(std::io::Error::other(format!("list task panicked: {e}"))))
     }
 
     async fn stat(&self, key: &str) -> Option<FileMeta> {
@@ -287,9 +269,7 @@ impl StorageBackend for LocalStorage {
     async fn put_from_path(&self, key: &str, src: &Path) -> Result<()> {
         let dest = self.key_to_path(key);
         if let Some(parent) = dest.parent() {
-            fs::create_dir_all(parent)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+            fs::create_dir_all(parent).await?;
         }
         // Try atomic rename first; fall back to streaming copy on EXDEV
         // (cross-device link — src and dest on different filesystems).
@@ -300,43 +280,25 @@ impl StorageBackend for LocalStorage {
                 Ok(())
             }
             Err(e) if e.raw_os_error() == Some(18 /* EXDEV */) => {
-                let mut reader = fs::File::open(src)
-                    .await
-                    .map_err(|e| StorageError::Io(e.to_string()))?;
+                let mut reader = fs::File::open(src).await?;
                 let tmp = dest.with_extension("tmp");
-                let mut writer = fs::File::create(&tmp)
-                    .await
-                    .map_err(|e| StorageError::Io(e.to_string()))?;
+                let mut writer = fs::File::create(&tmp).await?;
                 let mut buf = vec![0u8; 8 * 1024 * 1024]; // 8 MiB chunks
                 let copy_result: Result<()> = async {
                     loop {
-                        let n = reader
-                            .read(&mut buf)
-                            .await
-                            .map_err(|e| StorageError::Io(e.to_string()))?;
+                        let n = reader.read(&mut buf).await?;
                         if n == 0 {
                             break;
                         }
-                        writer
-                            .write_all(&buf[..n])
-                            .await
-                            .map_err(|e| StorageError::Io(e.to_string()))?;
+                        writer.write_all(&buf[..n]).await?;
                     }
-                    writer
-                        .flush()
-                        .await
-                        .map_err(|e| StorageError::Io(e.to_string()))?;
+                    writer.flush().await?;
                     // Durability: fsync the copied data before publishing it.
                     // flush() only pushes to the OS; sync_all() makes it crash-
                     // durable, matching the put() path (the direct-rename branch
                     // relies on the caller having fsync'd src).
-                    writer
-                        .sync_all()
-                        .await
-                        .map_err(|e| StorageError::Io(e.to_string()))?;
-                    fs::rename(&tmp, &dest)
-                        .await
-                        .map_err(|e| StorageError::Io(e.to_string()))?;
+                    writer.sync_all().await?;
+                    fs::rename(&tmp, &dest).await?;
                     // Durability: make the rename's directory entry durable.
                     sync_parent_dir(&dest).await?;
                     Ok(())
@@ -349,7 +311,7 @@ impl StorageBackend for LocalStorage {
                 let _ = fs::remove_file(src).await;
                 Ok(())
             }
-            Err(e) => Err(StorageError::Io(e.to_string())),
+            Err(e) => Err(StorageError::Io(e)),
         }
     }
 
@@ -359,13 +321,10 @@ impl StorageBackend for LocalStorage {
             if e.kind() == std::io::ErrorKind::NotFound {
                 StorageError::NotFound
             } else {
-                StorageError::Io(e.to_string())
+                StorageError::Io(e)
             }
         })?;
-        let meta = file
-            .metadata()
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
+        let meta = file.metadata().await?;
         Ok((meta.len(), Box::pin(file)))
     }
 
@@ -381,18 +340,12 @@ impl StorageBackend for LocalStorage {
             if e.kind() == std::io::ErrorKind::NotFound {
                 StorageError::NotFound
             } else {
-                StorageError::Io(e.to_string())
+                StorageError::Io(e)
             }
         })?;
-        let size = file
-            .metadata()
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?
-            .len();
+        let size = file.metadata().await?.len();
         if start > 0 {
-            file.seek(std::io::SeekFrom::Start(start))
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+            file.seek(std::io::SeekFrom::Start(start)).await?;
         }
         let len = end.saturating_sub(start) + 1;
         Ok((size, Box::pin(file.take(len))))

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -35,7 +35,7 @@ pub enum StorageError {
     NotFound,
 
     #[error("IO error: {0}")]
-    Io(String),
+    Io(#[from] std::io::Error),
 
     #[error("Validation error: {0}")]
     Validation(#[from] ValidationError),
@@ -145,10 +145,7 @@ pub trait StorageBackend: Send + Sync {
         let mut buf = [0u8; 64 * 1024];
         while to_skip > 0 {
             let want = to_skip.min(buf.len() as u64) as usize;
-            let n = reader
-                .read(&mut buf[..want])
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+            let n = reader.read(&mut buf[..want]).await?;
             if n == 0 {
                 break;
             }
@@ -252,14 +249,18 @@ impl Storage {
                                 .with_label_values(&["put", "pin_error"])
                                 .inc();
                             tracing::error!(error = %e, key = %key, "hash-pin record failed");
-                            return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
+                            return Err(StorageError::Io(std::io::Error::other(format!(
+                                "hash-pin record failed: {e}"
+                            ))));
                         }
                         Err(e) => {
                             STORAGE_OPERATIONS
                                 .with_label_values(&["put", "pin_error"])
                                 .inc();
                             tracing::error!(error = %e, key = %key, "hash-pin record task panicked");
-                            return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
+                            return Err(StorageError::Io(std::io::Error::other(format!(
+                                "hash-pin record failed: {e}"
+                            ))));
                         }
                     }
                 }
@@ -531,8 +532,11 @@ impl Storage {
         if !apply {
             return Ok(RepinOutcome::WouldUpdate { old, new: expected });
         }
-        pins.record_hash(key, &expected)
-            .map_err(|e| StorageError::Io(format!("hash-pin record failed: {e}")))?;
+        pins.record_hash(key, &expected).map_err(|e| {
+            StorageError::Io(std::io::Error::other(format!(
+                "hash-pin record failed: {e}"
+            )))
+        })?;
         Ok(RepinOutcome::Updated { old, new: expected })
     }
 
@@ -576,14 +580,18 @@ impl Storage {
                                 .with_label_values(&["put", "pin_error"])
                                 .inc();
                             tracing::error!(error = %e, key = %key, "hash-pin record failed");
-                            return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
+                            return Err(StorageError::Io(std::io::Error::other(format!(
+                                "hash-pin record failed: {e}"
+                            ))));
                         }
                         Err(e) => {
                             STORAGE_OPERATIONS
                                 .with_label_values(&["put", "pin_error"])
                                 .inc();
                             tracing::error!(error = %e, key = %key, "hash-pin record task panicked");
-                            return Err(StorageError::Io(format!("hash-pin record failed: {e}")));
+                            return Err(StorageError::Io(std::io::Error::other(format!(
+                                "hash-pin record failed: {e}"
+                            ))));
                         }
                     }
                 }

--- a/nora-registry/src/storage/s3.rs
+++ b/nora-registry/src/storage/s3.rs
@@ -243,9 +243,7 @@ impl StorageBackend for S3Storage {
         // Streaming multipart upload: read file in 8 MiB chunks, feed to
         // WriteMultipart which buffers into 5 MiB parts and uploads in
         // parallel. Never loads the entire file into RAM (#580).
-        let mut file = tokio::fs::File::open(src)
-            .await
-            .map_err(|e| StorageError::Io(e.to_string()))?;
+        let mut file = tokio::fs::File::open(src).await?;
 
         // CANCEL-SAFETY: if dropped between put_multipart and finish,
         // S3 does NOT automatically abort orphaned parts. Cleanup depends
@@ -258,10 +256,7 @@ impl StorageBackend for S3Storage {
 
         let mut buf = vec![0u8; 8 * 1024 * 1024]; // 8 MiB read buffer
         loop {
-            let n = file
-                .read(&mut buf)
-                .await
-                .map_err(|e| StorageError::Io(e.to_string()))?;
+            let n = file.read(&mut buf).await?;
             if n == 0 {
                 break;
             }


### PR DESCRIPTION
## What

`StorageError::Io` carried a `String`, so every filesystem call erased its
`io::Error` to text via `.map_err(|e| StorageError::Io(e.to_string()))?` —
losing the `ErrorKind` and the source chain.

Type the variant as `Io(#[from] std::io::Error)`:

- ~23 `.map_err(|e| StorageError::Io(e.to_string()))?` collapse to `?`
  (auto-conversion via `#[from]`); the real `io::Error` is preserved.
- Non-io constructions (hash-pin "record failed", `JoinError` "task panicked",
  one test mock) wrap their message via `std::io::Error::other(..)`.
- `Network(String)` is intentionally left untyped — it is matched on its
  payload (`s3.rs` `Network(msg) =>`), so `#[from]` would break that arm.

No `StorageError::Io` payload is pattern-matched anywhere, so the variant-shape
change is safe; `Display` is unchanged (`"IO error: {0}"`; `io::Error: Display`).

## Verification

- `cargo fmt --check` + `cargo clippy --package nora-registry -- -D warnings` clean
- 1434 tests pass
- Net −44 lines (map_err boilerplate removed)
