### PR TITLE
fix: internal-namespace Docker manifest/blob miss returns 404 not 403 (#821)

### DIFF
--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -850,6 +850,47 @@ fn quarantine_forbidden(
         .into_response()
 }
 
+/// Build a 404 `MANIFEST_UNKNOWN` response per the OCI Distribution Spec.
+///
+/// Used for a genuine not-found on a manifest we do not hold — including the local
+/// miss on a hosted internal-namespace repo (#821): namespace isolation refuses to
+/// proxy an internal name upstream, but a hosted image's absent tag is a not-found,
+/// not an authorization denial. Docker/BuildKit treats `403` on a manifest
+/// `HEAD`/`GET` as fatal, whereas `404 MANIFEST_UNKNOWN` lets push pre-flight probes
+/// and OCI referrers lookups proceed.
+fn manifest_unknown_response(name: &str, reference: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "errors": [{
+                "code": "MANIFEST_UNKNOWN",
+                "message": "manifest unknown",
+                "detail": { "name": name, "reference": reference }
+            }]
+        })),
+    )
+        .into_response()
+}
+
+/// Build a 404 `BLOB_UNKNOWN` response per the OCI Distribution Spec.
+///
+/// Companion to [`manifest_unknown_response`] for blobs; used for the internal-
+/// namespace local miss (#821) so `GET` agrees with the `HEAD` probe (`check_blob`
+/// already 404s) and never conflates not-found with `403 Forbidden`.
+fn blob_unknown_response(digest: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "errors": [{
+                "code": "BLOB_UNKNOWN",
+                "message": "blob unknown to registry",
+                "detail": { "digest": digest }
+            }]
+        })),
+    )
+        .into_response()
+}
+
 /// Cache-serve quarantine gate for an already-cached artifact with a known digest.
 ///
 /// Blocks (403 in enforce) ONLY when a proxy record for this digest is still
@@ -1362,14 +1403,13 @@ async fn download_blob(
             .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
 
-    // #733: an internal-namespace image's blob with no local copy is never proxied upstream.
+    // #733/#821: an internal-namespace image's blob with no local copy is never proxied
+    // upstream (dependency-confusion defense — this early return precedes the proxy loop).
+    // A hosted image's absent blob is a not-found, not an authz denial: return 404
+    // BLOB_UNKNOWN so GET agrees with the HEAD probe (check_blob, which already 404s)
+    // instead of the fatal-to-clients 403.
     if internal {
-        return crate::curation::check_namespace_isolation(
-            &state.curation().curation_engine,
-            crate::curation::RegistryType::Docker,
-            &name,
-        )
-        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+        return blob_unknown_response(&digest);
     }
 
     let temp_dir = proxy_temp_dir(&state.config.storage.path);
@@ -2253,18 +2293,17 @@ async fn get_manifest(
         }
     }
 
-    // #733: an internal-namespace image's manifest — serve any (stale) local copy, else block;
-    // never proxy upstream (the fresh path already returned above).
+    // #733/#821: an internal-namespace image's manifest — serve any (stale) local copy, else
+    // return a genuine not-found; never proxy upstream (the fresh path already returned above,
+    // and this branch precedes the proxy loop — dependency-confusion defense intact). A hosted
+    // image's absent tag is 404 MANIFEST_UNKNOWN, NOT 403: Docker/BuildKit treats 403 on a
+    // manifest HEAD/GET as fatal, breaking push HEAD-probes and OCI referrers (sha256-<digest>)
+    // lookups on locally-hosted images.
     if internal {
         if let Some(ref data) = cached {
             return serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
         }
-        return crate::curation::check_namespace_isolation(
-            &state.curation().curation_engine,
-            crate::curation::RegistryType::Docker,
-            &name,
-        )
-        .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response());
+        return manifest_unknown_response(&name, &reference);
     }
 
     // Try upstream proxies (always if no cache, or if cache is stale)
@@ -2754,30 +2793,10 @@ async fn delete_manifest(
                     tracing::info!(name = %name, reference = %reference, "Docker manifest deleted (legacy key)");
                     StatusCode::ACCEPTED.into_response()
                 }
-                _ => (
-                    StatusCode::NOT_FOUND,
-                    Json(json!({
-                        "errors": [{
-                            "code": "MANIFEST_UNKNOWN",
-                            "message": "manifest unknown",
-                            "detail": { "name": name, "reference": reference }
-                        }]
-                    })),
-                )
-                    .into_response(),
+                _ => manifest_unknown_response(&name, &reference),
             }
         }
