### PR TITLE
ci: reland large PRs without hitting jq ARG_MAX (#825)

### DIFF
--- a/.github/workflows/auto-reland.yml
+++ b/.github/workflows/auto-reland.yml
@@ -91,27 +91,18 @@ jobs:
             echo "::error::merge conflict with $BASE_REF"; exit 1
           fi
 
-          # Build the FileChanges payload for createCommitOnBranch.
-          # --no-renames → renames appear as delete-old + add-new (simplest correct form).
-          additions='[]'; deletions='[]'
-          while IFS=$'\t' read -r status path; do
-            case "$status" in
-              D)
-                # shellcheck disable=SC2016  # $p is a jq variable, not shell
-                deletions=$(jq -c --arg p "$path" '. + [{path:$p}]' <<<"$deletions")
-                ;;
-              A|M)
-                b64=$(base64 -w0 "$path")
-                # shellcheck disable=SC2016  # $p/$c are jq variables, not shell
-                additions=$(jq -c --arg p "$path" --arg c "$b64" '. + [{path:$p, contents:$c}]' <<<"$additions")
-                ;;
-              *)
-                echo "::error::unexpected status '$status' for '$path'"; exit 1
-                ;;
-            esac
-          done < <(git diff --cached --no-renames --name-status)
-
-          file_changes=$(jq -c -n --argjson a "$additions" --argjson d "$deletions" '{additions:$a, deletions:$d}')
+          # Build the createCommitOnBranch FileChanges from the staged tree.
+          # File contents stream through temp files into jq (see the builder
+          # script), never through argv — a large PR would otherwise exceed
+          # MAX_ARG_STRLEN (128 KiB/arg) and abort (#825). The builder also
+          # rejects an empty diff so a reland can't silently land nothing (#798).
+          work=$(mktemp -d)
+          if ! ./scripts/reland-build-filechanges.sh "$work/file_changes.json"; then
+            git merge --abort 2>/dev/null || true
+            gh pr comment "$PR" --repo "$REPO" \
+              --body "🤖 Auto-reland aborted: could not build a non-empty FileChanges payload from the squashed diff (empty diff or unexpected status — guards #798). Rebase onto \`$BASE_REF\` and re-add the \`reland\` label."
+            echo "::error::reland FileChanges build failed"; exit 1
+          fi
 
           # Create the reland branch at base HEAD.
           branch="reland/pr-$PR"
@@ -120,11 +111,15 @@ jobs:
           # createCommitOnBranch → GitHub web-flow signs the commit (verified).
           headline="$PR_TITLE"
           body=$(printf 'Relands #%s.\n\nCo-authored-by: %s <%s>' "$PR" "$a_name" "$a_email")
-          payload=$(jq -c -n \
+          # Read FileChanges from the file via --slurpfile so the (potentially
+          # large) base64 contents never pass through argv either.
+          jq -c -n \
             --arg repo "$REPO" --arg br "$branch" --arg oid "$base_sha" \
-            --arg hl "$headline" --arg bd "$body" --argjson fc "$file_changes" \
-            '{query:"mutation($repo:String!,$br:String!,$oid:GitObjectID!,$hl:String!,$bd:String!,$fc:FileChanges!){createCommitOnBranch(input:{branch:{repositoryNameWithOwner:$repo,branchName:$br},expectedHeadOid:$oid,message:{headline:$hl,body:$bd},fileChanges:$fc}){commit{oid url}}}",variables:{repo:$repo,br:$br,oid:$oid,hl:$hl,bd:$bd,fc:$fc}}')
-          commit_url=$(echo "$payload" | gh api graphql --input - --jq '.data.createCommitOnBranch.commit.url')
+            --arg hl "$headline" --arg bd "$body" \
+            --slurpfile fc "$work/file_changes.json" \
+            '{query:"mutation($repo:String!,$br:String!,$oid:GitObjectID!,$hl:String!,$bd:String!,$fc:FileChanges!){createCommitOnBranch(input:{branch:{repositoryNameWithOwner:$repo,branchName:$br},expectedHeadOid:$oid,message:{headline:$hl,body:$bd},fileChanges:$fc}){commit{oid url}}}",variables:{repo:$repo,br:$br,oid:$oid,hl:$hl,bd:$bd,fc:$fc[0]}}' \
+            >"$work/payload.json"
+          commit_url=$(gh api graphql --input "$work/payload.json" --jq '.data.createCommitOnBranch.commit.url')
           echo "Signed reland commit: $commit_url"
 
           # Open the reland PR (created with RELAND_TOKEN → required checks run).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
         run: ./scripts/coherence-check.sh
       - name: Verify changelog claims
         run: ./scripts/verify-changelog.sh
+      - name: Reland FileChanges builder — large-PR regression
+        run: ./scripts/test-reland-filechanges.sh
 
   test:
     name: Test

