### PR TITLE
chore(deps): bump bcrypt 0.19.0 → 0.19.2 (RUSTSEC-2026-0199)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.0"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523ab528ce3a7ada6597f8ccf5bd8d85ebe26d5edf311cad4d1d3cfb2d357ac6"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64",
  "blowfish",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "blowfish"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
+checksum = "62ce3946557b35e71d1bbe07ec385073ce9eda05043f95de134eb578fcf1a298"
 dependencies = [
  "byteorder",
  "cipher",
@@ -422,11 +422,11 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common 0.2.1",
  "inout",
 ]
 
@@ -1546,11 +1546,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3181,7 +3181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",


### PR DESCRIPTION
## Summary
CI `Security` (cargo audit) went red repo-wide after **RUSTSEC-2026-0199** landed in the advisory DB (published 2026-06-20, *after* main's last green run on 07-02). `bcrypt::verify()` panics on a 60-byte hash string with multi-byte UTF-8 at certain byte positions (DoS). Fixed in **0.19.2** by rejecting non-ASCII hash bytes upfront.

Lockfile-only bump (0.19.0 → 0.19.2; pulls bcrypt's transitive blowfish 0.10 / cipher 0.5 / inout 0.2).

## Exploitability in NORA
Low: `auth/htpasswd.rs` calls `bcrypt::verify(password, hash)` where the vulnerable arg (`hash`) is the **operator-controlled** stored htpasswd hash, not the wire-supplied password — so not attacker-reachable. This bump clears the advisory properly (vs adding it to the cargo-audit ignore-list).

## Test plan
- `cargo build -p nora-registry` OK
- `auth::htpasswd` tests 6/6 green
- Unblocks the `Security` job for all open PRs (e.g. #802).