### PR TITLE
fix: retention and GC schedulers run once at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Unreleased]
 
 ### Fixed
+- **Retention and GC schedulers run once at boot** — both schedulers used to wait a full interval before their first pass, so a process restarting more often than the interval (rolling deployments, crash loops) never ran either of them, accumulating unbounded garbage while the schedule looked configured. The interval's first tick now fires immediately, and the boot pass waits on the shared cleanup lock (instead of skip-if-held) so retention and GC don't race each other out of their first run.
 - **Cargo sparse index now advertises `auth-required` on private deployments** — with auth enabled and `anonymous_read` off, `/cargo/index/config.json` sets `"auth-required": true` (RFC 3139) so cargo sends credentials on index and download requests. Previously cargo only authenticated the publish API, and every sparse-index fetch against a private instance failed with 401 before publish even started.
 
 ### Added

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -835,8 +835,11 @@ pub fn spawn_gc_scheduler(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
-        // First tick fires immediately — skip it so GC doesn't run on startup
-        interval.tick().await;
+        // The interval's first tick fires immediately: GC runs once at boot,
+        // then every `interval_secs` — a process restarting more often than
+        // the interval otherwise never collects anything (see the matching
+        // note in `spawn_retention_scheduler`).
+        let mut boot_run = true;
 
         loop {
             // CANCEL-SAFETY: interval.tick() holds no state between polls.
@@ -854,12 +857,20 @@ pub fn spawn_gc_scheduler(
                 break;
             }
 
-            // Cross-scheduler lock: skip if GC or retention is already running
-            let guard = cleanup_lock.try_lock();
-            if guard.is_err() {
+            // Cross-scheduler lock: skip if GC or retention is already running.
+            // The boot run waits for the lock instead — retention's boot pass
+            // fires at the same instant, and skipping would postpone the first
+            // GC by a whole interval again.
+            let guard = if boot_run {
+                boot_run = false;
+                Ok(cleanup_lock.lock().await)
+            } else {
+                cleanup_lock.try_lock()
+            };
+            let Ok(guard) = guard else {
                 info!("GC: cleanup lock held (GC or retention running), skipping");
                 continue;
-            }
+            };
 
             info!("GC scheduler: starting periodic run");
             let result = run_gc(&storage, &publish_locks, dry_run, grace_secs).await;

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -1881,4 +1881,91 @@ mod tests {
         assert_eq!(result.deleted, 1);
         assert_eq!(result.metadata_phantoms_removed, 1); // npm phantom
     }
+
+    /// The scheduler must run once at boot, not a full interval later — a
+    /// process that restarts more often than the interval otherwise never
+    /// collects anything.
+    #[tokio::test]
+    async fn test_gc_scheduler_runs_at_boot() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+        // Orphan checksum sidecar: no primary artifact next to it.
+        storage
+            .put("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256", b"deadbeef")
+            .await
+            .unwrap();
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_gc_scheduler(
+            storage.clone(),
+            test_publish_locks(),
+            86400, // the boot run must not wait for this
+            false,
+            0,
+            Arc::new(tokio::sync::Mutex::new(())),
+            cancel.clone(),
+        );
+
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        while storage
+            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
+            .await
+            .is_ok()
+        {
+            assert!(Instant::now() < deadline, "boot run never fired");
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    /// The boot pass waits on the shared cleanup lock instead of the
+    /// periodic skip-if-held — losing the boot race to the sibling scheduler
+    /// must delay the first run, not forfeit it for a whole interval.
+    #[tokio::test]
+    async fn test_gc_boot_run_waits_for_cleanup_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+        storage
+            .put("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256", b"deadbeef")
+            .await
+            .unwrap();
+
+        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = cleanup_lock.clone().lock_owned().await;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_gc_scheduler(
+            storage.clone(),
+            test_publish_locks(),
+            86400,
+            false,
+            0,
+            cleanup_lock,
+            cancel.clone(),
+        );
+
+        // While the lock is held the boot pass must be parked, not skipped.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert!(storage
+            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
+            .await
+            .is_ok());
+
+        drop(held);
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        while storage
+            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
+            .await
+            .is_ok()
+        {
+            assert!(
+                Instant::now() < deadline,
+                "boot run skipped instead of waiting for the lock"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        cancel.cancel();
+        handle.await.unwrap();
+    }
 }

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -955,8 +955,12 @@ pub fn spawn_retention_scheduler(
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
-        // First tick fires immediately — skip it so retention doesn't run on startup
-        interval.tick().await;
+        // The interval's first tick fires immediately: retention runs once at
+        // boot, then every `interval_secs`. Waiting a full interval instead
+        // means a process that restarts more often than the interval NEVER
+        // runs retention — deploy-happy environments accumulated unbounded
+        // garbage exactly when the schedule looked configured.
+        let mut boot_run = true;
 
         loop {
             // CANCEL-SAFETY: Same as GC — interval.tick() is stateless between polls,
@@ -974,12 +978,20 @@ pub fn spawn_retention_scheduler(
                 break;
             }
 
-            // Cross-scheduler lock: skip if GC or retention is already running
-            let guard = cleanup_lock.try_lock();
-            if guard.is_err() {
+            // Cross-scheduler lock: skip if GC or retention is already running.
+            // The boot run waits for the lock instead — GC's boot pass fires at
+            // the same instant, and skipping here would silently postpone the
+            // first retention by a whole interval again.
+            let guard = if boot_run {
+                boot_run = false;
+                Ok(cleanup_lock.lock().await)
+            } else {
+                cleanup_lock.try_lock()
+            };
+            let Ok(guard) = guard else {
                 info!("Retention: cleanup lock held (GC or retention running), skipping");
                 continue;
-            }
+            };
 
             info!(
                 dry_run = dry_run,
@@ -1245,6 +1257,52 @@ mod tests {
             .get("maven/com/example/lib/3.0/lib-3.0.jar")
             .await
             .is_ok());
+    }
+
+    /// The scheduler must run once at boot, not a full interval later — a
+    /// process that restarts more often than the interval otherwise never
+    /// runs retention at all.
+    #[tokio::test]
+    async fn test_scheduler_runs_at_boot() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+        storage
+            .put("maven/com/test/a/1.0/a.jar", b"data")
+            .await
+            .unwrap();
+        storage
+            .put("maven/com/test/a/2.0/a.jar", b"data")
+            .await
+            .unwrap();
+
+        let rules = vec![RetentionRule {
+            registry: "maven".to_string(),
+            name_glob: None,
+            keep_last: Some(1),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_retention_scheduler(
+            storage.clone(),
+            test_publish_locks(),
+            None,
+            rules,
+            86400, // the boot run must not wait for this
+            false,
+            None,
+            Arc::new(tokio::sync::Mutex::new(())),
+            cancel.clone(),
+        );
+
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        while storage.get("maven/com/test/a/1.0/a.jar").await.is_ok() {
+            assert!(Instant::now() < deadline, "boot run never fired");
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        assert!(storage.get("maven/com/test/a/2.0/a.jar").await.is_ok());
+        cancel.cancel();
+        handle.await.unwrap();
     }
 
     #[tokio::test]

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -1305,6 +1305,62 @@ mod tests {
         handle.await.unwrap();
     }
 
+    /// The boot pass waits on the shared cleanup lock instead of the
+    /// periodic skip-if-held — losing the boot race to GC must delay the
+    /// first run, not forfeit it for a whole interval.
+    #[tokio::test]
+    async fn test_boot_run_waits_for_cleanup_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+        storage
+            .put("maven/com/test/a/1.0/a.jar", b"data")
+            .await
+            .unwrap();
+        storage
+            .put("maven/com/test/a/2.0/a.jar", b"data")
+            .await
+            .unwrap();
+
+        let rules = vec![RetentionRule {
+            registry: "maven".to_string(),
+            name_glob: None,
+            keep_last: Some(1),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = cleanup_lock.clone().lock_owned().await;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_retention_scheduler(
+            storage.clone(),
+            test_publish_locks(),
+            None,
+            rules,
+            86400,
+            false,
+            None,
+            cleanup_lock,
+            cancel.clone(),
+        );
+
+        // While the lock is held the boot pass must be parked, not skipped.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        assert!(storage.get("maven/com/test/a/1.0/a.jar").await.is_ok());
+
+        drop(held);
+        let deadline = Instant::now() + std::time::Duration::from_secs(10);
+        while storage.get("maven/com/test/a/1.0/a.jar").await.is_ok() {
+            assert!(
+                Instant::now() < deadline,
+                "boot run skipped instead of waiting for the lock"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
     #[tokio::test]
     async fn test_retention_dry_run_preserves() {
         let dir = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Both schedulers skipped the interval's immediate first tick, deferring their first pass by a full `interval_secs`. A process that restarts more often than the interval therefore **never** runs retention or GC at all — we hit this in production: six rolling deploys in 48h meant the 24h retention schedule never fired once, while ~190 GiB of expired CI-transport artifacts accumulated under a rule that looked correctly configured.

- The first tick now fires immediately: one pass at boot, then every `interval_secs`.
- The boot pass **waits** on the shared cleanup lock instead of the usual skip-if-held — retention's and GC's boot passes fire at the same instant, and skip-if-held would silently postpone whichever loses the race by a whole interval again (the exact failure mode this fixes). Periodic passes keep skip-if-held semantics.
- Regression test: scheduler spawned with a 24h interval must delete a dominated version within seconds of boot.

Boot-time work is bounded: both passes are no-ops when there's nothing to collect, and the cleanup lock serializes them.