### PR TITLE
ci(release): helm-charts dispatch via GitHub App (no PAT rotation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -623,9 +623,15 @@ jobs:
 
       - name: Notify helm-charts repo
         if: success()
+        # Best-effort downstream notification: the release is already published by
+        # this point, so a dispatch failure (e.g. an expired HELM_CHARTS_PAT) must
+        # not fail the release. Surface it as a warning instead of a red run.
+        continue-on-error: true
         run: |
-          gh api repos/getnora-io/helm-charts/dispatches \
-            -f event_type=nora-release \
-            -f 'client_payload[version]=${{ steps.ver.outputs.tag }}'
+          if ! gh api repos/getnora-io/helm-charts/dispatches \
+                -f event_type=nora-release \
+                -f 'client_payload[version]=${{ steps.ver.outputs.tag }}'; then
+            echo "::warning title=helm-charts notify failed::dispatch returned non-zero (expired HELM_CHARTS_PAT?) — chart appVersion NOT auto-bumped for ${{ steps.ver.outputs.tag }}; run it manually"
+          fi
         env:
           GH_TOKEN: ${{ secrets.HELM_CHARTS_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -621,17 +621,31 @@ jobs:
 
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md)
 
-      - name: Notify helm-charts repo
+      - name: Mint helm-charts app token
+        id: helm_app
         if: success()
-        # Best-effort downstream notification: the release is already published by
-        # this point, so a dispatch failure (e.g. an expired HELM_CHARTS_PAT) must
-        # not fail the release. Surface it as a warning instead of a red run.
+        # Short-lived installation token (auto-expires ~1h), minted per run from a
+        # GitHub App scoped to Contents:write on helm-charts only. Nothing to rotate,
+        # nothing to expire. continue-on-error so an App/key misconfig degrades to a
+        # warning below rather than failing an already-published release.
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.NORA_HELM_APP_ID }}
+          private-key: ${{ secrets.NORA_HELM_APP_KEY }}
+          owner: getnora-io
+          repositories: helm-charts
+
+      - name: Notify helm-charts repo
+        if: success() && steps.helm_app.outputs.token != ''
+        # Best-effort downstream bump: the release is already published by this point,
+        # so a dispatch failure must not fail the release. Surface it as a warning.
         continue-on-error: true
         run: |
           if ! gh api repos/getnora-io/helm-charts/dispatches \
                 -f event_type=nora-release \
                 -f 'client_payload[version]=${{ steps.ver.outputs.tag }}'; then
-            echo "::warning title=helm-charts notify failed::dispatch returned non-zero (expired HELM_CHARTS_PAT?) — chart appVersion NOT auto-bumped for ${{ steps.ver.outputs.tag }}; run it manually"
+            echo "::warning title=helm-charts notify failed::dispatch returned non-zero — chart appVersion NOT auto-bumped for ${{ steps.ver.outputs.tag }}; run it manually"
           fi
         env:
-          GH_TOKEN: ${{ secrets.HELM_CHARTS_PAT }}
+          GH_TOKEN: ${{ steps.helm_app.outputs.token }}


### PR DESCRIPTION
The release "Notify helm-charts repo" step used a long-lived HELM_CHARTS_PAT that
silently expired and failed the v0.9.7 release run with HTTP 401, even though the
release itself was published fine.

Two changes:
- Make the downstream notify best-effort: continue-on-error + a ::warning
  annotation, so a dispatch failure can never red an already-published release.
- Mint the dispatch token per run from a GitHub App scoped to Contents:write on
  helm-charts only (actions/create-github-app-token, pinned by SHA). Installation
  tokens auto-expire (~1h), so there is nothing to rotate.
