### PR TITLE
fix: token storage fails under systemd (relative default escapes sandbox)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,9 +616,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/deploy/nora.service
+++ b/deploy/nora.service
@@ -17,6 +17,9 @@ Environment=RUST_LOG=info
 Environment=NORA_HOST=0.0.0.0
 Environment=NORA_PORT=4000
 Environment=NORA_STORAGE_PATH=/var/lib/nora
+# Absolute path inside ReadWritePaths — the relative built-in default (data/tokens)
+# resolves outside the ProtectSystem=strict sandbox and breaks token writes (#816).
+Environment=NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens
 EnvironmentFile=-/etc/nora/nora.env
 
 # Security hardening

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -75,6 +75,9 @@ if [ ! -f "$CONFIG_DIR/nora.env" ]; then
 NORA_HOST=0.0.0.0
 NORA_PORT=4000
 NORA_STORAGE_PATH=/var/lib/nora
+# Absolute path inside ReadWritePaths — the relative built-in default (data/tokens)
+# resolves outside the ProtectSystem=strict sandbox and breaks token writes (#816).
+NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens
 ENVEOF
     sudo mv /tmp/nora.env "$CONFIG_DIR/nora.env"
     sudo chmod 600 "$CONFIG_DIR/nora.env"

--- a/dist/nora.env.example
+++ b/dist/nora.env.example
@@ -17,6 +17,11 @@ NORA_STORAGE_PATH=/var/lib/nora
 # Auth (optional)
 # NORA_AUTH_ENABLED=true
 # NORA_AUTH_HTPASSWD_FILE=/etc/nora/users.htpasswd
+# Token storage MUST be an absolute path inside the service's writable paths.
+# ProtectSystem=strict only allows writes under /var/lib/nora; the built-in
+# default (data/tokens) is relative and resolves to /etc/nora/data/tokens,
+# which is read-only under systemd, so token creation fails (#816).
+NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens
 
 # Rate limiting
 # NORA_RATE_LIMIT_ENABLED=true

--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -646,20 +646,29 @@ impl Config {
                 .push("server.body_limit_mb is 0, no request bodies will be accepted".to_string());
         }
 