-        Err(crate::storage::StorageError::NotFound) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "errors": [{
-                    "code": "MANIFEST_UNKNOWN",
-                    "message": "manifest unknown",
-                    "detail": { "name": name, "reference": reference }
-                }]
-            })),
-        )
-            .into_response(),
+        Err(crate::storage::StorageError::NotFound) => manifest_unknown_response(&name, &reference),
         Err(e) => {
             tracing::error!(error = %e, key = %key, name = %name, reference = %reference, "Failed to delete manifest");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
@@ -2821,17 +2840,7 @@ async fn delete_blob(
             tracing::info!(name = %name, digest = %digest, "Docker blob deleted");
             StatusCode::ACCEPTED.into_response()
         }
-        Err(crate::storage::StorageError::NotFound) => (
-            StatusCode::NOT_FOUND,
-            Json(json!({
-                "errors": [{
-                    "code": "BLOB_UNKNOWN",
-                    "message": "blob unknown to registry",
-                    "detail": { "digest": digest }
-                }]
-            })),
-        )
-            .into_response(),
+        Err(crate::storage::StorageError::NotFound) => blob_unknown_response(&digest),
         Err(e) => {
             tracing::error!(error = %e, key = %key, name = %name, digest = %digest, "Failed to delete blob");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()

--- a/nora-registry/src/registry/ns_isolation_metadata_tests.rs
+++ b/nora-registry/src/registry/ns_isolation_metadata_tests.rs
@@ -507,3 +507,172 @@ async fn conan_internal_recipe_file_served_local() {
         "locally-cached internal conan recipe file must be served (#733)"
     );
 }
+
+// ── #821: Docker/OCI internal-namespace local MISS is 404, never 403 ──
+// A hosted internal-namespace image's absent manifest/blob is a not-found, not an authz denial.
+// Docker/BuildKit treats 403 on a manifest HEAD/GET as FATAL (breaks `docker push` HEAD-probes and
+// OCI referrers lookups), whereas 404 MANIFEST_UNKNOWN/BLOB_UNKNOWN lets it proceed. The
+// dependency-confusion defense is unchanged: the internal branch precedes the proxy loop, so the
+// live BLACKHOLE upstream is NEVER contacted — proven by the synthetic OCI error body (a leak or a
+// proxy-fallback would yield a bare-body 404, failing the code assertion).
+
+#[tokio::test]
+async fn docker_internal_manifest_miss_get_404_not_403() {
+    use crate::config::DockerUpstream;
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal/**".to_string()];
+        c.docker.upstreams = vec![DockerUpstream {
+            url: BLACKHOLE.to_string(),
+            auth: None,
+            namespace: None,
+            prefix: None,
+        }];
+    });
+    // A tag that does not exist yet in a hosted internal namespace (docker push pre-flight).
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/v2/internal/backend/manifests/3.19.2",
+        "",
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "internal-ns manifest miss must be 404, not 403 (#821)"
+    );
+    let body = body_bytes(resp).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["errors"][0]["code"], "MANIFEST_UNKNOWN",
+        "must be OCI MANIFEST_UNKNOWN — proves the internal branch fired, upstream never contacted"
+    );
+}
+
+#[tokio::test]
+async fn docker_internal_manifest_miss_head_404_not_403() {
+    use crate::config::DockerUpstream;
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal/**".to_string()];
+        c.docker.upstreams = vec![DockerUpstream {
+            url: BLACKHOLE.to_string(),
+            auth: None,
+            namespace: None,
+            prefix: None,
+        }];
+    });
+    // The HEAD probe docker issues before pushing a new tag — 403 here is fatal to the client.
+    let resp = send(
+        &ctx.app,
+        Method::HEAD,
+        "/v2/internal/backend/manifests/3.19.2",
+        "",
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "internal-ns manifest HEAD miss must be 404, not the fatal-to-docker 403 (#821)"
+    );
+}
+
+#[tokio::test]
+async fn docker_internal_referrers_tag_miss_head_404() {
+    use crate::config::DockerUpstream;
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal/**".to_string()];
+        c.docker.upstreams = vec![DockerUpstream {
+            url: BLACKHOLE.to_string(),
+            auth: None,
+            namespace: None,
+            prefix: None,
+        }];
+    });
+    // OCI referrers fallback tag (sha256-<digest>) for a hosted image with no attestations:
+    // this HEAD must 404 so `docker pull` of attestation-carrying internal images proceeds.
+    let resp = send(
+        &ctx.app,
+        Method::HEAD,
+        "/v2/internal/app/manifests/sha256-1111111111111111111111111111111111111111111111111111111111111111",
+        "",
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "internal-ns referrers-tag miss must be 404 (#821)"
+    );
+}
+
+#[tokio::test]
+async fn docker_internal_blob_miss_get_404_and_head_agrees() {
+    use crate::config::DockerUpstream;
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal/**".to_string()];
+        c.docker.upstreams = vec![DockerUpstream {
+            url: BLACKHOLE.to_string(),
+            auth: None,
+            namespace: None,
+            prefix: None,
+        }];
+    });
+    let digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+    let uri = format!("/v2/internal/backend/blobs/{digest}");
+    // GET was the 403 half of the HEAD/GET asymmetry (check_blob already 404s) — now 404 BLOB_UNKNOWN.
+    let get = send(&ctx.app, Method::GET, &uri, "").await;
+    assert_eq!(
+        get.status(),
+        StatusCode::NOT_FOUND,
+        "internal-ns blob GET miss must be 404, not 403 (#821)"
+    );
+    let body = body_bytes(get).await;
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["errors"][0]["code"], "BLOB_UNKNOWN");
+    // HEAD and GET must now agree (both 404), closing the pre-fix asymmetry.
+    let head = send(&ctx.app, Method::HEAD, &uri, "").await;
+    assert_eq!(
+        head.status(),
+        StatusCode::NOT_FOUND,
+        "internal-ns blob HEAD and GET must agree (both 404)"
+    );
+}
+
+#[tokio::test]
+async fn docker_internal_manifest_served_local_still_ok() {
+    // Regression guard: the #821 fix touches only the MISS branch; a locally-hosted internal
+    // manifest must still be served 200 (serve-local, #733), never namespace-blocked.
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal/**".to_string()];
+    });
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+        "config": {
+            "mediaType": "application/vnd.docker.container.image.v1+json",
+            "size": 0,
+            "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "layers": []
+    });
+    // No upstream configured → canonicalize namespace is None → key docker/<name>/manifests/<ref>.json.
+    ctx.state
+        .storage
+        .put(
+            "docker/internal/backend/manifests/1.0.json",
+            &serde_json::to_vec(&manifest).unwrap(),
+        )
+        .await
+        .unwrap();
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/v2/internal/backend/manifests/1.0",
+        "",
+    )
+    .await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "locally-hosted internal manifest must still be served, not blocked (#733 serve-local)"
+    );
+}


### PR DESCRIPTION
Closes #821

Namespace isolation (`internal_namespaces`) returned **403** for any local-storage miss in an internal namespace, including manifest `HEAD`/`GET` probes for tags that don't exist yet. Docker/BuildKit treats 403 on a manifest HEAD/GET as fatal, so `docker push` of a new tag and `docker pull` of attestation images (OCI referrers `sha256-<digest>` tag) broke for locally-hosted internal images.

A hosted internal image is operator-owned: a local miss is a genuine not-found, not an authz denial → return **404 MANIFEST_UNKNOWN / BLOB_UNKNOWN**. The dependency-confusion defense is unchanged — the internal branch still returns before the proxy loop, so an internal name is never fetched upstream; only the client-facing status code changes. Reserving 403 for real authz denial also removes an info-leak (internal namespaces were distinguishable by their 403). Same principle as GHSA-78cx (`404` not `403` so a caller cannot probe existence).

The old `check_namespace_isolation(...).unwrap_or_else(|| 404)` was dead code: inside `if internal` the filter always re-evaluates to `Block`, so the 404 fallback was never reached. Also closes a HEAD/GET blob asymmetry (`check_blob` HEAD already 404'd; `download_blob` GET 403'd).

- `get_manifest` + `download_blob` internal miss → `manifest_unknown_response` / `blob_unknown_response` (new OCI-404 helpers); `delete_manifest` / `delete_blob` reuse them.
- +5 regression tests (manifest GET/HEAD miss, referrers-tag HEAD, blob GET/HEAD agree, serve-local still served) proving 404 + no upstream contact.

**No operator-visible metric change.** The Docker internal-namespace path resolves via `is_internal_namespace` / `check_namespace_isolation`, which call the namespace filter directly and bypass `evaluate()` — so these refusals were never recorded in `nora_curation_decisions_total` (before or after this change); only a test-internal counter was touched. Namespace-isolation refusals have no Prometheus signal today; adding one is a tracked follow-up.

pip/cargo/npm internal-namespace misses still return 403 (their clients tolerate it) — unifying them is a separate follow-up.
