### PR TITLE
fix: scrub slash-escaped upstream URL from ansible/nuget rewrites (#385)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -46,3 +46,8 @@ doc = false
 name = "fuzz_url_leak"
 path = "fuzz_targets/fuzz_url_leak.rs"
 doc = false
+
+[[bin]]
+name = "fuzz_rewrite_ansible"
+path = "fuzz_targets/fuzz_rewrite_ansible.rs"
+doc = false

--- a/fuzz/fuzz_targets/fuzz_rewrite_ansible.rs
+++ b/fuzz/fuzz_targets/fuzz_rewrite_ansible.rs
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 The NORA Authors
+// SPDX-License-Identifier: MIT
+#![no_main]
+//! #385: the ansible raw-JSON URL rewrite must never leak the configured upstream
+//! URL into client-facing output — neither the plain `https://host` form nor the
+//! JSON slash-escaped `https:\/\/host` form that dodges a naive `.replace()`. Feeds
+//! arbitrary text through `rewrite_ansible_urls` (which has a catch-all, so every
+//! occurrence of the exact upstream URL is rewritten) and asserts neither form
+//! survives. Run: `cargo +nightly fuzz run fuzz_rewrite_ansible`.
+//!
+//! NB: the invariant is on the exact upstream URL, not the bare host — arbitrary
+//! fuzz bytes may contain the bare host without it being a rewrite failure.
+use libfuzzer_sys::fuzz_target;
+use nora_registry::rewrite_fuzz::rewrite_ansible_urls;
+
+const UPSTREAM: &str = "https://origin-host.invalid";
+const NORA_BASE: &str = "http://nora.test";
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(text) = std::str::from_utf8(data) {
+        let out = rewrite_ansible_urls(text, UPSTREAM, NORA_BASE);
+        assert!(
+            !out.contains(UPSTREAM),
+            "plain upstream URL leaked through ansible rewrite (#385)"
+        );
+        let escaped = UPSTREAM.replace('/', "\\/");
+        assert!(
+            !out.contains(&escaped),
+            "slash-escaped upstream URL leaked through ansible rewrite (#385)"
+        );
+    }
+});

--- a/nora-registry/src/lib.rs
+++ b/nora-registry/src/lib.rs
@@ -325,3 +325,111 @@ pub mod version_fuzz {
         Some(version.to_string())
     }
 }
