### PR TITLE
fix: cancel the schedulers' boot pass while it waits on the cleanup lock

### DIFF
--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -863,7 +863,15 @@ pub fn spawn_gc_scheduler(
             // GC by a whole interval again.
             let guard = if boot_run {
                 boot_run = false;
-                Ok(cleanup_lock.lock().await)
+                // CANCEL-SAFETY: the boot pass waits on the lock (vs skip-if-held) so it
+                // can't forfeit its first run to retention's simultaneous boot pass — but
+                // race the wait against cancellation, so a SIGTERM during boot contention
+                // breaks promptly instead of blocking behind the sibling's whole pass.
+                // Dropping the not-yet-acquired lock() future only removes this waiter.
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    g = cleanup_lock.lock() => Ok(g),
+                }
             } else {
                 cleanup_lock.try_lock()
             };
@@ -1967,5 +1975,51 @@ mod tests {
         }
         cancel.cancel();
         handle.await.unwrap();
+    }
+
+    /// A shutdown requested while the boot pass is parked on the cleanup lock
+    /// must break promptly — not wait out the lock holder and then run a full
+    /// pass after cancellation was already requested.
+    #[tokio::test]
+    async fn test_gc_boot_run_cancels_while_parked() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+        // Orphan checksum sidecar the boot GC would collect if it ever ran.
+        storage
+            .put("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256", b"deadbeef")
+            .await
+            .unwrap();
+
+        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = cleanup_lock.clone().lock_owned().await;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_gc_scheduler(
+            storage.clone(),
+            test_publish_locks(),
+            86400,
+            false,
+            0,
+            cleanup_lock,
+            cancel.clone(),
+        );
+
+        // Let the boot pass reach the parked lock().await, then ask to stop.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        cancel.cancel();
+
+        // The scheduler must stop even though the lock is still held — the boot
+        // acquire races cancellation, so it can't block behind the holder.
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("scheduler did not stop when cancelled while parked on the boot lock")
+            .unwrap();
+
+        // It never acquired the lock, so it never collected the orphan.
+        assert!(storage
+            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
+            .await
+            .is_ok());
+        drop(held);
     }
 }

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -984,7 +984,15 @@ pub fn spawn_retention_scheduler(
             // first retention by a whole interval again.
             let guard = if boot_run {
                 boot_run = false;
-                Ok(cleanup_lock.lock().await)
+                // CANCEL-SAFETY: the boot pass waits on the lock (vs skip-if-held) so it
+                // can't forfeit its first run to GC's simultaneous boot pass — but race
+                // the wait against cancellation, so a SIGTERM during boot contention
+                // breaks promptly instead of blocking behind the sibling's whole pass.
+                // Dropping the not-yet-acquired lock() future only removes this waiter.
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    g = cleanup_lock.lock() => Ok(g),
+                }
             } else {
                 cleanup_lock.try_lock()
             };
@@ -1359,6 +1367,61 @@ mod tests {
         }
         cancel.cancel();
         handle.await.unwrap();
+    }
+
+    /// A shutdown requested while the boot pass is parked on the cleanup lock
+    /// must break promptly — not wait out the lock holder and then run a full
+    /// pass after cancellation was already requested.
+    #[tokio::test]
+    async fn test_retention_boot_run_cancels_while_parked() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+        storage
+            .put("maven/com/test/a/1.0/a.jar", b"data")
+            .await
+            .unwrap();
+        storage
+            .put("maven/com/test/a/2.0/a.jar", b"data")
+            .await
+            .unwrap();
+
+        let rules = vec![RetentionRule {
+            registry: "maven".to_string(),
+            name_glob: None,
+            keep_last: Some(1),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = cleanup_lock.clone().lock_owned().await;
+
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let handle = spawn_retention_scheduler(
+            storage.clone(),
+            test_publish_locks(),
+            None,
+            rules,
+            86400,
+            false,
+            None,
+            cleanup_lock,
+            cancel.clone(),
+        );
+
+        // Let the boot pass reach the parked lock().await, then ask to stop.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        cancel.cancel();
+
+        // The scheduler must stop even though the lock is still held — the boot
+        // acquire races cancellation, so it can't block behind the holder.
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("scheduler did not stop when cancelled while parked on the boot lock")
+            .unwrap();
+
+        // It never acquired the lock, so it never pruned the dominated version.
+        assert!(storage.get("maven/com/test/a/1.0/a.jar").await.is_ok());
+        drop(held);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #859. That change made the retention/GC boot pass **wait** on the shared cleanup lock (instead of skip-if-held) so the two schedulers' simultaneous boot passes can't knock each other out of their first run. The wait, however, sits outside the cancellation `select!`:

```rust
let guard = if boot_run {
    boot_run = false;
    Ok(cleanup_lock.lock().await)   // not raced against cancel
} else {
    cleanup_lock.try_lock()
};
```

So a `SIGTERM` that arrives while the *losing* scheduler is parked on the lock isn't observed until it acquires the lock and runs a full pass to completion (the pass isn't cancel-aware either). On a large store that pass can overrun the shutdown grace period (k8s default 30s) and be `SIGKILL`ed mid-pass. The pre-#859 `try_lock`-only path never initiated a pass after cancellation.

**Fix** — race the boot-lock acquisition against cancellation:

```rust
tokio::select! {
    _ = cancel.cancelled() => break,
    g = cleanup_lock.lock() => Ok(g),
}
```

On cancel the scheduler breaks out of its loop promptly instead of blocking behind the sibling's whole pass. Dropping the not-yet-acquired `lock()` future only removes the waiter, so it stays cancel-safe (noted in a `// CANCEL-SAFETY:` comment). Periodic passes are unchanged (`try_lock`).

**Tests** (`test_gc_boot_run_cancels_while_parked`, `test_retention_boot_run_cancels_while_parked`): with the cleanup lock held, a cancel issued while the boot pass is parked must stop the scheduler within seconds and never collect. Verified they hang to the 5s timeout on the unpatched boot path and pass with the fix. `cargo fmt --check` and `clippy --all-targets -D warnings` clean; the six boot tests pass.