-        // 6. Relative paths with explicit config — may resolve unexpectedly
-        if config_path.is_some() {
-            if self.storage.mode == StorageMode::Local && !self.storage.path.starts_with('/') {
-                warnings.push(format!(
-                    "storage.path=\"{}\" is relative — will resolve from CWD. Use absolute path for predictable behavior",
-                    self.storage.path
-                ));
-            }
-            if self.auth.enabled && !self.auth.token_storage.starts_with('/') {
-                warnings.push(format!(
-                    "auth.token_storage=\"{}\" is relative — will resolve from CWD. Use absolute path for predictable behavior",
-                    self.auth.token_storage
-                ));
-            }
+        // 6. Relative paths — may resolve unexpectedly.
+        // The storage.path hint is scoped to explicit-config starts, to avoid noise
+        // on the relative default of a bare `nora serve`.
+        if config_path.is_some()
+            && self.storage.mode == StorageMode::Local
+            && !self.storage.path.starts_with('/')
+        {
+            warnings.push(format!(
+                "storage.path=\"{}\" is relative — will resolve from CWD. Use absolute path for predictable behavior",
+                self.storage.path
+            ));
+        }
+        // The token_storage hint fires whenever auth is enabled with a relative
+        // path, regardless of config source: env-only (systemd) starts have
+        // config_path=None yet are exactly where a relative token_storage resolves
+        // outside ReadWritePaths and breaks token writes (#816).
+        if self.auth.enabled && !self.auth.token_storage.starts_with('/') {
+            warnings.push(format!(
+                "auth.token_storage=\"{}\" is relative — will resolve from CWD (under systemd it \
+                 resolves outside ReadWritePaths and token writes fail). Set an absolute path, e.g. \
+                 NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens",
+                self.auth.token_storage
+            ));
         }
 
         // 7. Trusted proxies /0 — security footgun
@@ -1856,6 +1865,26 @@ mod tests {
         assert!(
             warnings.iter().any(|w| w.contains("token_storage")),
             "should warn about relative token_storage"
+        );
+    }
+
+    #[test]
+    fn test_relative_token_storage_warns_without_config_path() {
+        // #816: env-only (systemd) starts have config_path=None. A relative
+        // token_storage with auth enabled must still warn — that is exactly the
+        // case that escapes the sandbox and breaks token writes.
+        let mut config = Config::default();
+        config.auth.enabled = true; // default token_storage = "data/tokens" (relative)
+        let (warnings, _) = config.validate_with_config_path(None);
+        assert!(
+            warnings.iter().any(|w| w.contains("token_storage")),
+            "relative token_storage must warn even with no config file (env-only deploy)"
+        );
+        // The storage.path hint stays scoped to explicit-config starts (no noise on
+        // the bare-serve relative default).
+        assert!(
+            !warnings.iter().any(|w| w.contains("storage.path")),
+            "storage.path hint should remain gated behind an explicit config file"
         );
     }
 

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1299,6 +1299,21 @@ async fn run_server(mut config: Config, storage: Storage) {
     // Initialize token store if auth is enabled
     let tokens = if config.auth.enabled {
         let token_path = Path::new(&config.auth.token_storage);
+        // Fail fast: with auth enabled a token store that cannot create/write its
+        // directory is unusable. Surface it at boot with the resolved path instead
+        // of swallowing the mkdir error and failing later with a bare ENOENT on the
+        // first POST /api/tokens (#816). Under a systemd sandbox a relative
+        // token_storage resolves outside ReadWritePaths and is not writable.
+        if let Err(e) = std::fs::create_dir_all(token_path) {
+            error!(
+                path = %config.auth.token_storage,
+                error = %e,
+                "Cannot create token storage directory — auth is enabled but tokens cannot be \
+                 persisted. Set NORA_AUTH_TOKEN_STORAGE to a writable absolute path (e.g. \
+                 /var/lib/nora/tokens, inside the service's ReadWritePaths)."
+            );
+            std::process::exit(1);
+        }
         info!(path = %config.auth.token_storage, "Token storage initialized");
         Some(TokenStore::with_cache_ttl(
             token_path,

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -117,8 +117,17 @@ impl TokenStore {
     /// bounds the window in which a token revoked on another replica is still
     /// served from this replica's cache.
     pub fn with_cache_ttl(storage_path: &Path, cache_ttl: Duration) -> Self {
-        // Ensure directory exists with restricted permissions
-        let _ = fs::create_dir_all(storage_path);
+        // Ensure directory exists with restricted permissions. The serve path
+        // fail-fasts on this in main.rs (#816); this is best-effort for library /
+        // standalone use, but surface a diagnostic rather than swallowing the error
+        // so a non-writable path is never silently broken until the first write.
+        if let Err(e) = fs::create_dir_all(storage_path) {
+            tracing::warn!(
+                path = %storage_path.display(),
+                error = %e,
+                "TokenStore: could not create storage directory — token writes will fail"
+            );
+        }
         #[cfg(unix)]
         {
             let _ = fs::set_permissions(storage_path, fs::Permissions::from_mode(0o700));


### PR DESCRIPTION
## Summary

Auth-enabled **service** deployments fail on the first `POST /api/tokens` with:

```
Storage error: No such file or directory (os error 2)
```

Reported in #816 (v0.9.7, Debian/Ubuntu systemd install).

## Root cause

`auth.token_storage` defaults to a **relative** path (`data/tokens`). Under the shipped systemd unit — `WorkingDirectory=/etc/nora`, `ProtectSystem=strict`, `ReadWritePaths=/var/lib/nora /var/log/nora` — it resolves to `/etc/nora/data/tokens`, which is **read-only** and outside the writable paths, so the directory can't be created and the first token write fails with `ENOENT`. The container image is unaffected: `config.docker.toml` ships an absolute `token_storage = "/data/tokens"`.

Three coupled defects:

- **A — packaging:** the shipped `nora.env`/service set `NORA_STORAGE_PATH` but not `NORA_AUTH_TOKEN_STORAGE`, so the service inherits the broken relative default.
- **B — silent failure:** `TokenStore::with_cache_ttl` swallows the `mkdir` result (`let _ = fs::create_dir_all(...)`) and `main.rs` logs *"Token storage initialized"* unconditionally, so the service boots "healthy" and only fails later with a bare `ENOENT` at request time.
- **C — no warning:** the relative-`token_storage` validation warning is gated behind `if config_path.is_some()`, so **env-only (systemd) deployments — exactly the failing case — never see it.**

## Changes

| Defect | Files | Change |
| --- | --- | --- |
| A | `dist/install.sh`, `deploy/nora.service` | ship `NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens` (service sibling of the container default) |
| B | `nora-registry/src/main.rs`, `nora-registry/src/tokens.rs` | fail fast at boot with the resolved path if the token dir can't be created; stop logging "initialized" before the dir exists; surface (not swallow) the `mkdir` error in `TokenStore` |
| C | `nora-registry/src/config/mod.rs` | emit the relative-`token_storage` warning for env-only starts too (+ regression test) |

> Follow-up: `dist/nora.env.example` should also gain `NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens` under the Auth section (docs mirror).

## Tests

`cargo fmt --check` ✓ · `cargo clippy -- -D warnings` ✓ · **1526 tests pass** (new: `test_relative_token_storage_warns_without_config_path`).

### Acceptance on real systemd (`ProtectSystem=strict`, `ReadWritePaths`, read-only `WorkingDirectory`)

| Case | Binary | `token_storage` | Result |
| --- | --- | --- | --- |
| Reproduce #816 | shipped 0.9.7 | relative default | boots active → `POST` → `Storage error: No such file or directory (os error 2)` |
| Fail-fast (B+C) | this PR | relative default | boot **fails** (exit 1): `Cannot create token storage directory … Read-only file system (os error 30)` + relative-path warning fires |
| Fixed (A) | this PR | absolute | boots active → `POST` → `200 {token, expires_in_days}` |
| Workaround | shipped 0.9.7 | absolute env | boots active → `POST` → `200` |

Closes #816
