### PR TITLE
feat(observability): surface a geo/policy upstream 4xx (relayed as 404) with a warn log + metric (#881)

### DIFF
--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -91,6 +91,20 @@ pub static PROXY_UPSTREAM_304_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| 
     .expect("failed to create PROXY_UPSTREAM_304_TOTAL metric at startup")
 });
 
+/// Upstream 4xx responses that carried a policy/geo block signature (e.g. an AWS
+/// WAF geo rule via `x-amzn-waf-reason`) and were relayed as a bare 404. Lets an
+/// operator tell an effective region/policy outage apart from a genuine not-found
+/// — which is otherwise invisible (a 4xx logs nothing and never trips the breaker).
+/// Labels: `registry`, `reason` (bounded: `geo` | `waf`) (#881).
+pub static UPSTREAM_POLICY_BLOCKED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "nora_upstream_policy_blocked_total",
+        "Upstream 4xx responses bearing a policy/geo block signature, relayed as 404",
+        &["registry", "reason"]
+    )
+    .expect("failed to create UPSTREAM_POLICY_BLOCKED_TOTAL metric at startup")
+});
+
 /// Body bytes saved by revalidation (size of the cached body that did NOT have
 /// to be re-downloaded because upstream returned 304) (#596).
 pub static PROXY_REVALIDATION_BYTES_SAVED_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -48,7 +48,7 @@ pub use terraform::routes as terraform_routes;
 
 use crate::circuit_breaker::CircuitBreakerRegistry;
 use crate::config::basic_auth_header;
-use crate::metrics::UPSTREAM_REQUEST_DURATION;
+use crate::metrics::{UPSTREAM_POLICY_BLOCKED_TOTAL, UPSTREAM_REQUEST_DURATION};
 use crate::registry_type::RegistryType;
 use crate::AppState;
 use axum::body::{Body, Bytes};
@@ -121,6 +121,22 @@ pub(crate) fn circuit_open_response(registry: &str) -> Response {
         .into_response()
 }
 