--- a/scripts/reland-build-filechanges.sh
+++ b/scripts/reland-build-filechanges.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Build the GitHub GraphQL `createCommitOnBranch` FileChanges object from the
+# currently staged tree (the result of `git merge --squash <pr-head>` in
+# auto-reland.yml) and write it as JSON to $1.
+#
+# Why a script instead of inline YAML: file contents are streamed through temp
+# files and read into jq with --rawfile / --slurpfile, NEVER passed as
+# command-line arguments. The previous inline builder did
+# `jq --arg c "$base64_of_whole_file"`, and a single argv string is capped at
+# MAX_ARG_STRLEN (128 KiB on Linux); a large PR (the RPM registry, #825) blew
+# past it with "Argument list too long" and the reland failed. Reading from
+# files has no such limit.
+#
+# Exits non-zero on an empty diff: a reland that stages nothing would land an
+# empty commit and silently drop the reviewed diff (the #798 incident).
+set -euo pipefail
+
+out="${1:?usage: reland-build-filechanges.sh <out.json>}"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+: >"$work/additions.jsonl"
+: >"$work/deletions.jsonl"
+
+# --no-renames → a rename shows up as delete-old + add-new (simplest correct form).
+while IFS=$'\t' read -r status path; do
+  case "$status" in
+    D)
+      # shellcheck disable=SC2016  # $p is a jq variable, not a shell one
+      jq -cn --arg p "$path" '{path: $p}' >>"$work/deletions.jsonl"
+      ;;
+    A | M)
+      # base64 to a file (strip the trailing newline base64(1) appends), then
+      # read it back with --rawfile so the content never touches argv.
+      base64 -w0 "$path" | tr -d '\n' >"$work/b64"
+      # shellcheck disable=SC2016  # $p/$c are jq variables, not shell ones
+      jq -cn --arg p "$path" --rawfile c "$work/b64" '{path: $p, contents: $c}' \
+        >>"$work/additions.jsonl"
+      ;;
+    *)
+      echo "reland-build-filechanges: unexpected status '$status' for '$path'" >&2
+      exit 1
+      ;;
+  esac
+done < <(git diff --cached --no-renames --name-status)
+
+if [ ! -s "$work/additions.jsonl" ] && [ ! -s "$work/deletions.jsonl" ]; then
+  echo "reland-build-filechanges: empty diff — refusing to build an empty reland (guards #798)" >&2
+  exit 2
+fi
+
+# --slurpfile reads the newline-delimited objects from each file into an array.
+jq -c -n \
+  --slurpfile a "$work/additions.jsonl" \
+  --slurpfile d "$work/deletions.jsonl" \
+  '{additions: $a, deletions: $d}' >"$out"

--- a/scripts/test-reland-filechanges.sh
+++ b/scripts/test-reland-filechanges.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Regression test for scripts/reland-build-filechanges.sh.
+#
+# Guards the auto-reland ARG_MAX bug (#825): a staged file whose base64 is well
+# past MAX_ARG_STRLEN (128 KiB/arg) must still produce a valid FileChanges
+# payload that round-trips. If anyone reverts the builder to passing contents
+# through `jq --arg`, this test fails with "Argument list too long".
+# Also checks the empty-diff guard (#798).
+set -euo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+builder="$here/reland-build-filechanges.sh"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# --- large + small file build and round-trip ---------------------------------
+repo="$(mktemp -d)"
+trap 'rm -rf "$repo"' EXIT
+git -C "$repo" init -q
+git -C "$repo" config user.email t@example.com
+git -C "$repo" config user.name test
+git -C "$repo" commit -q --allow-empty -m base
+
+# 512 KiB → base64 ≈ 683 KiB, over 5× the 128 KiB single-arg limit.
+head -c 524288 /dev/zero | tr '\0' 'A' >"$repo/big.txt"
+printf 'hello\n' >"$repo/small.txt"
+git -C "$repo" add big.txt small.txt
+
+out="$repo/fc.json"
+( cd "$repo" && "$builder" "$out" ) || fail "builder errored on a large staged file"
+
+jq -e . "$out" >/dev/null || fail "output is not valid JSON"
+n=$(jq '.additions | length' "$out")
+[ "$n" = 2 ] || fail "expected 2 additions, got $n"
+jq -r '.additions[] | select(.path=="big.txt") | .contents' "$out" \
+  | base64 -d | cmp -s - "$repo/big.txt" \
+  || fail "big.txt content did not round-trip through base64"
+echo "PASS: large-file FileChanges builds and round-trips ($(wc -c <"$out") bytes JSON)"
+
+# --- empty diff must be rejected (#798) --------------------------------------
+empty="$(mktemp -d)"
+git -C "$empty" init -q
+git -C "$empty" config user.email t@example.com
+git -C "$empty" config user.name test
+git -C "$empty" commit -q --allow-empty -m base
+if ( cd "$empty" && "$builder" "$empty/fc.json" ) 2>/dev/null; then
+  fail "empty diff should have been rejected"
+fi
+echo "PASS: empty diff rejected (#798 guard)"


### PR DESCRIPTION
## What

`auto-reland.yml` failed on large PRs. It built the GraphQL `createCommitOnBranch` `FileChanges` object by passing each file's base64 through `jq --arg` / `--argjson`. A single command-line argument is capped at `MAX_ARG_STRLEN` (128 KiB on Linux), so once a PR's staged content exceeded that, the reland step aborted with:

```
/usr/bin/jq: Argument list too long
##[error]Process completed with exit code 126
```

and no signed reland commit was created. The RPM registry PR (#825) is the first PR large enough to trip this; the Debian/APT PR (#827) would hit it too.

## Fix

- Move the FileChanges builder into `scripts/reland-build-filechanges.sh`. File contents are streamed through temp files and read into jq with `--rawfile` / `--slurpfile` — they never pass through argv, so there is no per-argument size limit. The mutation payload is assembled the same way (`--slurpfile`), not `--argjson`.
- The builder also refuses an empty staged diff (exit 2), so a reland can never land an empty commit and silently drop the reviewed diff.
- `scripts/test-reland-filechanges.sh` exercises the builder against a 512 KiB file (5× the arg limit) with a base64 round-trip assertion, plus the empty-diff case, and runs in the Coherence CI job so a regression can't return unnoticed.

## Verify

- Reproduced the original failure: `jq --arg c "$(base64 -w0 <512KiB file>)"` → `Argument list too long`, exit 126 (same as the CI log).
- New builder produces a valid ~683 KiB FileChanges JSON that round-trips through base64; empty diff rejected.
- `shellcheck` clean, `yamllint` clean, coherence check passes; regression test passes locally.

Unblocks the `reland` flow for #825 and #827.
