### PR TITLE
docs(ci): note that excluded/non-instrumented paths are ungated in diff-coverage

### DIFF
--- a/scripts/diff-coverage.py
+++ b/scripts/diff-coverage.py
@@ -28,6 +28,13 @@ Only changed lines that carry a ``DA:`` record are counted — non-instrumentabl
 lines (comments, item declarations, ``use`` statements) are ignored, matching
 the behaviour of diff-cover style tools. A changed line with ``DA:<line>,0`` is
 uncovered; ``DA:<line>,<n>`` with ``n > 0`` is covered.
+
+Scope note (ungated by design): the gate can only see lines tarpaulin
+instruments. Changes in the ``exclude-files`` of ``tarpaulin.toml``
+(e.g. ``nora-registry/src/ui/*``, ``main.rs``, ``openapi.rs``) and any
+``#[cfg(...)]``-gated code not built in the coverage profile produce no ``DA:``
+record, so they contribute zero instrumentable lines and are **not** gated by
+this check — the whole-repo ``coverage`` job remains their only floor.
 """
 
 import argparse


### PR DESCRIPTION
Small docs-only follow-up on `scripts/diff-coverage.py`.

The diff-coverage check excludes a few paths from its ratio (UI templates,
`main.rs`, `openapi.rs`) and can't see lines that are compiled out by `#[cfg]`
at the configuration it runs under. That scoping is deliberate, but it wasn't
written down — so a reader could mistake an excluded or compiled-out file for
"0% covered", or assume every changed line is measured.

This adds a short "Scope note" paragraph to the module docstring that spells out
which paths are ungated. No behavior change.

Thanks to @01luyicheng for the original diff-coverage gate.