+
+/// Re-export of the escape-aware raw-JSON URL rewrites for fuzz targets (#385).
+///
+/// These MIRROR the private `registry::{ansible,nuget}` rewrites, which live in the
+/// binary crate and are unreachable from this library — so a fuzz-friendly copy is
+/// the only option (same constraint as `npm_fuzz`). The *real* functions are enforced
+/// on every CI run by their in-module `#[cfg(test)]` leak tests; these byte-faithful
+/// copies let `cargo fuzz` explore the encoding-space for new dodge forms. A finding
+/// here must be reproduced against the real function before it counts.
+pub mod rewrite_fuzz {
+    /// Mirror of `registry::replace_url_escape_aware`.
+    fn replace_url_escape_aware(text: &str, from: &str, to: &str) -> String {
+        let plain = text.replace(from, to);
+        let esc_from = from.replace('/', "\\/");
+        if !plain.contains(&esc_from) {
+            return plain;
+        }
+        let esc_to = to.replace('/', "\\/");
+        plain.replace(&esc_from, &esc_to)
+    }
+
+    /// Mirror of `registry::ansible::rewrite_ansible_urls`.
+    pub fn rewrite_ansible_urls(json_text: &str, upstream_url: &str, base_url: &str) -> String {
+        const API_PREFIX: &str = "/api/v3/plugin/ansible/content/published/collections/index";
+        let upstream = upstream_url.trim_end_matches('/');
+        let base = base_url.trim_end_matches('/');
+        let nora_ansible = format!("{}/ansible", base);
+        let s = replace_url_escape_aware(
+            json_text,
+            &format!("{}/download/", upstream),
+            &format!("{}/download/", nora_ansible),
+        );
+        let s = replace_url_escape_aware(
+            &s,
+            &format!(
+                "{}/api/v3/plugin/ansible/content/published/collections/artifacts/",
+                upstream
+            ),
+            &format!("{}/download/", nora_ansible),
+        );
+        let s = replace_url_escape_aware(
+            &s,
+            &format!("{}{}/", upstream, API_PREFIX),
+            &format!("{}/v3/collections/", nora_ansible),
+        );
+        replace_url_escape_aware(&s, upstream, &nora_ansible)
+    }
+
+    /// Mirror of `registry::nuget::rewrite_registration_urls`.
+    pub fn rewrite_registration_urls(
+        json_text: &str,
+        upstream_url: &str,
+        base_url: &str,
+    ) -> String {
+        let upstream = upstream_url.trim_end_matches('/');
+        let nora_nuget = format!("{}/nuget", base_url.trim_end_matches('/'));
+        let nora_reg = format!("{}/v3/registration/", nora_nuget);
+        let s = replace_url_escape_aware(
+            json_text,
+            &format!("{}/v3/registration5-semver1/", upstream),
+            &nora_reg,
+        );
+        let s = replace_url_escape_aware(
+            &s,
+            &format!("{}/v3/registration5-gz-semver1/", upstream),
+            &nora_reg,
+        );
+        let s = replace_url_escape_aware(
+            &s,
+            &format!("{}/v3/registration5-gz-semver2/", upstream),
+            &nora_reg,
+        );
+        replace_url_escape_aware(
+            &s,
+            &format!("{}/v3-flatcontainer/", upstream),
+            &format!("{}/v3/flatcontainer/", nora_nuget),
+        )
+    }
+
+    #[cfg(test)]
+    mod url_leak_tests {
+        //! Deterministic front-loop cases (no fuzz CI job) — the fuzz targets
+        //! `fuzz_rewrite_ansible` / `fuzz_rewrite_nuget` explore the rest.
+        use super::*;
+        const UP: &str = "https://origin-host.invalid";
+        const NORA: &str = "http://nora.test";
+
+        #[test]
+        fn ansible_escaped_slash_scrubbed() {
+            let out = rewrite_ansible_urls(
+                r#"{"d":"https:\/\/origin-host.invalid\/download\/a.tar.gz"}"#,
+                UP,
+                NORA,
+            );
+            assert!(!out.contains("origin-host.invalid"), "leak: {out}");
+        }
+
+        #[test]
+        fn nuget_escaped_slash_scrubbed() {
+            let out = rewrite_registration_urls(
+                r#"{"@id":"https:\/\/origin-host.invalid\/v3\/registration5-semver1\/p\/i.json"}"#,
+                UP,
+                NORA,
+            );
+            assert!(!out.contains("origin-host.invalid"), "leak: {out}");
+        }
+    }
+}

--- a/nora-registry/src/registry/ansible.rs
+++ b/nora-registry/src/registry/ansible.rs
@@ -695,28 +695,33 @@ fn rewrite_ansible_urls(json_text: &str, upstream_url: &str, base_url: &str) -> 
     let upstream = upstream_url.trim_end_matches('/');
     let base = base_url.trim_end_matches('/');
     let nora_ansible = format!("{}/ansible", base);
+    // Each mapping is escape-aware (plain + `\/`-escaped) so a slash-escaped upstream
+    // URL cannot survive and leak the host to the client (#385).
+    use super::replace_url_escape_aware as rw;
 
