### PR TITLE
ci: harden auto-reland.yml (Scorecard: pin + permissions + dangerous-workflow)

### DIFF
--- a/.github/workflows/auto-reland.yml
+++ b/.github/workflows/auto-reland.yml
@@ -22,9 +22,12 @@ on:
   pull_request_target:
     types: [labeled]
 
+# Least-privilege GITHUB_TOKEN (Scorecard Token-Permissions): this token is used
+# only to check out the base and for the guard's read-only API calls. All writes
+# (create branch/commit, open the reland PR, comment) go through RELAND_TOKEN.
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   reland:
@@ -51,9 +54,14 @@ jobs:
           fi
 
       - name: Checkout base (main) — never the PR head
-        uses: actions/checkout@v4
+        # No explicit `ref:` — under pull_request_target the default checkout is the
+        # BASE branch HEAD (github.sha = base tip), exactly what reland needs. Deriving
+        # the ref from `github.event.pull_request.*` tripped Scorecard Dangerous-Workflow
+        # (it can't tell base.ref (trusted) from head.ref (untrusted)); the default is
+        # equivalent here and untrusted PR content is only fetched+staged below, never
+        # checked out or executed.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Clears all **three** open code-scanning alerts on `auto-reland.yml` (surfaced from the code-scanning page):

| sev | alert | fix |
|-----|-------|-----|
| critical | Dangerous-Workflow — untrusted-checkout heuristic on `ref: ${{ github.event.pull_request.base.ref }}` | remove the explicit `ref:`; under `pull_request_target` the default checkout **is** base HEAD (equivalent) and no longer derives from `github.event.pull_request.*`. False positive: `base.ref` is trusted, Scorecard cannot tell it from `head.ref`. The workflow never checks out or executes PR code — it only fetch+squash-**stages** the reviewed diff. |
| high | Token-Permissions — top-level `contents: write` | `GITHUB_TOKEN` → `contents: read` + `pull-requests: read`. All writes go through `RELAND_TOKEN`; `GITHUB_TOKEN` is used only for checkout + the guard reads. |
| medium | Pinned-Dependencies — `actions/checkout@v4` | pin to `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6), matching the other 19 uses. |

`pull_request_target` behavior preserved (base checkout, no PR-code execution, approved-PR + write-access-labeler guards intact).

⚠️ Reviewer note: the permissions drop assumes every write flows via `RELAND_TOKEN` (verified by reading the workflow) — worth a maintainer eye since `pull_request_target` cannot be dry-run locally.