### PR TITLE
docs(compat): npm audit is implemented (#597); unpublish → quarantine

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -42,10 +42,10 @@ This document describes which parts of each registry protocol are implemented in
 | Tarball download | Full | SHA256 verified |
 | Tarball URL rewriting | Full | Points to NORA, not upstream |
 | Publish (`npm publish`) | Full | Immutable versions |
-| Unpublish | — | Not implemented |
+| Unpublish | — | Immutable; use quarantine/blocklist to disable a version |
 | Dist-tags (`latest`, `next`) | Partial | Read from metadata, no explicit management |
 | Search (`/-/v1/search`) | — | Not implemented |
-| Audit (`/-/npm/v1/security/advisories`) | — | Not implemented |
+| Audit (`bulk` npm7 / `audits/quick` npm6) | Full | Proxy repos: forwarded to upstream verbatim; internal-namespace names stripped/refused; anonymous-read eligible. Proxied packages only (no local advisory DB). (#597) |
 | Upstream proxy | Full | Configurable TTL |
 
 ## Maven


### PR DESCRIPTION
#597 (merged in #805) added `npm audit` proxying, but the compat matrix still listed it as *not implemented*. Fixes the drift:
- **Audit** → **Full** — proxy repos forward the audit POST to upstream verbatim; internal-namespace names are stripped/refused (dependency-confusion); anonymous-read eligible; proxied packages only (no local advisory DB).
- **Unpublish** note clarified — immutable, use **quarantine/blocklist** to disable a version (matches the actual remediation path).

Docs-only.