### PR TITLE
chore: drop the dead docs-site route-consistency check

### DIFF
--- a/scripts/coherence-check.sh
+++ b/scripts/coherence-check.sh
@@ -118,47 +118,7 @@ if [ "$SILENT_ERRORS" -eq 0 ]; then
 fi
 echo ""
 
-# ── 7. Route path vs docs-site path consistency ──────────────────────────
-
-echo "--- Route Path vs Docs ---"
-DOCS_DIR="$REPO_ROOT/docs-site/src/content/docs/registries"
-SRC_DIR="$REPO_ROOT/nora-registry/src/registry"
-
-if [ -d "$DOCS_DIR" ] && [ -d "$SRC_DIR" ]; then
-    # Path mismatches caught by field testing:
-    # Docs path → Actual route → Problem
-    # Each entry: docs_wrong_pattern|correct_pattern
-    # If docs contain the wrong pattern and NOT the correct one → FAIL
-    declare -A PATH_CHECKS=(
-        [cargo]="/cargo/[^i]|/cargo/index/"    # docs say /cargo/ but route is /cargo/index/
-        [pypi]="/pypi/simple|/simple/"          # docs say /pypi/simple/ but route is /simple/
-        [maven]="/maven[^2]|/maven2"             # docs say /maven/ but route is /maven2/
-    )
-
-    for reg in "${!PATH_CHECKS[@]}"; do
-        doc_file="$DOCS_DIR/$reg.md"
-        [ ! -f "$doc_file" ] && continue
-
-        IFS='|' read -r wrong_pattern correct_pattern <<< "${PATH_CHECKS[$reg]}"
-
-        # Check if docs contain the correct path
-        if grep -qP ":\d+${correct_pattern//\//\\/}" "$doc_file" 2>/dev/null; then
-            ok "$reg: docs use correct client path ($correct_pattern)"
-        else
-            # Check if docs contain the wrong path
-            if grep -qP ":\d+${wrong_pattern}" "$doc_file" 2>/dev/null; then
-                fail "$reg: docs use wrong path (matches $wrong_pattern) — correct is $correct_pattern"
-            else
-                warn "$reg: could not verify path in docs — manual check needed"
-            fi
-        fi
-    done
-else
-    warn "docs-site or registry src not found — skipping route path check"
-fi
-echo ""
-
-# ── 8. CANCEL-SAFETY annotations ─────────────────────────────────────────
+# ── 7. CANCEL-SAFETY annotations ─────────────────────────────────────────
 
 echo "--- Cancel-Safety Annotations ---"
 SRC="$REPO_ROOT/nora-registry/src"


### PR DESCRIPTION
Follow-up to #812 (which removed the orphaned `docs-site/` tree).

`scripts/coherence-check.sh` section 7 ("Route path vs docs-site path consistency") read its expected client paths from `docs-site/`, which no longer lives in this repo — docs are maintained and published separately. With that source gone the check degraded to a no-op skip warning on every run, so remove it and renumber the following CANCEL-SAFETY section.

No behavior change to the remaining checks — `coherence-check.sh` still runs green (`exit 0`, `Errors: 0`). The docs↔code coherence that section approximated (against stale data — only 2 of 13 pages existed here) is now enforced properly in the docs pipeline itself.

`scripts/coherence-check.sh` only — one section removed (−41 lines).