### PR TITLE
fix(ui): correct RU labels and make footer brag zero-dependencies

### DIFF
--- a/nora-registry/src/ui/components.rs
+++ b/nora-registry/src/ui/components.rs
@@ -915,8 +915,8 @@ pub fn render_bragging_footer(lang: Lang, stats: &BraggingStats) -> String {
                 <div class="text-xs text-slate-500 mt-1">amd64 / arm64</div>
             </div>
             <div class="p-3">
-                <div class="text-2xl font-bold text-cyan-400">{zero_config}</div>
-                <div class="text-xs text-slate-500 mt-1">Config</div>
+                <div class="text-2xl font-bold text-cyan-400">{zero_deps}</div>
+                <div class="text-xs text-slate-500 mt-1">{deps_label}</div>
             </div>
         </div>
         <div class="text-center mt-4">
@@ -934,7 +934,8 @@ pub fn render_bragging_footer(lang: Lang, stats: &BraggingStats) -> String {
         reg_count = stats.registry_count,
         reg_label = t.registries_count,
         multi_arch = t.multi_arch,
-        zero_config = t.zero_config,
+        zero_deps = t.zero_deps,
+        deps_label = t.deps_label,
         tagline = t.tagline,
     )
 }

--- a/nora-registry/src/ui/i18n.rs
+++ b/nora-registry/src/ui/i18n.rs
@@ -118,7 +118,8 @@ pub struct Translations {
     pub memory: &'static str,
     pub registries_count: &'static str,
     pub multi_arch: &'static str,
-    pub zero_config: &'static str,
+    pub zero_deps: &'static str,
+    pub deps_label: &'static str,
     pub tagline: &'static str,
 
     // Token management
@@ -235,7 +236,8 @@ pub static TRANSLATIONS_EN: Translations = Translations {
     memory: "Memory",
     registries_count: "Registries",
     multi_arch: "Multi-arch",
-    zero_config: "Zero",
+    zero_deps: "0",
+    deps_label: "Dependencies",
     tagline: "Pure Rust. Single binary. OCI compatible.",
 
     // Token management
@@ -276,7 +278,7 @@ pub static TRANSLATIONS_RU: Translations = Translations {
     // Dashboard
     dashboard_title: "Панель управления",
     dashboard_subtitle: "Обзор всех реестров",
-    uptime: "Аптайм",
+    uptime: "Время работы",
 
     // Stats
     stat_downloads: "Загрузки",
@@ -343,8 +345,9 @@ pub static TRANSLATIONS_RU: Translations = Translations {
     cold_start: "Холодный старт",
     memory: "Память",
     registries_count: "Реестров",
-    multi_arch: "Мульти-арх",
-    zero_config: "Без",
+    multi_arch: "Мультиарх",
+    zero_deps: "0",
+    deps_label: "зависимостей",
     tagline: "Чистый Rust. Один бинарник. OCI совместимый.",
 
     // Token management
@@ -453,7 +456,8 @@ pub static TRANSLATIONS_ZH: Translations = Translations {
     memory: "内存",
     registries_count: "注册表",
     multi_arch: "多架构",
-    zero_config: "零配置",
+    zero_deps: "0",
+    deps_label: "依赖",
     tagline: "纯 Rust 实现。单二进制文件。兼容 OCI。",
 
     // Token management


### PR DESCRIPTION
## Summary

Small dashboard i18n/label fixes:

- **RU labels**: `Аптайм` → `Время работы`, `Мульти-арх` → `Мультиарх` (drop the anglicism and the hyphen).
- **Footer stat**: `Zero Config` → `0 Dependencies` across EN/RU/ZH (`zero_config` → `zero_deps` + `deps_label`). NORA is a single static binary, so zero-dependencies is the accurate brag.

## Test plan

`cargo fmt --check`, `cargo clippy --bin nora -- -D warnings`, and the i18n/ui tests — all green. Translation-key completeness is compiler-enforced: the `Translations` struct requires every field in all three language tables, so a missing key is a build error.