-    json_text
-        // Most specific first: download URLs
-        .replace(
-            &format!("{}/download/", upstream),
-            &format!("{}/download/", nora_ansible),
-        )
-        // Artifact URLs → download path (#438)
-        .replace(
-            &format!(
-                "{}/api/v3/plugin/ansible/content/published/collections/artifacts/",
-                upstream
-            ),
-            &format!("{}/download/", nora_ansible),
-        )
-        // Pulp-style API paths → short v3 paths
-        .replace(
-            &format!("{}{}/", upstream, API_PREFIX),
-            &format!("{}/v3/collections/", nora_ansible),
-        )
-        // Catch-all: any remaining upstream references
-        .replace(upstream, &nora_ansible)
+    // Most specific first: download URLs
+    let s = rw(
+        json_text,
+        &format!("{}/download/", upstream),
+        &format!("{}/download/", nora_ansible),
+    );
+    // Artifact URLs → download path (#438)
+    let s = rw(
+        &s,
+        &format!(
+            "{}/api/v3/plugin/ansible/content/published/collections/artifacts/",
+            upstream
+        ),
+        &format!("{}/download/", nora_ansible),
+    );
+    // Pulp-style API paths → short v3 paths
+    let s = rw(
+        &s,
+        &format!("{}{}/", upstream, API_PREFIX),
+        &format!("{}/v3/collections/", nora_ansible),
+    );
+    // Catch-all: any remaining upstream references
+    rw(&s, upstream, &nora_ansible)
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -823,6 +828,36 @@ fn is_safe_filename(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #385: a slash-escaped upstream URL (`https:\/\/host` — valid JSON many
+    /// origins emit) must not survive the raw-text rewrite and leak the host.
+    #[test]
+    fn rewrite_ansible_drops_upstream_host_plain_and_escaped() {
+        const HOST: &str = "galaxy.ansible.com";
+        let upstream = "https://galaxy.ansible.com";
+        let base = "http://nora.test";
+
+        let plain = rewrite_ansible_urls(
+            r#"{"download_url":"https://galaxy.ansible.com/download/x/a.tar.gz"}"#,
+            upstream,
+            base,
+        );
+        assert!(!plain.contains(HOST), "plain upstream host leaked: {plain}");
+
+        let escaped = rewrite_ansible_urls(
+            r#"{"download_url":"https:\/\/galaxy.ansible.com\/download\/x\/a.tar.gz"}"#,
+            upstream,
+            base,
+        );
+        assert!(
+            !escaped.contains(HOST),
+            "slash-escaped upstream host leaked (#385): {escaped}"
+        );
+        assert!(
+            escaped.contains("nora.test"),
+            "escaped url not rewritten to nora base: {escaped}"
+        );
+    }
 
     #[test]
     fn test_valid_names() {

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -50,6 +50,27 @@ pub(crate) fn method_not_allowed(allow: &'static str) -> Response {
     (StatusCode::METHOD_NOT_ALLOWED, [(header::ALLOW, allow)]).into_response()
 }
 
+/// Replace `from`→`to` in raw JSON text, matching BOTH the plain form and the
+/// JSON slash-escaped form (`\/`) of `from`.
+///
+/// Raw-text registry rewrites (ansible, nuget) `.replace()` on the unparsed
+/// upstream response. A valid JSON escaping that many origins emit —
+/// `"https:\/\/host\/path"` — dodges a plain `https://host/path` needle, so the
+/// upstream URL survives the rewrite and leaks the host once the client's JSON
+/// parser unescapes `\/`→`/` (#385, class of #377/#379/#380/#381). Handling the
+/// `\/` form here closes that. NB: `\uXXXX`-escaped separators are a documented
+/// residual — see `rewrite-drops-upstream-host` — caught by the runtime
+/// `UPSTREAM_URL_LEAK_TOTAL` detector, not by this string pass.
+pub(crate) fn replace_url_escape_aware(text: &str, from: &str, to: &str) -> String {
+    let plain = text.replace(from, to);
+    let esc_from = from.replace('/', "\\/");
+    if !plain.contains(&esc_from) {
+        return plain;
+    }
+    let esc_to = to.replace('/', "\\/");
+    plain.replace(&esc_from, &esc_to)
+}
+
 /// Build NORA base URL from config (for URL rewriting).
 ///
 /// Thin wrapper over [`ServerConfig::public_base_url`] — the single source of

--- a/nora-registry/src/registry/nuget.rs
+++ b/nora-registry/src/registry/nuget.rs
@@ -1532,23 +1532,30 @@ fn rewrite_registration_urls(json_text: &str, upstream_url: &str, base_url: &str
     // catalog0 URLs (catalogEntry.@id) are intentionally left as-is: Nora has
     // no catalog handler, and NuGet clients do not fetch these during restore.
     // Rewriting them would produce Nora URLs that 404.
-    json_text
-        .replace(
-            &format!("{}/v3/registration5-semver1/", upstream),
-            &nora_reg,
-        )
-        .replace(
-            &format!("{}/v3/registration5-gz-semver1/", upstream),
-            &nora_reg,
-        )
-        .replace(
-            &format!("{}/v3/registration5-gz-semver2/", upstream),
-            &nora_reg,
-        )
-        .replace(
-            &format!("{}/v3-flatcontainer/", upstream),
-            &format!("{}/v3/flatcontainer/", nora_nuget),
-        )
+    // Each mapping is escape-aware (plain + `\/`-escaped) so a slash-escaped upstream
+    // registration/flatcontainer URL cannot survive and leak the host — sending the
+    // client back to the origin, past Nora — after the client unescapes `\/` (#385).
+    use super::replace_url_escape_aware as rw;
+    let s = rw(
+        json_text,
+        &format!("{}/v3/registration5-semver1/", upstream),
+        &nora_reg,
+    );
+    let s = rw(
+        &s,
+        &format!("{}/v3/registration5-gz-semver1/", upstream),
+        &nora_reg,
+    );
+    let s = rw(
+        &s,
+        &format!("{}/v3/registration5-gz-semver2/", upstream),
+        &nora_reg,
+    );
+    rw(
+        &s,
+        &format!("{}/v3-flatcontainer/", upstream),
+        &format!("{}/v3/flatcontainer/", nora_nuget),
+    )
 }
 
 /// Validate NuGet version string for use in URL path construction.
@@ -1604,6 +1611,36 @@ fn is_safe_path(path: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// #385: a slash-escaped upstream registration URL must not survive the
+    /// raw-text rewrite — otherwise the client, after unescaping `\/`, is sent
+    /// back to the origin past Nora (host leak + air-gap bypass).
+    #[test]
+    fn rewrite_nuget_registration_drops_upstream_host_plain_and_escaped() {
+        const HOST: &str = "api.nuget.org";
+        let upstream = "https://api.nuget.org";
+        let base = "http://nora.test";
+
+        let plain = rewrite_registration_urls(
+            r#"{"@id":"https://api.nuget.org/v3/registration5-semver1/pkg/index.json"}"#,
+            upstream,
+            base,
+        );
+        assert!(
+            !plain.contains(HOST),
+            "plain registration host leaked: {plain}"
+        );
+
+        let escaped = rewrite_registration_urls(
+            r#"{"@id":"https:\/\/api.nuget.org\/v3\/registration5-semver1\/pkg\/index.json"}"#,
+            upstream,
+            base,
+        );
+        assert!(
+            !escaped.contains(HOST),
+            "slash-escaped registration host leaked (#385): {escaped}"
+        );
+    }
 
     #[test]
     fn test_valid_package_ids() {


### PR DESCRIPTION
Closes #385 (and fixes a real leak it surfaced).

Adding fuzz coverage for the Type-A registry rewrites (#385) surfaced a genuine **upstream-host leak** — so this is a security fix plus the requested fuzz/test infrastructure.

### The leak

`rewrite_ansible_urls` and `rewrite_registration_urls` (nuget) rewrite the **unparsed** upstream JSON with chained `.replace("https://host", …)`. A valid JSON escaping that many origins emit — `"https:\/\/host\/path"` — does not match the plain needle, so the upstream URL **survives the rewrite**. Once the client's JSON parser unescapes `\/`→`/`, the client is sent back to the origin **past NORA**: upstream-host disclosure + air-gap / curation bypass. Class of #377/#379/#380/#381.

Confirmed live: ansible leaked `https:\/\/galaxy.ansible.com` (rewritten output still contained the host). npm/pub_dart round-trip through `serde` (which canonicalizes escapes) and are structurally immune; nuget intentionally leaves `catalog0` URLs on upstream (clients never fetch them during restore).

### Fix

`registry::replace_url_escape_aware(text, from, to)` replaces **both** the plain and the `\/`-escaped form; every ansible/nuget URL mapping routes through it.

**Accepted residual** (documented, not silent): `\uXXXX`- and percent-encoded separators (`/`, `%2F`) still dodge the string pass — rare (origins don't unicode/percent-escape ASCII slashes in URLs) and caught by the runtime `UPSTREAM_URL_LEAK_TOTAL` detector (defense-in-depth). **Upgrade path**: parse + re-serialize like npm/pub_dart (serde canonicalizes *all* escapes) — deferred (bigger rewrite of the two functions).

### Enforcement (#385)

- **Real-code leak tests** (the teeth, every CI): `rewrite_ansible_drops_upstream_host_plain_and_escaped`, `rewrite_nuget_registration_drops_upstream_host_plain_and_escaped` — on the actual functions.
- **`fuzz_rewrite_ansible`** cargo-fuzz target (registered) — ansible has a catch-all, so the exact-URL (plain + escaped) invariant is clean and generically fuzzable.
- **`lib::rewrite_fuzz`** — byte-faithful mirrors (the real fns live in the binary crate, unreachable from the lib — same constraint as `npm_fuzz`) + deterministic cases.
- **No `fuzz_rewrite_nuget`**: nuget's rewrite is *conditional* (catalog passthrough by design), so a generic byte-fuzz "no upstream URL" invariant is ill-defined; the deterministic tests are its enforcement.

### Verification
`cargo fmt` · `clippy -D warnings` · `cargo test` (1477 lib+bin, +2 real-code, +2 mirror) · coherence / lock-audit / verify-changelog green.

Follow-up: `fuzz_rewrite_terraform` / `fuzz_rewrite_pub_dart` (both parse JSON → immune, regression-guard-only) to fully tick #385's 5-target checklist; and the parse-based robust upgrade for ansible/nuget.
