### PR TITLE
fix(health): stop probing object storage from /health and /ready

### DIFF
--- a/nora-registry/src/health.rs
+++ b/nora-registry/src/health.rs
@@ -43,7 +43,7 @@ async fn health_check(State(state): State<AppState>) -> (StatusCode, Json<Health
     let status = if storage_reachable {
         "healthy"
     } else {
-        "unhealthy"
+        "degraded"
     };
 
     let uptime = state.start_time.elapsed().as_secs();
@@ -69,13 +69,12 @@ async fn health_check(State(state): State<AppState>) -> (StatusCode, Json<Health
         upstreams,
     };
 
-    let status_code = if storage_reachable {
-        StatusCode::OK
-    } else {
-        StatusCode::SERVICE_UNAVAILABLE
-    };
-
-    (status_code, Json(health))
+    // Always 200: /health is a liveness signal — the process is up and serving.
+    // Storage reachability is informational (`status: degraded`); gating liveness
+    // or the LB on it turns a storage blip into a restart loop / full 502 outage
+    // for every route, storage-backed or not (#869). Readiness (`/ready`) is the
+    // storage gate.
+    (StatusCode::OK, Json(health))
 }
 
 async fn readiness_check(State(state): State<AppState>) -> StatusCode {
@@ -187,6 +186,32 @@ mod tests {
 
         let size = json["storage"]["total_size_bytes"].as_u64().unwrap();
         assert_eq!(size, 0, "empty storage should report 0 bytes");
+    }
+
+    /// Storage unreachable → `/health` stays 200 (liveness = process up) and reports
+    /// `degraded`; `/ready` is the storage gate and goes 503 (#869).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_health_200_degraded_when_storage_unreachable() {
+        use std::os::unix::fs::PermissionsExt;
+        let ctx = create_test_context();
+        let dir = ctx._tempdir.path();
+        let mut perms = std::fs::metadata(dir).unwrap().permissions();
+        perms.set_mode(0o500);
+        std::fs::set_permissions(dir, perms).unwrap();
+
+        let health = send(&ctx.app, Method::GET, "/health", "").await;
+        assert_eq!(health.status(), StatusCode::OK);
+        let body = body_bytes(health).await;
+        assert!(std::str::from_utf8(&body).unwrap().contains("degraded"));
+
+        let ready = send(&ctx.app, Method::GET, "/ready", "").await;
+        assert_eq!(ready.status(), StatusCode::SERVICE_UNAVAILABLE);
+
+        // Restore write permission so TempDir::drop can clean up.
+        let mut perms = std::fs::metadata(dir).unwrap().permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(dir, perms).unwrap();
     }
 
     #[tokio::test]

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -1772,8 +1772,10 @@ async fn run_server(mut config: Config, storage: Storage) {
             registry::docker::cleanup_expired_sessions(&metrics_state.upload_sessions);
             metrics_state.auth_failures.cleanup();
 
-            // Every 60s (every other tick): refresh S3 total_size cache + storage gauge
-            if tick_count.is_multiple_of(2) {
+            // Every 60s (odd ticks — the interval's first tick fires immediately, so the
+            // boot pass runs right away: object-store reachability (#869) and the storage
+            // gauge are populated before the first readiness probe, not 30s in).
+            if !tick_count.is_multiple_of(2) {
                 metrics_state.storage.refresh_total_size_cache().await;
                 metrics::STORAGE_BYTES
                     .with_label_values(&["total"])

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -268,8 +268,7 @@ pub struct ErrorResponse {
     path = "/health",
     tag = "health",
     responses(
-        (status = 200, description = "Service is healthy", body = HealthResponse),
-        (status = 503, description = "Service is unhealthy", body = HealthResponse)
+        (status = 200, description = "Process is up; `status` field reports `healthy` or `degraded` (storage unreachable)", body = HealthResponse)
     )
 )]
 pub async fn health_check() {}

--- a/nora-registry/src/storage/object.rs
+++ b/nora-registry/src/storage/object.rs
@@ -24,6 +24,12 @@ pub struct ObjectStorage {
     cached_total_size: std::sync::atomic::AtomicU64,
     /// Whether cached_total_size has been initialized at least once.
     size_cache_initialized: std::sync::atomic::AtomicBool,
+    /// Outcome of the last background refresh, served by `health_check()`.
+    /// Starts `false` so readiness gates until the boot refresh confirms the
+    /// store — a live probe here would list the whole bucket on every kubelet
+    /// and LB health check, and slow listings under load mark the backend
+    /// unhealthy exactly when it is busiest (#869).
+    cached_reachable: std::sync::atomic::AtomicBool,
 }
 
 impl ObjectStorage {
@@ -68,6 +74,7 @@ impl ObjectStorage {
             name: "s3",
             cached_total_size: std::sync::atomic::AtomicU64::new(0),
             size_cache_initialized: std::sync::atomic::AtomicBool::new(false),
+            cached_reachable: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -105,6 +112,7 @@ impl ObjectStorage {
             name: "gcs",
             cached_total_size: std::sync::atomic::AtomicU64::new(0),
             size_cache_initialized: std::sync::atomic::AtomicBool::new(false),
+            cached_reachable: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -260,10 +268,11 @@ impl StorageBackend for ObjectStorage {
     }
 
     async fn health_check(&self) -> bool {
-        // Try listing with no prefix — if the store responds, it's healthy.
-        // Even an empty bucket or a 404 on prefix is fine.
-        let result: std::result::Result<Vec<_>, _> = self.store.list(None).try_collect().await;
-        result.is_ok()
+        // Cached outcome of the last background refresh (#869) — probes must
+        // never hit the store. False until the boot refresh succeeds, so
+        // readiness still gates a misconfigured store at rollout.
+        self.cached_reachable
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     async fn total_size(&self) -> u64 {
@@ -278,6 +287,8 @@ impl StorageBackend for ObjectStorage {
     async fn refresh_total_size(&self) {
         let result: std::result::Result<Vec<_>, _> = self.store.list(None).try_collect().await;
 
+        self.cached_reachable
+            .store(result.is_ok(), std::sync::atomic::Ordering::Relaxed);
         if let Ok(objects) = result {
             let total: u64 = objects.iter().map(|m| m.size).sum();
             self.cached_total_size
@@ -382,6 +393,17 @@ mod tests {
         assert_eq!(storage.backend_name(), "s3");
     }
 
+    /// `health_check` is a cached signal (#869): false at construction (probes do no
+    /// store I/O), and still false after a refresh against an unreachable endpoint.
+    /// The true-path is the background refresh loop against a live store.
+    #[tokio::test]
+    async fn test_health_check_cached_not_live() {
+        let storage = ObjectStorage::new("http://127.0.0.1:1", "b", "r", None, None, false);
+        assert!(!storage.health_check().await);
+        storage.refresh_total_size().await;
+        assert!(!storage.health_check().await);
+    }
+
     #[test]
     fn test_s3_storage_creation_anonymous() {
         let storage = ObjectStorage::new(
@@ -412,11 +434,12 @@ mod tests {
         assert_eq!(storage.backend_name(), "gcs");
     }
 
-    /// Empty ListObjectsV2 body so `health_check`'s `list(None)` succeeds against the mock.
+    /// Empty ListObjectsV2 body so `refresh_total_size`'s `list(None)` succeeds against the mock.
     const EMPTY_LIST_XML: &str = r#"<?xml version="1.0" encoding="UTF-8"?><ListBucketResult><Name>test-bucket</Name><KeyCount>0</KeyCount><MaxKeys>1000</MaxKeys><IsTruncated>false</IsTruncated></ListBucketResult>"#;
 
-    /// Run one `health_check` (a ListObjectsV2) against a mock server and return the
-    /// request path the client actually used.
+    /// Run one `refresh_total_size` (a ListObjectsV2) against a mock server and return the
+    /// request path the client actually used. Also covers the cached-reachability true
+    /// path (#869): a successful refresh flips `health_check()` to true.
     async fn observed_list_path(virtual_hosted: bool) -> String {
         let server = wiremock::MockServer::start().await;
         wiremock::Mock::given(wiremock::matchers::method("GET"))
@@ -434,6 +457,8 @@ mod tests {
             Some("secret"),
             virtual_hosted,
         );
+        assert!(!storage.health_check().await);
+        storage.refresh_total_size().await;
         assert!(storage.health_check().await);
         let requests = server.received_requests().await.unwrap();
         requests[0].url.path().to_string()


### PR DESCRIPTION
Fixes #869.

## Problem

`ObjectStorage::health_check()` runs a **full bucket listing** on every probe, and `/health` + `/ready` call it per request — so kubelet liveness, kubelet readiness, and the LB health check each list the whole bucket, continuously. Real-world effect (single-replica GKE + GCS, ~11.5k objects): ~1.1s per probe idle, >5s under blob-streaming load → probes time out → endpoint group empties → the LB returns `failed_to_pick_backend` 502s for **every** route until checks recover. The health check itself causes the outage, during exactly the traffic it exists to protect.

## Fix

Three small pieces:

1. **Cached reachability** — `ObjectStorage` keeps an `AtomicBool` updated by the existing 60s `refresh_total_size` background loop (which already performs this exact listing for the size gauge). `health_check()` reads the flag; probes do zero storage I/O. Starts `false`, so readiness still gates a misconfigured store at rollout.
2. **Boot pass** — the refresh loop now runs on its first (immediate) tick instead of 30s in, so reachability and the storage gauge are populated before the first readiness probe. (Same first-tick disease previously fixed for the GC/retention schedulers in #859.)
3. **`/health` is liveness, not storage** — always 200 while the process serves; storage state moves to the body as `status: "degraded"` + `storage.reachable`. Restarting the process never fixes remote storage, and failing liveness/LB checks on it converts a storage blip into a restart loop or a total 502 outage for routes that never touch storage. `/ready` remains the storage gate (now zero-I/O).

Local backend unchanged: its write-probe is cheap, and a failing local disk *is* actionable by rescheduling.

## Behavior changes

- `/health` no longer returns 503 (OpenAPI updated); operators watching for storage trouble read `status`/`storage.reachable` from the body.
- Sustained storage outage still un-readies the pod (cached flag goes false within 60s) — but a transiently slow listing no longer can, since the refresh has no probe deadline.

## Tests

- `observed_list_path` harness now drives `refresh_total_size` → asserts `health_check()` flips false→true on a successful refresh (wiremock).
- `test_health_check_cached_not_live`: false at construction, still false after refresh against an unreachable endpoint.
- `test_health_200_degraded_when_storage_unreachable`: unreachable storage → `/health` 200 + `degraded`, `/ready` 503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WQbaFrgw82c7KCcbhpRbQ