### PR TITLE
feat: observe namespace-isolation refusals in Prometheus (#821 follow-up)

### DIFF
--- a/nora-registry/src/curation.rs
+++ b/nora-registry/src/curation.rs
@@ -356,6 +356,7 @@ pub fn check_namespace_isolation(
         let decision = ns_filter.evaluate(&request);
         if let Decision::Block { rule, reason } = &decision {
             engine.metrics.blocked.fetch_add(1, Ordering::Relaxed);
+            crate::metrics::record_namespace_isolation_refused(registry.as_str());
             return Some(
                 BlockedResponse {
                     rule: rule.clone(),

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -45,6 +45,28 @@ pub static CURATION_DECISIONS_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| 
     .expect("failed to create CURATION_DECISIONS_TOTAL metric at startup")
 });
 
+/// Internal-namespace requests refused by namespace isolation — the
+/// dependency-confusion defense firing: an internal name that was neither served
+/// from local storage nor proxied upstream (blocked / 404'd). Previously the guard
+/// was invisible in Prometheus (only a client 403/404 and a test-internal counter
+/// existed), so an operator could neither alert on nor graph it. By registry.
+pub static NAMESPACE_ISOLATION_REFUSED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_namespace_isolation_refused_total",
+        "Internal-namespace requests refused by namespace isolation (never served locally, never proxied upstream), by registry",
+        &["registry"]
+    )
+    .expect("failed to create NAMESPACE_ISOLATION_REFUSED_TOTAL metric at startup")
+});
+
+/// Record one namespace-isolation refusal for `registry` (dependency-confusion
+/// defense). `registry` must be a [`crate::registry_type::RegistryType::as_str`] value.
+pub fn record_namespace_isolation_refused(registry: &str) {
+    NAMESPACE_ISOLATION_REFUSED_TOTAL
+        .with_label_values(&[registry])
+        .inc();
+}
+
 /// Proxy artifacts held by the digest quarantine, by registry and outcome
 /// (`blocked` = enforce returned 403; `observed` = observe served but recorded).
 /// Gives the operator an alertable/graphable signal — the quarantine was

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -1409,6 +1409,7 @@ async fn download_blob(
     // BLOB_UNKNOWN so GET agrees with the HEAD probe (check_blob, which already 404s)
     // instead of the fatal-to-clients 403.
     if internal {
+        crate::metrics::record_namespace_isolation_refused("docker");
         return blob_unknown_response(&digest);
     }
 
@@ -2303,6 +2304,7 @@ async fn get_manifest(
         if let Some(ref data) = cached {
             return serve_cached_manifest(&state, data, &name, &reference, ns.as_deref());
         }
+        crate::metrics::record_namespace_isolation_refused("docker");
         return manifest_unknown_response(&name, &reference);
     }
 

--- a/nora-registry/src/registry/ns_isolation_metadata_tests.rs
+++ b/nora-registry/src/registry/ns_isolation_metadata_tests.rs
@@ -676,3 +676,56 @@ async fn docker_internal_manifest_served_local_still_ok() {
         "locally-hosted internal manifest must still be served, not blocked (#733 serve-local)"
     );
 }
+
+// ── observability: namespace-isolation refusals are counted in Prometheus ──
+// The dependency-confusion defense firing was previously invisible in telemetry (only
+// the client 403/404 and a test-internal counter existed). nora_namespace_isolation_refused_total
+// makes it alertable/graphable. Delta assertion (after > before) is robust to parallel tests
+// incrementing the same label, and still catches a removed increment (nothing bumps the label
+// anywhere -> after == before -> fail).
+
+#[tokio::test]
+async fn docker_internal_miss_increments_isolation_refused_metric() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal/**".to_string()];
+    });
+    let before = crate::metrics::NAMESPACE_ISOLATION_REFUSED_TOTAL
+        .with_label_values(&["docker"])
+        .get();
+    let resp = send(
+        &ctx.app,
+        Method::GET,
+        "/v2/internal/backend/manifests/9.9.9",
+        "",
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let after = crate::metrics::NAMESPACE_ISOLATION_REFUSED_TOTAL
+        .with_label_values(&["docker"])
+        .get();
+    assert!(
+        after > before,
+        "a docker internal-namespace refusal must increment nora_namespace_isolation_refused_total{{registry=docker}}"
+    );
+}
+
+#[tokio::test]
+async fn pypi_internal_refusal_increments_isolation_refused_metric() {
+    let ctx = create_test_context_with_config(|c| {
+        c.curation.internal_namespaces = vec!["internal*".to_string()];
+        c.pypi.proxy = Some(BLACKHOLE.to_string());
+    });
+    let before = crate::metrics::NAMESPACE_ISOLATION_REFUSED_TOTAL
+        .with_label_values(&["pypi"])
+        .get();
+    // Internal name, no local copy → check_namespace_isolation refusal (403).
+    let resp = send(&ctx.app, Method::GET, "/simple/internalpkg-metric/", "").await;
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    let after = crate::metrics::NAMESPACE_ISOLATION_REFUSED_TOTAL
+        .with_label_values(&["pypi"])
+        .get();
+    assert!(
+        after > before,
+        "a non-docker internal-namespace refusal (check_namespace_isolation) must increment the isolation-refused metric"
+    );
+}


### PR DESCRIPTION
Follow-up to #821 / #822 (observability).

The namespace-isolation guard — the dependency-confusion defense — fired **invisibly** in telemetry. An internal-namespace name that was neither served locally nor proxied upstream returned only a client **403** (`check_namespace_isolation`, the 11 proxy registries) or **404** (docker manifest/blob miss, #821/#822) and bumped a test-only internal counter. `nora_curation_decisions_total` does **not** cover it: the internal path resolves via `is_internal_namespace` / `check_namespace_isolation`, which call the namespace filter directly and bypass `evaluate()`. So an operator could neither alert on nor graph the guard.

### Change

Add **`nora_namespace_isolation_refused_total{registry}`**, incremented at every refusal:
- the `check_namespace_isolation` `Block` branch — all 11 proxy registries (pypi, cargo, maven, go, npm, nuget, conan, pub, terraform, ansible, gems);
- the two docker internal-miss sites (`get_manifest` / `download_blob`).

Deliberately **not** incremented:
- delete paths — a delete-not-found is not an isolation refusal (the record is at the call site, not inside the shared `*_unknown_response` helpers);
- `raw` — hosted-only, no upstream, so an internal miss is a plain not-found, nothing is refused.

Closes a concrete hole under the `metrics-security-events-observable` invariant.

### Files
- `metrics.rs`: `NAMESPACE_ISOLATION_REFUSED_TOTAL` + `record_namespace_isolation_refused()`.
- `curation.rs` / `docker.rs`: increment at the three refusal sites.
- `ns_isolation_metadata_tests.rs`: +2 regression tests (docker + pypi) asserting the counter increments on a refusal (delta `after > before` — robust to parallel tests, catches a removed increment).

### Verification
`cargo fmt` · `clippy -D warnings` · `cargo test` (1475 pass) · coherence / lock-audit / verify-changelog green. `dead_metric_detector` (handle live) + `metric_labels_gate` (registry label enum-typed) green.

Follow-up (concentric v2): distinguish a would-have-been-proxied-upstream refusal (a real dependency-confusion probe) from a benign hosted not-found.
