### PR TITLE
docs(curation): document internal_namespaces pattern forms (#731)

### DIFF
--- a/docs-site/src/content/docs/configuration/curation.md
+++ b/docs-site/src/content/docs/configuration/curation.md
@@ -195,6 +195,20 @@ internal_namespaces = ["@mycompany/**", "com.mycompany.**"]
 export NORA_CURATION_INTERNAL_NS="@mycompany/**,com.mycompany.**"
 ```
 
+### Pattern forms
+
+A pattern is matched against a package's **coordinate** — docker `org/image`, raw `org/path`, npm `@scope/name`, Go the module path, Maven the dotted/colon `group.artifact` / `group:artifact`, PyPI/Cargo the normalized name.
+
+| Pattern | Matches | Use for |
+|---------|---------|---------|
+| `prefix/**` | `prefix` itself **and** `prefix/anything/deeper` | slash-pathed coordinates: docker, raw, npm scope, Go |
+| `prefix.**` | `prefix`, `prefix.anything`, `prefix:anything` | dotted/colon coordinates: Maven `group.artifact` / `group:artifact` |
+| `name` (no wildcard) | that **exact** coordinate only — **not** its children | pinning a single package |
+| `prefix*` | any value **starting with** the literal `prefix` (crosses `/` and `.`) | ⚠️ over-matches — `myorg*` also matches `myorganization` |
+| `*` (alone) | everything | rarely useful for an isolation list |
+
+**Rule of thumb:** to isolate a namespace *and everything under it*, use the boundary-aware `prefix/**` (slash coordinates) or `prefix.**` (Maven dotted/colon) forms — **not** a bare name (exact-only, so it misses `myorg/pkg`) and **not** `myorg*` (a raw prefix that also catches siblings like `myorganization`). This is dependency-confusion defense, so err toward `**`.
+
 ---
 
 ## Minimum Release Age Quarantine


### PR DESCRIPTION
Closes #731.

The **Internal Namespaces** section had `@mycompany/**` / `com.mycompany.**` examples but never documented the matcher, so `prefix.**` / `prefix/**` vs a single `*` was unclear. Adds a pattern-form table grounded in the actual matcher (`nora-registry/src/curation.rs` `glob_match`):

- `prefix/**` — namespace + all descendants, slash coordinates (docker, raw, npm scope, Go)
- `prefix.**` — namespace + all descendants, Maven dotted/colon (`group.artifact` / `group:artifact`)
- bare `name` — exact coordinate only (misses children)
- `prefix*` — raw prefix, ⚠️ over-matches siblings (`myorg*` also hits `myorganization`)
- `*` — everything

Plus a rule-of-thumb to prefer the boundary-aware `**` forms (dependency-confusion defense). Docs-only.