+/// Detect a policy/geo block signature on an upstream 4xx response, returning a
+/// bounded reason label (low metric cardinality) or `None` for a genuine 4xx.
+///
+/// Currently keys off `x-amzn-waf-reason`, which AWS CloudFront + WAF sets when a
+/// rule blocks a request — a trade-control/geo rule returns it as a 404 that is
+/// otherwise indistinguishable from a not-found (#881). More signatures can be
+/// added here without touching the call site.
+fn policy_block_reason(headers: &reqwest::header::HeaderMap) -> Option<&'static str> {
+    let reason = headers.get("x-amzn-waf-reason")?;
+    let is_geo = reason
+        .to_str()
+        .map(|v| v.eq_ignore_ascii_case("geo"))
+        .unwrap_or(false);
+    Some(if is_geo { "geo" } else { "waf" })
+}
+
 /// Core fetch logic with retry. Callers provide a response extractor.
 #[allow(clippy::too_many_arguments)]
 async fn proxy_fetch_core<T, F, Fut>(
@@ -174,6 +190,24 @@ where
                     UPSTREAM_REQUEST_DURATION
                         .with_label_values(&[registry_str, "4xx"])
                         .observe(elapsed);
+                    // A policy/geo block (e.g. an AWS WAF geo rule) is a 4xx that is
+                    // effectively an outage dressed up as a not-found: it logs nothing,
+                    // never moves the breaker, and only bumps the 4xx metric — so an
+                    // operator cannot tell it apart from a genuine 404. Surface it
+                    // distinctly when the response carries a block signature (#881).
+                    // A plain 4xx (no signature) stays silent, exactly as before.
+                    if let Some(reason) = policy_block_reason(response.headers()) {
+                        UPSTREAM_POLICY_BLOCKED_TOTAL
+                            .with_label_values(&[registry_str, reason])
+                            .inc();
+                        tracing::warn!(
+                            registry = registry_str,
+                            url,
+                            status,
+                            reason,
+                            "upstream returned a policy/geo block, relayed as 404 (not a genuine not-found) — check egress/region"
+                        );
+                    }
                     // A 4xx means the upstream is alive and answered — not an
                     // availability failure. `record_alive` closes the breaker
                     // from HalfOpen (so it recovers instead of slow-probing) but
@@ -805,6 +839,89 @@ mod tests {
         )
         .await;
         assert!(matches!(result, Err(ProxyError::Network(_))));
+    }
+
+    // --- Policy/geo upstream block observability (#881) ---
+
+    #[test]
+    fn policy_block_reason_detects_waf_geo() {
+        use reqwest::header::HeaderMap;
+        let mut geo = HeaderMap::new();
+        geo.insert("x-amzn-waf-reason", "geo".parse().unwrap());
+        assert_eq!(policy_block_reason(&geo), Some("geo"));
+
+        let mut other = HeaderMap::new();
+        other.insert("x-amzn-waf-reason", "rate-based".parse().unwrap());
+        assert_eq!(policy_block_reason(&other), Some("waf"));
+
+        // A genuine 4xx (no WAF signature) is not a policy block.
+        assert_eq!(policy_block_reason(&HeaderMap::new()), None);
+    }
+
+    /// A geo-blocked upstream 4xx (WAF `x-amzn-waf-reason: geo`) bumps the policy-block
+    /// metric and is still relayed as `NotFound`; a plain 4xx does neither (#881).
+    #[tokio::test]
+    async fn upstream_waf_geo_block_surfaced_but_plain_4xx_silent() {
+        use wiremock::matchers::any;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Geo-blocked upstream: 404 + x-amzn-waf-reason: geo.
+        let blocked = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(404).insert_header("x-amzn-waf-reason", "geo"))
+            .mount(&blocked)
+            .await;
+        let reg = RegistryType::Terraform;
+        let before = UPSTREAM_POLICY_BLOCKED_TOTAL
+            .with_label_values(&[reg.as_str(), "geo"])
+            .get();
+        let r = proxy_fetch_text(
+            &reqwest::Client::new(),
+            &blocked.uri(),
+            Duration::from_secs(5),
+            None,
+            None,
+            &noop_cb(),
+            reg,
+        )
+        .await;
+        assert!(matches!(r, Err(ProxyError::NotFound)));
+        assert_eq!(
+            UPSTREAM_POLICY_BLOCKED_TOTAL
+                .with_label_values(&[reg.as_str(), "geo"])
+                .get(),
+            before + 1,
+            "a WAF geo 4xx must bump the policy-block metric"
+        );
+
+        // Control: a plain 404 (no WAF signature) must NOT bump the metric.
+        let plain = MockServer::start().await;
+        Mock::given(any())
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&plain)
+            .await;
+        let reg2 = RegistryType::Cargo;
+        let before2 = UPSTREAM_POLICY_BLOCKED_TOTAL
+            .with_label_values(&[reg2.as_str(), "geo"])
+            .get();
+        let r2 = proxy_fetch_text(
+            &reqwest::Client::new(),
+            &plain.uri(),
+            Duration::from_secs(5),
+            None,
+            None,
+            &noop_cb(),
+            reg2,
+        )
+        .await;
+        assert!(matches!(r2, Err(ProxyError::NotFound)));
+        assert_eq!(
+            UPSTREAM_POLICY_BLOCKED_TOTAL
+                .with_label_values(&[reg2.as_str(), "geo"])
+                .get(),
+            before2,
+            "a plain 4xx must NOT bump the policy-block metric"
+        );
     }
 
     // --- Conditional revalidation (#596) ---


### PR DESCRIPTION
## Summary

Follow-up to #879. A proxied upstream 4xx is mapped to `ProxyError::NotFound` and relayed as a bare `404` — correct for a genuine not-found, but it makes a policy/geo block invisible: `registry.terraform.io` behind AWS CloudFront + WAF returns `404` with `x-amzn-waf-reason: geo` for a trade-controlled region, and NORA relays it with **no log** (a 4xx logs nothing), **no circuit-breaker movement** (a 4xx does `record_alive`, so the breaker stays `Closed`), and only the generic `{status="4xx"}` histogram moving — indistinguishable from a real not-found.

## Change

Detect the block signature on a 4xx and surface it, **without** changing the 404 relay or the breaker — a policy block is genuinely not an availability failure (you don't want the breaker to open, and a plain 404 must not be treated as a block):

- a `warn!` log with `registry`, `url`, `status`, `reason`;
- a new counter `nora_upstream_policy_blocked_total{registry, reason}` (reason bounded: `geo | waf`);
- a `policy_block_reason()` helper keyed off `x-amzn-waf-reason`, extensible to more signatures without touching the call site.

A genuine 4xx (no signature) stays silent, exactly as before.

## Tests

- unit: `policy_block_reason` detects `geo` / `waf` / none;
- integration (wiremock through `proxy_fetch_text`): a `404` + `x-amzn-waf-reason: geo` bumps the metric and is still `NotFound`; a plain `404` does neither.

Closes #881
