### PR TITLE
docs: fill metrics, config, and registry-page gaps (#708 #710 #711)

### DIFF
--- a/docs-site/src/content/docs/configuration/settings.md
+++ b/docs-site/src/content/docs/configuration/settings.md
@@ -339,10 +339,11 @@ general_burst = 200
 # =============================================================================
 [docker]
 enabled = true
-proxy_timeout = 60
-read_timeout = 60
+proxy_timeout = 300            # connection timeout (seconds)
+read_timeout = 60              # per-chunk read timeout while streaming a blob
 metadata_ttl = -1              # -1 = forever, 0 = always refetch, >0 = seconds
 serve_stale = true
+default_action = "allow"       # action when an image matches no upstream prefix: allow | deny
 
 [[docker.upstreams]]
 url = "https://registry-1.docker.io"
@@ -533,6 +534,48 @@ internal_namespaces = []    # e.g., ["@mycompany/**", "com.mycompany.**"]
 [audit]
 mode = "file"               # "file", "stdout", "both", "off"
 ```
+
+---
+
+## Additional options
+
+Options supported by the code but not shown in the tables above.
+
+### Server & auth
+
+| TOML | Env | Default | Description |
+|------|-----|---------|-------------|
+| `server.proxy_coalesce` | *(none)* | `true` | Single-flight coalescing of concurrent identical upstream fetches (kill-switch) |
+| `server.trust_upstream_dates` | `NORA_TRUST_UPSTREAM_DATES` | `false` | Trust upstream publish dates for `min_release_age`. **Default `false`** — NORA uses its own first-seen (cache) time, since upstream dates are unsigned/spoofable. Set `true` to restore pre-0.9 behavior |
+| `auth.token_cache_ttl` | `NORA_AUTH_TOKEN_CACHE_TTL` | `300` | In-memory token-verify cache TTL (seconds); bounds the cross-replica revocation window |
+| `auth.admin_users` | `NORA_AUTH_ADMIN_USERS` | *(empty)* | htpasswd usernames allowed to self-mint an `admin` token via `POST /api/tokens` (bootstrap); see also the admin-gated `POST /api/v1/admin/tokens` |
+| `auth.oidc.providers[].jwks_uri` | *(none)* | *(discovered)* | Explicit JWKS URI, overriding `/.well-known` discovery |
+
+### Per-registry: staleness & revalidation
+
+Most proxy registries support these (defaults shown; `metadata_ttl` in seconds):
+
+| TOML (per registry) | Env pattern | Default | Description |
+|------|-----|---------|-------------|
+| `<reg>.metadata_ttl` | `NORA_<REG>_METADATA_TTL` | `300` (ansible `3600`) | Mutable-metadata cache TTL |
+| `<reg>.serve_stale` | `NORA_<REG>_SERVE_STALE` | `true` | Serve stale metadata when upstream is unreachable |
+| `<reg>.revalidate` | `NORA_<REG>_REVALIDATE` | `true` | Conditional revalidation (`If-None-Match` / `If-Modified-Since`) |
+
+Applies to npm, gems, terraform, ansible, nuget, pub, conan (and `metadata_ttl` to maven/cargo/go). NuGet also has `metadata_proxy_timeout` (`NORA_NUGET_METADATA_TIMEOUT`, default `2`s), `search_service`, and `autocomplete` endpoint overrides. PyPI supports a multi-upstream list `pypi.proxies` (`NORA_PYPI_PROXIES`, takes precedence over `proxy`).
+
+### GC & curation
+
+| TOML | Env | Default | Description |
+|------|-----|---------|-------------|
+| `gc.grace_secs` | `NORA_GC_GRACE` | `604800` (7d) | Minimum orphan age before GC deletes it — protects in-flight push blobs |
+| `curation.quarantine` | `NORA_CURATION_QUARANTINE` | *(off)* | Digest first-seen quarantine: `off` \| `observe` \| `enforce` |
+| `curation.quarantine_ttl` | `NORA_CURATION_QUARANTINE_TTL` | *(none)* | Quarantine hold duration (e.g. `14d`) |
+| `curation.<reg>.min_release_age` | `NORA_CURATION_<REG>_MIN_RELEASE_AGE` | *(none)* | Per-registry override — available for **all** registries (npm, pypi, cargo, go, docker, maven, gems, terraform, ansible, nuget, pub, conan) |
+| `curation.<reg>.quarantine` / `.quarantine_ttl` | `NORA_CURATION_<REG>_QUARANTINE[_TTL]` | *(none)* | Per-registry quarantine override |
+
+:::note[0.9.x defaults to know]
+`server.trust_upstream_dates` defaults to `false` (freshly cached packages are quarantined for the full `min_release_age` window even if published long ago — set `true` to trust upstream dates). `auth.docker_anon_pull` (default `false`) is now separate from `anonymous_read` — anonymous `docker pull` must be opted into explicitly.
+:::
 
 ---
 

--- a/docs-site/src/content/docs/observability/prometheus-metrics.md
+++ b/docs-site/src/content/docs/observability/prometheus-metrics.md
@@ -100,6 +100,58 @@ nora_circuit_breaker_state == 1
 increase(nora_gc_bytes_freed_total[1h])
 ```
 
+## Additional metrics
+
+Every metric below is exposed at `/metrics`. Metrics carrying a `registry` label use the same path-prefix → registry mapping described above.
+
+### Curation & quarantine
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_curation_decisions_total` | counter | `decision` | Curation decisions by outcome (`allow`, `block`, `audit`, `skip`) |
+| `nora_quarantine_holds_total` | counter | `registry`, `outcome` | Proxy artifacts held by the digest quarantine (`outcome`: `blocked`, `observed`) |
+
+### Proxy — revalidation & coalescing
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_proxy_upstream_304_total` | counter | `registry` | Upstream `304 Not Modified` on revalidation (cached body reused) |
+| `nora_proxy_revalidation_bytes_saved_total` | counter | `registry` | Body bytes not re-downloaded thanks to a 304 |
+| `nora_proxy_revalidation_errors_total` | counter | `registry` | Revalidations that fell back to a full fetch (nonzero = degrading) |
+| `nora_proxy_coalesced_total` | counter | `registry` | Followers served from the single-flight leader without an upstream fetch |
+| `nora_proxy_inflight` | gauge | `registry` | Distinct keys currently fetched under single-flight (monotonic climb = guard leak) |
+| `nora_proxy_coalesce_fallthrough_total` | counter | `registry`, `reason` | Followers that fetched on their own (`reason`: `leader`, `budget`) |
+| `nora_proxy_active_downloads` | gauge | — | Docker blob proxy downloads currently in progress |
+| `nora_proxy_download_bytes_total` | counter | — | Total bytes downloaded from upstream Docker registries (use `rate()` for bandwidth) |
+| `nora_upstream_request_duration_seconds` | histogram | `registry`, `status` | Upstream proxy request latency (buckets 1ms–30s) |
+
+### Storage & integrity
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_storage_bytes` | gauge | `registry` | Stored bytes per registry; the special value `registry="total"` is the full footprint incl. metadata |
+| `nora_storage_verify_duration_seconds` | histogram | `registry` | SHA-256 integrity-verify wall-clock per buffered get (incl. blocking-pool queue) |
+| `nora_storage_get_bytes` | histogram | `registry` | Body size of buffered `Storage::get()` reads (buckets 1KB–512MB) |
+| `nora_cache_write_errors_total` | counter | `registry`, `operation` | Cache write failures in background cache tasks |
+| `nora_metadata_corrupt_total` | counter | `registry` | Corrupt metadata detected during publish (parse failure on existing data) |
+| `nora_gc_stat_failures_total` | counter | — | Orphans GC could not stat (kept, age unknown) — **alert on nonzero** |
+
+### Downloads, uploads & process
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_downloads_total` | counter | `registry` | Total artifact downloads |
+| `nora_uploads_total` | counter | `registry` | Total artifact uploads |
+| `nora_uptime_seconds` | gauge | — | Process uptime in seconds |
+
+### Auth & security
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `nora_auth_namespace_scope_total` | counter | `provider`, `decision` | OIDC `namespace_scope` enforcement (`decision`: `allow`, `deny`, `would_deny`) |
+| `nora_response_upstream_url_leak_total` | counter | `registry` | Upstream hostname detected in an outgoing response body (detection only, never blocks) |
+| `nora_leak_detection_skipped_total` | counter | `reason` | Leak scans skipped (`reason`: `own_surface`, `too_large`, `unknown_size`, `body_read_error`, `gzip_truncated`) |
+
 ## Scrape configuration
 
 ```yaml

--- a/docs-site/src/content/docs/registries/cargo.md
+++ b/docs-site/src/content/docs/registries/cargo.md
@@ -1,0 +1,104 @@
+---
+title: Cargo
+description: Cargo registry — sparse index (RFC 2789) proxy and host.
+---
+
+The Cargo registry implements the sparse index protocol (RFC 2789) as both a transparent proxy for crates.io and a private host for internal crates. Index entries and `.crate` tarballs are cached on first access.
+
+## Client Configuration
+
+Add NORA as a named registry in `.cargo/config.toml`:
+
+```toml
+[registries.nora]
+index = "sparse+http://nora.example.com:4000/cargo/index/"
+```
+
+To replace crates.io transparently:
+
+```toml
+[source.crates-io]
+replace-with = "nora"
+
+[source.nora]
+registry = "sparse+http://nora.example.com:4000/cargo/index/"
+```
+
+Publish to NORA with credentials in `~/.cargo/credentials.toml`:
+
+```toml
+[registries.nora]
+token = "your-api-token"
+```
+
+Then:
+
+```bash
+cargo publish --registry nora
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to crates.io (`https://crates.io`). To use an alternate upstream:
+
+```bash
+export NORA_CARGO_PROXY=https://crates-mirror.internal.example.com
+export NORA_CARGO_PROXY_AUTH=user:password
+```
+
+NORA rewrites the `dl` field in the sparse index config (`/cargo/index/config.json`) to point all `.crate` downloads through itself.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Sparse index proxy | Full | RFC 2789; prefix layout `1/` `2/` `3/ab/` `ab/cd/` |
+| Index config | Full | `config.json` with rewritten `dl` URL |
+| Crate download | Full | Immutable cache |
+| Crate metadata | Full | `/api/v1/crates/{name}` |
+| Cargo publish | Full | `PUT /cargo/api/v1/crates/new` |
+| Yank / unyank | -- | Not supported |
+| Owner management | -- | Not supported |
+| Search | -- | Categories and keywords stored but not searchable via API |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_CARGO_ENABLED` | Enable Cargo registry | `true` |
+| `NORA_CARGO_PROXY` | Upstream registry URL | `https://crates.io` |
+| `NORA_CARGO_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_CARGO_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_CARGO_METADATA_TTL` | Index entry cache TTL in seconds | `300` |
+
+**config.toml:**
+
+```toml
+[cargo]
+enabled = true
+proxy = "https://crates.io"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+metadata_ttl = 300
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/cargo/index/config.json` | GET | Sparse index config (rewritten `dl` URL) |
+| `/cargo/index/{*path}` | GET | Index entry (prefix layout: `1/`, `2/`, `3/ab/`, `ab/cd/`) |
+| `/cargo/api/v1/crates/{name}` | GET | Crate metadata |
+| `/cargo/api/v1/crates/{name}/{ver}/download` | GET | Download `.crate` tarball |
+| `/cargo/api/v1/crates/new` | PUT | Publish a crate (`cargo publish`) |
+
+## Caching Behavior
+
+- **Index entries**: cached for `NORA_CARGO_METADATA_TTL` seconds (default 300). On expiry, NORA revalidates with the upstream using `If-None-Match` / `ETag` per the sparse index protocol.
+- **`.crate` tarballs**: cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+
+## Known Limitations
+
+- Yank and unyank are not supported; published crate versions are immutable in NORA's storage.
+- Owner management (`cargo owner`) is not implemented.
+- Categories and keywords are stored in crate metadata but are not exposed via a search API.

--- a/docs-site/src/content/docs/registries/conan.md
+++ b/docs-site/src/content/docs/registries/conan.md
@@ -1,0 +1,103 @@
+---
+title: Conan
+description: Caching proxy for the Conan v2 API (C/C++).
+---
+
+The Conan registry provides a transparent caching proxy for [center2.conan.io](https://center2.conan.io). Recipe and package revision metadata is TTL-cached, and recipe/package file downloads are immutably cached on first fetch.
+
+## Client Configuration
+
+Register NORA as a Conan remote:
+
+```bash
+conan remote add nora http://nora.example.com:4000/conan
+```
+
+Install a package through the NORA remote:
+
+```bash
+conan install boost/1.86.0@ -r nora
+```
+
+To make NORA the default remote for all installs, place it first in the remote list:
+
+```bash
+conan remote add nora http://nora.example.com:4000/conan --index 0
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to ConanCenter (`https://center2.conan.io`). To use a private Conan server (Artifactory, conan_server):
+
+```bash
+export NORA_CONAN_PROXY=https://conan.internal.example.com
+export NORA_CONAN_PROXY_AUTH=user:password
+```
+
+NORA does not rewrite URLs embedded in recipe files; clients communicate directly with NORA for all revision, file list, and download endpoints.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Server capabilities ping | Full | Returns `revisions` capability |
+| Recipe search | Full | Proxied from upstream |
+| Recipe revision listing | Full | TTL-cached |
+| Recipe file listing | Full | TTL-cached |
+| Recipe file download | Full | Immutable cache on first download |
+| Package revision listing | Full | TTL-cached |
+| Package file listing | Full | TTL-cached |
+| Package file download | Full | Immutable cache on first download |
+| Recipe/package upload | -- | Proxy-only (read) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_CONAN_ENABLED` | Enable Conan registry | `false` |
+| `NORA_CONAN_PROXY` | Upstream Conan server URL | `https://center2.conan.io` |
+| `NORA_CONAN_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_CONAN_PROXY_TIMEOUT` | Proxy timeout in seconds (metadata) | `30` |
+| `NORA_CONAN_PROXY_TIMEOUT_DL` | Proxy timeout in seconds (file download) | `120` |
+| `NORA_CONAN_METADATA_TTL` | Metadata cache TTL in seconds | `300` |
+| `NORA_CONAN_REVALIDATE` | Revalidate stale metadata in the background | `true` |
+| `NORA_CONAN_SERVE_STALE` | Serve cached metadata when upstream is unreachable | `true` |
+
+**config.toml:**
+
+```toml
+[conan]
+enabled = true
+proxy = "https://center2.conan.io"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+proxy_timeout_dl = 120
+metadata_ttl = 300
+revalidate = true
+serve_stale = true
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/conan/v2/ping` | GET | Server health; returns `X-Conan-Server-Capabilities: revisions` |
+| `/conan/v2/conans/search` | GET | Search recipes by name pattern |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/latest` | GET | Latest recipe revision (TTL-cached) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions` | GET | All recipe revisions (TTL-cached) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rev}/files` | GET | Recipe file list (TTL-cached) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/revisions/{rev}/files/{*file}` | GET | Recipe file download (immutable cache) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/packages/{pkg}/revisions/latest` | GET | Latest package revision (TTL-cached) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/packages/{pkg}/revisions` | GET | All package revisions (TTL-cached) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/packages/{pkg}/revisions/{rev}/files` | GET | Package file list (TTL-cached) |
+| `/conan/v2/conans/{name}/{ver}/{user}/{chan}/packages/{pkg}/revisions/{rev}/files/{*file}` | GET | Package file download (immutable cache) |
+
+## Caching Behavior
+
+- **Metadata** (revision lists, latest revision, file lists): TTL-cached for `NORA_CONAN_METADATA_TTL` seconds (default 300) with background revalidation when `NORA_CONAN_REVALIDATE=true`. Stale entries are served when upstream is unreachable and `NORA_CONAN_SERVE_STALE=true`.
+- **Recipe and package files**: cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+
+## Known Limitations
+
+- Proxy-only: recipe and package upload is not supported. Use `conan upload` directly against ConanCenter or a private Conan server.
+- Anonymous read only: Conan v2 authentication (token-based login via `conan remote login`) is not implemented. Upstreams that require authentication are not supported.

--- a/docs-site/src/content/docs/registries/docker.md
+++ b/docs-site/src/content/docs/registries/docker.md
@@ -1,0 +1,106 @@
+---
+title: Docker
+description: OCI Distribution Spec registry — proxy and host.
+---
+
+The Docker registry implements [OCI Distribution Spec 1.1](https://github.com/opencontainers/distribution-spec) as a proxy and host, mounted at `/v2/`.
+
+## Client Configuration
+
+Pull a public image through NORA without authentication:
+
+```bash
+docker pull nora.example.com:4000/library/nginx:latest
+```
+
+To push or pull private images, authenticate first:
+
+```bash
+docker login nora.example.com:4000
+docker pull nora.example.com:4000/myorg/image:tag
+docker push nora.example.com:4000/myorg/image:tag
+```
+
+## Upstream Proxy
+
+By default, NORA proxies pull requests to Docker Hub (`https://registry-1.docker.io`). Additional upstreams can be added in `config.toml`; NORA tries each in declaration order and returns the first successful response.
+
+```bash
+export NORA_DOCKER_UPSTREAMS=https://registry-1.docker.io
+```
+
+Upstream authentication is configured per-upstream in `config.toml` via the `auth` field.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| API version check (`/v2/`) | Full | |
+| Repository listing (`/v2/_catalog`) | Full | |
+| Image pull (proxy) | Full | Multi-upstream fallback |
+| Image push (host) | Full | |
+| Manifest get / put / delete | Full | By tag or digest |
+| Blob (layer) pull / delete | Full | Content-addressable |
+| Blob upload session | Full | POST → PATCH → PUT |
+| Content-addressable dedup | Full | Same digest stored once across all images |
+| OCI 1.1 Referrers API | -- | Not implemented |
+| Cross-repo blob mount | -- | Not implemented |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_DOCKER_ENABLED` | Enable Docker registry | `true` |
+| `NORA_DOCKER_UPSTREAMS` | Comma-separated upstream URLs (TOML: `[[docker.upstreams]]`) | `https://registry-1.docker.io` |
+| `NORA_DOCKER_PROXY_TIMEOUT` | Upstream proxy timeout in seconds | `300` |
+| `NORA_DOCKER_READ_TIMEOUT` | Upstream read timeout in seconds | `60` |
+| `NORA_DOCKER_METADATA_TTL` | Manifest cache TTL in seconds (`-1` = cache forever) | `-1` |
+| `NORA_DOCKER_SERVE_STALE` | Serve cached manifests when upstream is unreachable | `true` |
+| `NORA_DOCKER_DEFAULT_ACTION` | Action when no upstream prefix matches (`allow`\|`deny`) | `allow` |
+| `NORA_AUTH_DOCKER_ANON_PULL` | Allow anonymous pulls (separate from `anonymous_read`; set in `[auth]`) | `false` |
+
+**config.toml:**
+
+```toml
+[docker]
+enabled = true
+proxy_timeout = 300
+read_timeout = 60
+metadata_ttl = -1
+serve_stale = true
+default_action = "allow"
+
+[[docker.upstreams]]
+url = "https://registry-1.docker.io"
+# auth = "user:password"
+# prefix = "library"
+# namespace = "library"
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/v2/` | GET | API version check |
+| `/v2/_catalog` | GET | List repositories |
+| `/v2/{name}/tags/list` | GET | List tags for image |
+| `/v2/{name}/manifests/{ref}` | GET, HEAD | Pull manifest by tag or digest |
+| `/v2/{name}/manifests/{ref}` | PUT | Push manifest |
+| `/v2/{name}/manifests/{ref}` | DELETE | Delete manifest |
+| `/v2/{name}/blobs/{digest}` | GET, HEAD | Pull blob (layer) |
+| `/v2/{name}/blobs/{digest}` | DELETE | Delete blob |
+| `/v2/{name}/blobs/uploads/` | POST | Start blob upload session |
+| `/v2/{name}/blobs/uploads/{uuid}` | PATCH | Append chunk to upload |
+| `/v2/{name}/blobs/uploads/{uuid}` | PUT | Complete blob upload |
+
+## Caching Behavior
+
+- **Manifests**: cached by reference (tag or digest) with TTL set by `metadata_ttl`. The default `-1` means manifests are cached indefinitely. When `serve_stale = true`, a cached manifest is returned even if the upstream is unreachable.
+- **Blobs (layers)**: stored permanently by content digest (`sha256:…`). Once a blob is cached it is never re-fetched from upstream. The same blob shared across multiple images is stored only once.
+
+## Known Limitations
+
+- Image names are limited to two path segments (`org/image`). Three or more segments (e.g., `org/sub/path/image`) are not routed and return 404.
+- Cross-repository blob mounting (`POST /v2/{name}/blobs/uploads/?mount={digest}&from={source}`) is not supported; the Docker client falls back to a standard upload session automatically.
+- The OCI Distribution Spec 1.1 Referrers API (`GET /v2/{name}/referrers/{digest}`) is not implemented.
+- Docker daemon mirror-auth bug ([moby/moby#30880](https://github.com/moby/moby/issues/30880), [#42022](https://github.com/moby/moby/issues/42022)): an authenticated mirror pull can fail because Docker sends wrong credentials to the mirror. Workaround: set `docker_anon_pull = true` under `[auth]` in `config.toml` to allow unauthenticated mirror pulls.

--- a/docs-site/src/content/docs/registries/go.md
+++ b/docs-site/src/content/docs/registries/go.md
@@ -1,0 +1,99 @@
+---
+title: Go Modules
+description: Go module proxy (GOPROXY protocol).
+---
+
+The Go Modules registry provides a transparent caching proxy for Go modules using the [GOPROXY protocol](https://go.dev/ref/mod#module-proxy). Module metadata and zip archives are fetched from an upstream proxy on first request and served from local storage on subsequent requests.
+
+## Client Configuration
+
+Point `GOPROXY` at NORA before the fallback:
+
+```bash
+export GOPROXY=http://nora.example.com:4000/go/,direct
+go get github.com/your/module@v1.2.3
+```
+
+To make the setting permanent, add it to your shell profile or `~/.config/go/env`:
+
+```bash
+go env -w GOPROXY=http://nora.example.com:4000/go/,direct
+```
+
+In a CI environment (e.g. GitLab CI):
+
+```yaml
+variables:
+  GOPROXY: "http://nora.example.com:4000/go/,direct"
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to the public Go module proxy (`https://proxy.golang.org`). To use a private or alternative proxy:
+
+```bash
+export NORA_GO_PROXY=https://goproxy.internal.example.com
+export NORA_GO_PROXY_AUTH=user:password
+```
+
+Module path escaping follows the GOPROXY spec: capital letters in import paths are encoded as `!x` (lowercase), for example `github.com/Azure/azure-sdk-go` is stored under `github.com/!azure/azure-sdk-go`.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Version list | Full | `/@v/list` |
+| Version metadata | Full | `/@v/{ver}.info` |
+| go.mod fetch | Full | `/@v/{ver}.mod` |
+| Module zip download | Full | Immutable cache |
+| Latest version query | Full | `/@latest` |
+| Module upload | -- | Proxy-only (read) |
+| Sum database | -- | Client-side (`GONOSUMDB`) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_GO_ENABLED` | Enable Go Modules registry | `true` |
+| `NORA_GO_PROXY` | Upstream Go proxy URL | `https://proxy.golang.org` |
+| `NORA_GO_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_GO_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_GO_PROXY_TIMEOUT_ZIP` | Timeout for zip downloads in seconds | `120` |
+| `NORA_GO_METADATA_TTL` | TTL in seconds for `@v/list` and `@latest` | `300` |
+| `NORA_GO_MAX_ZIP_SIZE` | Maximum module zip size in bytes | `104857600` |
+
+**config.toml:**
+
+```toml
+[go]
+enabled = true
+proxy = "https://proxy.golang.org"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+proxy_timeout_zip = 120
+metadata_ttl = 300
+max_zip_size = 104857600
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/go/{module}/@v/list` | GET | List known versions for module |
+| `/go/{module}/@v/{ver}.info` | GET | Version metadata (JSON) |
+| `/go/{module}/@v/{ver}.mod` | GET | `go.mod` file for version |
+| `/go/{module}/@v/{ver}.zip` | GET | Module zip archive |
+| `/go/{module}/@latest` | GET | Latest version metadata (JSON) |
+
+Module paths use GOPROXY capital-letter escaping: a capital letter `X` in the import path is encoded as `!x` in the URL path segment.
+
+## Caching Behavior
+
+- **Immutable** (`.info`, `.mod`, `.zip`): written once on first fetch and served from local storage on all subsequent requests. The upstream is never contacted again for the same version.
+- **Mutable** (`@v/list`, `@latest`): cached with a TTL controlled by `NORA_GO_METADATA_TTL` (default 300 seconds). After the TTL expires the upstream is queried again.
+
+## Known Limitations
+
+- Proxy-only: `go mod upload` or any write operation is not supported.
+- `GONOSUMDB` and `GONOSUMCHECK` are client-side settings; NORA does not interact with the Go checksum database.
+- Module zips larger than `NORA_GO_MAX_ZIP_SIZE` are not cached and are streamed directly from upstream.

--- a/docs-site/src/content/docs/registries/maven.md
+++ b/docs-site/src/content/docs/registries/maven.md
@@ -1,0 +1,100 @@
+---
+title: Maven
+description: Maven repository — proxy (multi-upstream) and host.
+---
+
+The Maven registry provides a proxy with multi-upstream fallback and hosted storage, mounted at `/maven2/`.
+
+## Client Configuration
+
+Add NORA as a mirror in `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <mirrors>
+    <mirror>
+      <id>nora</id>
+      <name>NORA Maven Proxy</name>
+      <url>http://nora.example.com:4000/maven2/</url>
+      <mirrorOf>central</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>
+```
+
+To publish artifacts, add a `<distributionManagement>` section in your `pom.xml`:
+
+```xml
+<distributionManagement>
+  <repository>
+    <id>nora</id>
+    <url>http://nora.example.com:4000/maven2/</url>
+  </repository>
+</distributionManagement>
+```
+
+## Upstream Proxy
+
+NORA proxies to Maven Central by default. Multiple upstreams can be configured in `config.toml`; NORA tries each in declaration order and returns the first successful response.
+
+```bash
+export NORA_MAVEN_PROXIES=https://repo1.maven.org/maven2/
+```
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Artifact download (GET) | Full | JARs, POMs, WARs, ZIPs |
+| Checksum download (.md5 / .sha1 / .sha256) | Full | |
+| Artifact upload (PUT) | Full | Auto-checksum generated on upload |
+| maven-metadata.xml update on upload | Full | |
+| Multi-upstream fallback | Full | First upstream to respond wins |
+| Checksum verification | Full | Controlled by `checksum_verify` |
+| Release immutability | Full | Re-upload returns 409 when `immutable_releases = true` |
+| SNAPSHOT version management | -- | Latest timestamp returned; per-snapshot metadata not generated |
+| maven-metadata.xml auto-generate on publish | -- | Upload the file explicitly |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_MAVEN_ENABLED` | Enable Maven registry | `true` |
+| `NORA_MAVEN_PROXIES` | Comma-separated upstream URLs (TOML: `[[maven.proxies]]`) | `https://repo1.maven.org/maven2/` |
+| `NORA_MAVEN_PROXY_TIMEOUT` | Upstream proxy timeout in seconds | `30` |
+| `NORA_MAVEN_METADATA_TTL` | TTL for `maven-metadata.xml` and SNAPSHOT metadata in seconds | `300` |
+| `NORA_MAVEN_CHECKSUM_VERIFY` | Verify artifact checksums against upstream | `true` |
+| `NORA_MAVEN_IMMUTABLE_RELEASES` | Reject re-upload of release versions | `true` |
+
+**config.toml:**
+
+```toml
+[maven]
+enabled = true
+proxy_timeout = 30
+metadata_ttl = 300
+checksum_verify = true
+immutable_releases = true
+
+[[maven.proxies]]
+url = "https://repo1.maven.org/maven2/"
+# auth = "user:password"
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/maven2/{*path}` | GET | Download artifact, checksum, or metadata |
+| `/maven2/{*path}` | HEAD | Check artifact existence |
+| `/maven2/{*path}` | PUT | Upload artifact (auto-checksum + maven-metadata update) |
+
+## Caching Behavior
+
+- **Release artifacts** (JARs, POMs, WARs): cached on first download and served from local storage on subsequent requests. Immutable release files are never re-fetched from upstream.
+- **maven-metadata.xml and SNAPSHOT metadata**: TTL-based cache controlled by `metadata_ttl` (default 300 seconds). Re-fetched from upstream after expiry.
+
+## Known Limitations
+
+- `maven-metadata.xml` is not auto-generated when publishing artifacts directly to NORA. Upload the metadata file explicitly alongside the artifact.
+- No SNAPSHOT version management: `-SNAPSHOT` paths resolve to the latest uploaded timestamp, but NORA does not generate or merge per-snapshot metadata files.

--- a/docs-site/src/content/docs/registries/npm.md
+++ b/docs-site/src/content/docs/registries/npm.md
@@ -1,0 +1,97 @@
+---
+title: npm
+description: npm registry — proxy, host, and npm audit.
+---
+
+The npm registry provides a transparent proxy and private host for npm packages. Metadata and tarballs are cached on first download; package versions are immutable once published.
+
+## Client Configuration
+
+Point the npm client at NORA globally:
+
+```bash
+npm config set registry http://nora.example.com:4000/npm/
+```
+
+Or per-project via `.npmrc`:
+
+```ini
+registry=http://nora.example.com:4000/npm/
+```
+
+For scoped packages:
+
+```ini
+@myorg:registry=http://nora.example.com:4000/npm/
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to the public npm registry (`https://registry.npmjs.org`). To use a private or self-hosted registry:
+
+```bash
+export NORA_NPM_PROXY=https://npm.internal.example.com
+export NORA_NPM_PROXY_AUTH=user:password
+```
+
+NORA rewrites `dist.tarball` URLs in metadata responses to point through itself, so tarballs are always fetched through the proxy.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Metadata proxy | Full | `GET /npm/{*path}` |
+| Tarball proxy | Full | Immutable cache, served on first download |
+| Package publish | Full | `PUT /npm/{*path}` (`npm publish`); versions are immutable |
+| npm audit (npm7) | Full | `POST /-/npm/v1/security/advisories/bulk` forwarded upstream |
+| npm audit (npm6) | Full | `POST /-/npm/v1/security/audits/quick` forwarded upstream |
+| Other POSTs | -- | 405 Method Not Allowed |
+| Search | -- | `/-/v1/search` not supported |
+| Unpublish | -- | Immutable; use quarantine/blocklist to disable a version |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_NPM_ENABLED` | Enable npm registry | `true` |
+| `NORA_NPM_PROXY` | Upstream registry URL | `https://registry.npmjs.org` |
+| `NORA_NPM_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_NPM_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_NPM_METADATA_TTL` | Metadata cache TTL in seconds | `300` |
+| `NORA_NPM_REVALIDATE` | Revalidate cached metadata on TTL expiry | `true` |
+| `NORA_NPM_SERVE_STALE` | Serve stale metadata if upstream is unreachable | `true` |
+
+**config.toml:**
+
+```toml
+[npm]
+enabled = true
+proxy = "https://registry.npmjs.org"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+metadata_ttl = 300
+revalidate = true
+serve_stale = true
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/npm/{*path}` | GET | Package metadata and tarball download |
+| `/npm/{*path}` | PUT | Publish a package (`npm publish`) |
+| `/npm/-/npm/v1/security/advisories/bulk` | POST | npm7 audit (forwarded to upstream) |
+| `/npm/-/npm/v1/security/audits/quick` | POST | npm6 audit (forwarded to upstream) |
+| `/npm/{*path}` (other POST) | POST | 405 Method Not Allowed |
+
+## Caching Behavior
+
+- **Metadata** (package manifests): cached for `NORA_NPM_METADATA_TTL` seconds (default 300). On expiry, NORA revalidates with the upstream using `If-None-Match` / `ETag`. If upstream is unreachable and `NORA_NPM_SERVE_STALE=true`, the last known metadata is returned.
+- **Tarballs**: cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+
+## Known Limitations
+
+- `npm unpublish` is not supported; published versions are immutable. To disable a version, add it to the quarantine or blocklist.
+- Dist-tag management (`npm dist-tag add/rm/ls`) is not supported.
+- Search (`/-/v1/search`) is not implemented; queries return 404.
+- npm audit is proxied to the upstream advisory database; there is no local advisory DB. Audit results are only available for packages reachable via the upstream registry.

--- a/docs-site/src/content/docs/registries/nuget.md
+++ b/docs-site/src/content/docs/registries/nuget.md
@@ -1,0 +1,120 @@
+---
+title: NuGet
+description: Caching proxy for the NuGet v3 API (also serves Chocolatey and PowerShell Gallery clients).
+---
+
+The NuGet registry provides a transparent caching proxy for [api.nuget.org](https://api.nuget.org). Service index URLs are rewritten to point through NORA, registration and version-list metadata is TTL-cached, and `.nupkg` / `.nuspec` files are immutably cached on first download. Chocolatey and PowerShell Gallery clients are supported via path aliases.
+
+## Client Configuration
+
+Add the NORA source with the .NET CLI:
+
+```bash
+dotnet nuget add source http://nora.example.com:4000/nuget/v3/index.json -n nora
+```
+
+Reference the source in a project's `NuGet.Config`:
+
+```xml
+<configuration>
+  <packageSources>
+    <add key="nora" value="http://nora.example.com:4000/nuget/v3/index.json" />
+  </packageSources>
+</configuration>
+```
+
+For Chocolatey clients:
+
+```bash
+choco source add -n nora -s http://nora.example.com:4000/chocolatey/v3/index.json
+```
+
+For PowerShell Gallery clients, use the `/pwsh/` alias:
+
+```powershell
+Register-PSRepository -Name nora `
+  -SourceLocation http://nora.example.com:4000/pwsh/v3/index.json `
+  -InstallationPolicy Trusted
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to the public NuGet API (`https://api.nuget.org`). To use a private feed (Azure Artifacts, Nexus, GitHub Packages):
+
+```bash
+export NORA_NUGET_PROXY=https://pkgs.dev.azure.com/myorg/_packaging/myfeed/nuget/v3/index.json
+export NORA_NUGET_PROXY_AUTH=user:personalAccessToken
+```
+
+NORA rewrites all `@id` URLs in the service index response and in registration pages to route through itself, so clients always download through the proxy. When proxying a non-default feed, NORA auto-discovers the search and autocomplete service URLs from the upstream service index.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Service index | Full | `@id` URLs rewritten through NORA |
+| Package search | Full | Delegated to upstream search service |
+| Autocomplete | Full | Delegated to upstream autocomplete service |
+| Registration (metadata) | Full | TTL-cached with stale-while-revalidate |
+| Flat container (version list) | Full | TTL-cached |
+| `.nupkg` download | Full | Immutable cache on first download |
+| `.nuspec` download | Full | Immutable cache on first download |
+| Chocolatey clients | Full | `/chocolatey/` alias |
+| PowerShell Gallery clients | Full | `/pwsh/` alias |
+| Package push | -- | Proxy-only (read) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_NUGET_ENABLED` | Enable NuGet registry | `false` |
+| `NORA_NUGET_PROXY` | Upstream feed URL | `https://api.nuget.org` |
+| `NORA_NUGET_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_NUGET_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_NUGET_METADATA_TIMEOUT` | Fast timeout for registration and version-list requests | `2` |
+| `NORA_NUGET_METADATA_TTL` | Metadata cache TTL in seconds | `300` |
+| `NORA_NUGET_REVALIDATE` | Revalidate stale metadata in the background | `true` |
+| `NORA_NUGET_SERVE_STALE` | Serve cached metadata when upstream is unreachable | `true` |
+| `NORA_NUGET_SEARCH_SERVICE` | Override upstream search endpoint | `https://azuresearch-usnc.nuget.org/query` |
+| `NORA_NUGET_AUTOCOMPLETE` | Override upstream autocomplete endpoint | `https://azuresearch-usnc.nuget.org/autocomplete` |
+
+**config.toml:**
+
+```toml
+[nuget]
+enabled = true
+proxy = "https://api.nuget.org"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+metadata_timeout = 2
+metadata_ttl = 300
+revalidate = true
+serve_stale = true
+# search_service = "https://azuresearch-usnc.nuget.org/query"
+# autocomplete = "https://azuresearch-usnc.nuget.org/autocomplete"
+```
+
+## Endpoints
+
+All routes are also available under the `/chocolatey/` and `/pwsh/` path aliases.
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/nuget/v3/index.json` | GET | Service index (`@id` URLs rewritten through NORA) |
+| `/nuget/v3/query` | GET | Package search (proxied to upstream search service) |
+| `/nuget/v3/autocomplete` | GET | Package ID autocomplete (proxied to upstream) |
+| `/nuget/v3/registration/{id}/index.json` | GET | Registration leaf index (TTL-cached) |
+| `/nuget/v3/registration/{id}/page/{lower}/{*upper}` | GET | Registration page (TTL-cached) |
+| `/nuget/v3/flatcontainer/{*path}` | GET | Version list, `.nupkg`, and `.nuspec` (immutable files cached on first download) |
+
+## Caching Behavior
+
+- **Metadata** (service index, registration, version lists): TTL-cached for `NORA_NUGET_METADATA_TTL` seconds (default 300) with a fast upstream timeout of `NORA_NUGET_METADATA_TIMEOUT` seconds (default 2). Background revalidation runs when `NORA_NUGET_REVALIDATE=true`. Stale entries are served when upstream is unreachable and `NORA_NUGET_SERVE_STALE=true`.
+- **Package files** (`.nupkg`, `.nuspec`): cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+- **Search and autocomplete**: not stored locally; every request is proxied live to the configured search service.
+
+## Known Limitations
+
+- Proxy-only: package push (`dotnet nuget push`) is not supported. Use the push command directly against NuGet.org or your private feed.
+- Search and autocomplete results are delegated to the upstream search service and are not stored locally. If the upstream search service is unreachable, search requests return 502.
+- When proxying a non-default feed, NORA discovers the search and autocomplete endpoints from the upstream service index. Feeds that do not advertise these resources in their service index will have search and autocomplete unavailable.

--- a/docs-site/src/content/docs/registries/pub.md
+++ b/docs-site/src/content/docs/registries/pub.md
@@ -1,0 +1,89 @@
+---
+title: Pub (Dart/Flutter)
+description: Caching proxy for pub.dev (hosted repository spec v2).
+---
+
+The Pub registry provides a transparent caching proxy for [pub.dev](https://pub.dev) using the [hosted repository spec v2](https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md). Package metadata is TTL-cached; package archives are immutably cached on first download with SHA-256 integrity verification.
+
+## Client Configuration
+
+Set `PUB_HOSTED_URL` before running Dart or Flutter package commands:
+
+```bash
+export PUB_HOSTED_URL=http://nora.example.com:4000/pub
+dart pub get
+```
+
+```bash
+export PUB_HOSTED_URL=http://nora.example.com:4000/pub
+flutter pub get
+```
+
+To make the setting permanent, add it to your shell profile or CI environment variables. For Flutter projects, you can also set it in `pubspec.yaml` if using a workspace configuration that supports environment variable substitution.
+
+## Upstream Proxy
+
+By default, NORA proxies to the public Dart package repository (`https://pub.dev`). To use a private or self-hosted Pub server:
+
+```bash
+export NORA_PUB_PROXY=https://pub.internal.example.com
+export NORA_PUB_PROXY_AUTH=user:password
+```
+
+NORA implements the hosted repository spec v2 API, so all standard `dart pub` and `flutter pub` commands work without client-side changes beyond setting `PUB_HOSTED_URL`.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Package search | Full | `?q=` and `?page=` |
+| Package metadata | Full | All versions, TTL-cached |
+| Version detail | Full | TTL-cached |
+| Security advisories | Full | TTL-cached |
+| Archive download | Full | Immutable cache, SHA-256 verified |
+| Package publish | -- | Proxy-only (read) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_PUB_ENABLED` | Enable Pub registry | `false` |
+| `NORA_PUB_PROXY` | Upstream Pub server URL | `https://pub.dev` |
+| `NORA_PUB_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_PUB_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_PUB_METADATA_TTL` | TTL in seconds for metadata responses | `300` |
+| `NORA_PUB_REVALIDATE` | Revalidate stale metadata against upstream | `true` |
+| `NORA_PUB_SERVE_STALE` | Serve stale cached metadata when upstream is unreachable | `true` |
+
+**config.toml:**
+
+```toml
+[pub]
+enabled = false
+proxy = "https://pub.dev"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+metadata_ttl = 300
+revalidate = true
+serve_stale = true
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/pub/api/packages` | GET | Search packages (`?q=`, `?page=`) |
+| `/pub/api/packages/{package}` | GET | Package metadata and version list, TTL-cached |
+| `/pub/api/packages/{package}/versions/{version}` | GET | Single version detail, TTL-cached |
+| `/pub/api/packages/{package}/advisories` | GET | Security advisories for package, TTL-cached |
+| `/pub/packages/{package}/versions/{archive}` | GET | Package archive (`.tar.gz`), immutable, SHA-256 verified |
+
+## Caching Behavior
+
+- **Immutable** (package archives under `/pub/packages/`): written once on first download with SHA-256 integrity verification and served from local storage on all subsequent requests.
+- **TTL-cached** (all `/pub/api/` endpoints): refreshed after `NORA_PUB_METADATA_TTL` seconds (default 300). When `NORA_PUB_REVALIDATE` is `true`, NORA contacts upstream after TTL expiry. When upstream is unreachable and `NORA_PUB_SERVE_STALE` is `true`, the cached response is served rather than returning an error.
+
+## Known Limitations
+
+- Proxy-only: `dart pub publish` is not supported. Publish packages directly to pub.dev or your private Pub server.
+- No offline/air-gap mode for metadata: if the upstream is unreachable and no cached copy exists, requests return 502.

--- a/docs-site/src/content/docs/registries/pypi.md
+++ b/docs-site/src/content/docs/registries/pypi.md
@@ -1,0 +1,97 @@
+---
+title: PyPI
+description: PyPI registry — PEP 503/691 proxy and host.
+---
+
+The PyPI registry implements the Simple Repository API (PEP 503 HTML and PEP 691 JSON) as both a transparent proxy for pypi.org and a private host for internal packages. Wheels and source distributions are cached on first download.
+
+## Client Configuration
+
+Pass the NORA URL as `--index-url` to pip:
+
+```bash
+pip install --index-url http://nora.example.com:4000/simple/ requests
+```
+
+Or set it globally in `pip.conf` (Linux: `~/.config/pip/pip.conf`; macOS: `~/Library/Application Support/pip/pip.conf`):
+
+```ini
+[global]
+index-url = http://nora.example.com:4000/simple/
+```
+
+Upload packages with twine:
+
+```bash
+twine upload --repository-url http://nora.example.com:4000/simple/ dist/*
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to the public PyPI simple index (`https://pypi.org/simple/`). To use a private index or mirror:
+
+```bash
+export NORA_PYPI_PROXY=https://pypi.internal.example.com/simple/
+export NORA_PYPI_PROXY_AUTH=user:password
+```
+
+To proxy multiple upstreams, use `NORA_PYPI_PROXIES` (takes precedence over `NORA_PYPI_PROXY`). Each entry is `url` or `url|user:pass`, separated by commas; NORA queries them in order and returns the first successful response:
+
+```bash
+export NORA_PYPI_PROXIES="https://pypi.org/simple/,https://mirror.internal.example.com/simple/|user:pass"
+```
+
+NORA rewrites download URLs in index responses to point through itself.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Simple index (HTML, PEP 503) | Full | `GET /simple/` and `GET /simple/{name}/` |
+| Simple index (JSON, PEP 691) | Full | `Accept: application/vnd.pypi.simple.v1+json` |
+| File download | Full | Wheel, sdist, egg; immutable cache |
+| Package upload | Full | `POST /simple/` (twine multipart) |
+| Multi-upstream proxy | Full | `NORA_PYPI_PROXIES` comma-separated list |
+| Yank | -- | Not supported |
+| PGP upload signatures | -- | Not supported |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_PYPI_ENABLED` | Enable PyPI registry | `true` |
+| `NORA_PYPI_PROXY` | Upstream simple index URL | `https://pypi.org/simple/` |
+| `NORA_PYPI_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_PYPI_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_PYPI_PROXIES` | Multi-upstream list (`url\|auth`, comma-separated); takes precedence over `NORA_PYPI_PROXY` | *(none)* |
+
+**config.toml:**
+
+```toml
+[pypi]
+enabled = true
+proxy = "https://pypi.org/simple/"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+# proxies = "https://pypi.org/simple/,https://mirror.example.com/simple/|user:pass"
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/simple/` | GET | Root index (HTML PEP 503 or JSON PEP 691 via `Accept`) |
+| `/simple/` | POST | Upload a package (`twine upload`, multipart) |
+| `/simple/{name}/` | GET | Package versions page |
+| `/simple/{name}/{filename}` | GET | Download wheel, sdist, or egg |
+
+## Caching Behavior
+
+- **Index pages** (`/simple/` and `/simple/{name}/`): proxied on every request; index responses are not stored locally, so freshness is always fetched from upstream.
+- **Distribution files** (wheels, sdists, eggs): cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+
+## Known Limitations
+
+- Yanking packages or individual files is not supported.
+- PGP upload signatures are not accepted or stored.
+- With `NORA_PYPI_PROXIES`, NORA returns the first successful upstream response; results are not merged across upstreams.

--- a/docs-site/src/content/docs/registries/rubygems.md
+++ b/docs-site/src/content/docs/registries/rubygems.md
@@ -1,0 +1,95 @@
+---
+title: RubyGems
+description: Caching proxy for rubygems.org.
+---
+
+The RubyGems registry provides a transparent caching proxy for [rubygems.org](https://rubygems.org). Index files are cached with a configurable TTL; gem archives and gemspecs are immutably cached on first download.
+
+## Client Configuration
+
+Configure Bundler to mirror rubygems.org through NORA:
+
+```bash
+bundle config mirror.https://rubygems.org http://nora.example.com:4000/gems/
+```
+
+Or set the source directly in your `Gemfile`:
+
+```ruby
+source "http://nora.example.com:4000/gems/"
+```
+
+For `gem` CLI usage without Bundler:
+
+```bash
+gem install rails --source http://nora.example.com:4000/gems/
+```
+
+## Upstream Proxy
+
+By default, NORA proxies to the public RubyGems index (`https://rubygems.org`). To use a private or mirror source:
+
+```bash
+export NORA_GEMS_PROXY=https://gems.internal.example.com
+export NORA_GEMS_PROXY_AUTH=user:password
+```
+
+NORA serves all RubyGems Bundler v2 compact index endpoints as well as the legacy Marshal index, allowing both modern and older clients to resolve dependencies through the same mount point.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Full index | Full | `specs.4.8.gz`, TTL-cached |
+| Latest index | Full | `latest_specs.4.8.gz`, TTL-cached |
+| Prerelease index | Full | `prerelease_specs.4.8.gz`, TTL-cached |
+| Compact index | Full | `/info/{name}`, TTL-cached |
+| Gem download | Full | Immutable cache |
+| Gemspec fetch | Full | Immutable cache |
+| Gem push / publish | -- | Proxy-only (read) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_GEMS_ENABLED` | Enable RubyGems registry | `false` |
+| `NORA_GEMS_PROXY` | Upstream RubyGems server URL | `https://rubygems.org` |
+| `NORA_GEMS_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_GEMS_PROXY_TIMEOUT` | Proxy timeout in seconds | `30` |
+| `NORA_GEMS_METADATA_TTL` | TTL in seconds for index and compact index responses | `300` |
+| `NORA_GEMS_REVALIDATE` | Revalidate stale metadata against upstream | `true` |
+| `NORA_GEMS_SERVE_STALE` | Serve stale cached metadata when upstream is unreachable | `true` |
+
+**config.toml:**
+
+```toml
+[gems]
+enabled = false
+proxy = "https://rubygems.org"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+metadata_ttl = 300
+revalidate = true
+serve_stale = true
+```
+
+## Endpoints
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/gems/specs.4.8.gz` | GET | Full gem index (Marshal, gzipped), TTL-cached |
+| `/gems/latest_specs.4.8.gz` | GET | Latest-version index (Marshal, gzipped), TTL-cached |
+| `/gems/prerelease_specs.4.8.gz` | GET | Prerelease index (Marshal, gzipped), TTL-cached |
+| `/gems/info/{name}` | GET | Compact index for gem (Bundler v2), TTL-cached |
+| `/gems/gems/{filename}` | GET | Gem archive download (`.gem`), immutable |
+| `/gems/quick/Marshal.4.8/{filename}` | GET | Gemspec fetch (Marshal), immutable |
+
+## Caching Behavior
+
+- **Immutable** (gem archives under `/gems/gems/`, gemspecs under `/gems/quick/`): written once on first download and served from local storage on all subsequent requests.
+- **TTL-cached** (index files and compact index): refreshed after `NORA_GEMS_METADATA_TTL` seconds (default 300). When `NORA_GEMS_REVALIDATE` is `true`, NORA contacts upstream after TTL expiry. When upstream is unreachable and `NORA_GEMS_SERVE_STALE` is `true`, the cached response is served rather than returning an error.
+
+## Known Limitations
+
+- Proxy-only: `gem push` is not supported. Publish gems directly to rubygems.org or your private gem server.
+- No offline/air-gap mode for index files: if the upstream is unreachable and no cached copy exists, requests return 502.

--- a/docs-site/src/content/docs/registries/terraform.md
+++ b/docs-site/src/content/docs/registries/terraform.md
@@ -1,0 +1,116 @@
+---
+title: Terraform
+description: Caching proxy for the Terraform registry — Registry + Network Mirror protocols.
+---
+
+The Terraform registry provides a transparent caching proxy for [registry.terraform.io](https://registry.terraform.io). NORA serves two complementary protocols from a single mount: the standard Registry Protocol (provider/module metadata and download URL rewriting) and the Network Mirror Protocol (version index and signed archive distribution).
+
+## Client Configuration
+
+Configure Terraform to install providers through the NORA network mirror. Add to `~/.terraformrc`:
+
+```hcl
+provider_installation {
+  network_mirror {
+    url = "https://nora.example.com/terraform/"
+  }
+}
+```
+
+> **Note:** Terraform requires the network mirror URL to use `https:` and end with a trailing slash.
+
+To install a provider directly using the Registry Protocol (without a `~/.terraformrc` change), point `TERRAFORM_REGISTRY_DISCOVERY_RETRY` at NORA or configure a custom hostname alias in your provider source:
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+```
+
+Then rely on the `~/.terraformrc` network mirror block above to redirect downloads.
+
+## Upstream Proxy
+
+By default, NORA proxies to the public Terraform registry (`https://registry.terraform.io`). To use a private or air-gapped registry:
+
+```bash
+export NORA_TF_PROXY=https://registry.internal.example.com
+export NORA_TF_PROXY_AUTH=user:password
+```
+
+NORA rewrites all `download_url` fields in provider metadata responses and all archive URLs in mirror index responses to point through itself, so clients always download through the proxy.
+
+## Features
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Provider version listing | Full | Registry Protocol |
+| Provider download URL rewriting | Full | Proxied binary served via NORA |
+| Provider binary caching | Full | Immutable on first download |
+| Module version listing | Full | Registry Protocol |
+| Module download redirect | Full | `X-Terraform-Get` rewritten |
+| Network Mirror index | Full | `index.json` per provider |
+| Network Mirror archives | Full | `{version}.json` with `zh:` hashes |
+| Provider/module publish | -- | Proxy-only (read) |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NORA_TF_ENABLED` | Enable Terraform registry | `false` |
+| `NORA_TF_PROXY` | Upstream registry URL | `https://registry.terraform.io` |
+| `NORA_TF_PROXY_AUTH` | Upstream auth (`user:pass`) | *(none)* |
+| `NORA_TF_PROXY_TIMEOUT` | Proxy timeout in seconds (metadata) | `30` |
+| `NORA_TF_PROXY_TIMEOUT_DL` | Proxy timeout in seconds (binary download) | `120` |
+| `NORA_TF_METADATA_TTL` | Metadata cache TTL in seconds | `300` |
+| `NORA_TF_SERVE_STALE` | Serve cached metadata when upstream is unreachable | `true` |
+
+**config.toml:**
+
+```toml
+[terraform]
+enabled = true
+proxy = "https://registry.terraform.io"
+# proxy_auth = "user:pass"
+proxy_timeout = 30
+proxy_timeout_dl = 120
+metadata_ttl = 300
+serve_stale = true
+```
+
+## Endpoints
+
+### Registry Protocol
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/terraform/.well-known/terraform.json` | GET | Service discovery |
+| `/terraform/v1/providers/{ns}/{type}/versions` | GET | Provider version list |
+| `/terraform/v1/providers/{ns}/{type}/{ver}/download/{os}/{arch}` | GET | Provider download metadata (`download_url` rewritten to NORA) |
+| `/terraform/v1/providers/download/{*path}` | GET | Provider binary (immutable cache) |
+| `/terraform/v1/modules/{ns}/{name}/{provider}/versions` | GET | Module version list |
+| `/terraform/v1/modules/{ns}/{name}/{provider}/{ver}/download` | GET | Module download redirect (`X-Terraform-Get`) |
+| `/terraform/v1/modules/download/{ns}/{name}/{provider}/{ver}/source` | GET | Module source archive |
+
+### Network Mirror Protocol
+
+| Path | Method | Description |
+|------|--------|-------------|
+| `/terraform/{hostname}/{ns}/{type}/index.json` | GET | Available versions for a provider |
+| `/terraform/{hostname}/{ns}/{type}/{version}.json` | GET | Archive URLs and `zh:` SHA-256 hashes |
+
+## Caching Behavior
+
+- **Metadata** (provider/module version lists, download metadata, mirror index): TTL-cached for `NORA_TF_METADATA_TTL` seconds (default 300). Stale entries are served when upstream is unreachable and `NORA_TF_SERVE_STALE=true`.
+- **Binaries and source archives**: cached on first download with `Cache-Control: public, max-age=31536000, immutable`. Subsequent requests are served from local storage without contacting upstream.
+
+## Known Limitations
+
+- Single upstream only: the `{hostname}` path segment in a Network Mirror request is validated but not routed. Only providers available from the configured `NORA_TF_PROXY` upstream will resolve correctly.
+- In Network Mirror mode, Terraform skips the origin-registry GPG signature check. NORA does not verify `SHA256SUMS.sig` at ingest time — archives carry a `zh:` SHA-256 hash for integrity. Upgrade path: verify the signed `SHA256SUMS` file at ingest and store the result as a contract.
+- Provider and module publish are not supported. Use `terraform registry push` directly against the upstream registry.


### PR DESCRIPTION
Three getnora.dev documentation gaps, all reconciled against the code (grounded discovery, no invention).

**Closes #710** — Prometheus metrics: adds the **23** metrics exposed at `/metrics` but missing from the page (curation/quarantine, proxy revalidation + single-flight coalescing, upstream duration, storage/integrity, downloads/uploads, auth `namespace_scope`, leak-detection, `gc_stat_failures`, uptime), grouped with labels + descriptions.

**Closes #708** — configuration: adds the 0.9.x options absent from `settings.md` (`server.proxy_coalesce`, `server.trust_upstream_dates`, `auth.token_cache_ttl`, `auth.admin_users`, OIDC `jwks_uri`, per-registry `serve_stale`/`revalidate`/`metadata_ttl`, NuGet `metadata_timeout`/`search_service`/`autocomplete`, `pypi.proxies`, `gc.grace_secs`, curation `quarantine` + per-registry `min_release_age`/`quarantine`). Fixes the `docker.proxy_timeout` example (`60` → `300`, the real default) and calls out the 0.9.x default changes (`trust_upstream_dates=false`, `docker_anon_pull` split from `anonymous_read`).

**Closes #711** — registries: adds the **11** missing per-format pages (docker, maven, npm, cargo, pypi, go, rubygems, terraform, nuget, pub, conan). Each follows the existing `ansible.md`/`raw.md` template: client setup, upstream proxy, features, env-var table, `config.toml`, endpoints, caching behavior, limitations. Sidebar already wired in `astro.config.mjs`.

Docs-only.