### PR TITLE
test(fuzz): exercise namespace_match in fuzz_validation target

### DIFF
--- a/fuzz/fuzz_targets/fuzz_validation.rs
+++ b/fuzz/fuzz_targets/fuzz_validation.rs
@@ -1,7 +1,8 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
 use nora_registry::validation::{
-    validate_digest, validate_docker_name, validate_docker_reference, validate_storage_key,
+    namespace_match, validate_digest, validate_docker_name, validate_docker_reference,
+    validate_storage_key,
 };
 
 fuzz_target!(|data: &str| {
@@ -10,4 +11,12 @@ fuzz_target!(|data: &str| {
     let _ = validate_docker_name(data);
     let _ = validate_digest(data);
     let _ = validate_docker_reference(data);
+
+    // #861: intra-segment `*` wildcards in namespace_scope patterns. The glob
+    // matcher must never panic, recurse to stack overflow, or blow up
+    // super-linearly on adversarial pattern×value pairs. Split on the first
+    // space to feed an independent pattern and value; otherwise exercise the
+    // whole input as both.
+    let (pattern, value) = data.split_once(' ').unwrap_or((data, data));
+    let _ = namespace_match(pattern, value);
 });


### PR DESCRIPTION
## What

`fuzz_validation` now feeds every input through `namespace_match` (the `namespace_scope` glob matcher), alongside the existing storage / docker / digest validators.

## Why

#861 added intra-segment `*` globbing to `namespace_scope` patterns (`segment_glob` — iterative single-star backtracking). The PR described the matcher as fuzzed, but `fuzz_validation` only ever reached `validate_storage_key` / `validate_docker_name` / `validate_digest` / `validate_docker_reference` — `namespace_match` was never actually exercised by the harness.

This closes that gap, so the "never panics, no stack overflow, no super-linear blow-up on adversarial `pattern` × `value`" property is enforced by the fuzzer rather than only asserted in prose and property tests.

## How

Split each input on the first space to get an independent `pattern` and `value`; with no space, use the whole input as both. Then call `namespace_match(pattern, value)` and discard the result — same no-panic contract as the other validators.

## Verification

- `rustfmt --check` clean
- `cargo +nightly fuzz build fuzz_validation` compiles
- 30s local run: ~194k execs, 0 crashes

Follow-up to #861.