### PR TITLE
ci: auto-reland surfaces real merge error instead of masking as conflict

### DIFF
--- a/.github/workflows/auto-reland.yml
+++ b/.github/workflows/auto-reland.yml
@@ -87,11 +87,24 @@ jobs:
           # NB: clean up with `git reset --hard`, not `git merge --abort` —
           # `--squash` never records MERGE_HEAD, so `--abort` always fails
           # ("no merge to abort") and masks the real error in the log.
-          if ! git merge --squash pr-head >/dev/null 2>&1; then
+          # `-c merge.ff=true`: a runner/global `merge.ff=false` makes
+          # `git merge --squash` fatal ("cannot combine --squash with --no-ff"),
+          # which is NOT a content conflict — force ff so squash always parses.
+          # Capture the output instead of `>/dev/null 2>&1`: masking it made every
+          # failure (fatal invocation, dirty tree, real conflict) read as the same
+          # "merge conflict", sending contributors to rebase a branch that already
+          # merges clean. Surface the git output and name the true cause.
+          if ! merge_out=$(git -c merge.ff=true merge --squash pr-head 2>&1); then
+            if git ls-files -u | grep -q .; then
+              reason="content conflict with \`$BASE_REF\` — rebase onto \`$BASE_REF\`"
+            else
+              reason="merge could not run (not a content conflict); see the git output"
+            fi
+            echo "::group::git merge --squash output"; echo "$merge_out"; echo "::endgroup::"
             git reset -q --hard HEAD 2>/dev/null || true
             gh pr comment "$PR" --repo "$REPO" \
-              --body "🤖 Auto-reland aborted: this branch conflicts with \`$BASE_REF\`. Rebase onto \`$BASE_REF\` and re-add the \`reland\` label."
-            echo "::error::merge conflict with $BASE_REF"; exit 1
+              --body "$(printf '🤖 Auto-reland aborted: %s. Then re-add the `reland` label.\n\n<details><summary>git merge --squash output</summary>\n\n```\n%s\n```\n</details>' "$reason" "$merge_out")"
+            echo "::error::auto-reland merge failed: $reason"; exit 1
           fi
 
           # Build the createCommitOnBranch FileChanges from the staged tree.


### PR DESCRIPTION
## What & why

Auto-reland (`auto-reland.yml`) ran `git merge --squash pr-head >/dev/null 2>&1` and, on **any** non-zero exit, always printed `::error::merge conflict with main` and told the contributor to rebase. That conflates three unrelated failures — a fatal invocation (`merge.ff=false` → "cannot combine --squash with --no-ff"), a dirty tree, and a real content conflict — and misdirects.

**Incident (#827):** the reland aborted with "merge conflict" while GitHub reported `mergeable: true` and a pristine-config `git merge --squash` was clean (2 A + 26 M, 0 unmerged). The real cause was hidden by the suppressed stderr.

## Changes
- Drop `>/dev/null 2>&1` on the merge — surface the `git merge` output in a log group (`::group`) and in the abort comment (`<details>`).
- Distinguish causes: `git ls-files -u` non-empty → real content conflict (rebase); empty → "merge could not run (not a content conflict); see the git output".
- Invoke ff-robust (`-c merge.ff=true`) so a `merge.ff=false` config can't fatally abort the squash.

Validated: YAML parses, `bash -n` of the step is clean.

> Note: this primarily restores diagnosability. The true cause of the #827 merge failure will surface on the next reland run, in the log/comment.
