### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-13
+
 ### Security
 - **The browse web UI is now gated on a private deployment.** With auth enabled and `anonymous_read` off, the UI, its JSON API (`/ui`, `/api/ui`), and the API docs (`/api-docs`) were served without authentication — enumerating every repository and package a private registry exists to hide. They now require credentials unless `anonymous_read` (which already exposes the same names through the registry read APIs) or the new `auth.public_web_ui` (`NORA_AUTH_PUBLIC_WEB_UI`, default false) opens them; an unauthenticated request gets a Basic challenge so browsers prompt. Health/readiness probes stay unconditionally public. `/metrics` gets its own `auth.public_metrics` (`NORA_AUTH_PUBLIC_METRICS`, default **true** — scrapers rarely carry credentials and labels name registry formats, not repositories); set it false to gate metrics too. **Behavior change:** operators who relied on an anonymous web UI while keeping the registry APIs authenticated must set `public_web_ui = true` (or enable `anonymous_read`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ar",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "1.0.0",
+        version = "1.0.1",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, Conan, RPM, and Debian",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
Patch release over 1.0.0 — cuts `[Unreleased]` to `[1.0.1]`, bumps the workspace version (Cargo.toml / Cargo.lock / OpenAPI info).

Contents (all already on `main`):
- **Native Google Cloud Storage backend** (`storage.mode = "gcs"`) — #842
- **Streaming raw uploads and downloads** — bounded memory at any size — #845
- **rpm/deb repository reconcile** (`POST /{rpm,deb}/{repo}/-/reindex`) — #847

No code changes beyond the version bump and CHANGELOG.