### PR TITLE
fix(storage): size object_store timeouts for client-paced streaming

### DIFF
--- a/nora-registry/src/storage/object.rs
+++ b/nora-registry/src/storage/object.rs
@@ -86,9 +86,10 @@ impl ObjectStorage {
             .with_endpoint(url)
             .with_bucket_name(bucket)
             .with_region(region)
-            .with_allow_http(allow_http)
+            // One combined ClientOptions: with_client_options REPLACES the
+            // options with_allow_http would have accumulated.
+            .with_client_options(streaming_client_options().with_allow_http(allow_http))
             .with_virtual_hosted_style_request(virtual_hosted)
-            .with_client_options(streaming_client_options())
             .with_retry(streaming_retry_config());
 
         match (access_key, secret_key) {

--- a/nora-registry/src/storage/object.rs
+++ b/nora-registry/src/storage/object.rs
@@ -13,6 +13,26 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 
 use super::{FileMeta, Result, StorageBackend, StorageError};
 
+/// Downloads stream store -> server -> client under backpressure, so a slow
+/// download client paces the store read. object_store's request timeout covers
+/// the whole body of an attempt, and its retry deadline runs from the FIRST
+/// request while gating every transparent ranged resume of a streamed body —
+/// with the defaults (30 s attempt, 180 s deadline) any transfer slower than
+/// object-size / 180 s is reset mid-stream. Size both for the slowest
+/// tolerated download instead.
+const STREAM_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3600);
+
+fn streaming_client_options() -> object_store::ClientOptions {
+    object_store::ClientOptions::new().with_timeout(STREAM_ATTEMPT_TIMEOUT)
+}
+
+fn streaming_retry_config() -> object_store::RetryConfig {
+    object_store::RetryConfig {
+        retry_timeout: STREAM_ATTEMPT_TIMEOUT.saturating_mul(2),
+        ..Default::default()
+    }
+}
+
 /// Object-store backend (S3-compatible or Google Cloud Storage) using the
 /// `object_store` crate. Everything past construction goes through the
 /// [`ObjectStore`] trait, so both providers share one implementation.
@@ -67,7 +87,9 @@ impl ObjectStorage {
             .with_bucket_name(bucket)
             .with_region(region)
             .with_allow_http(allow_http)
-            .with_virtual_hosted_style_request(virtual_hosted);
+            .with_virtual_hosted_style_request(virtual_hosted)
+            .with_client_options(streaming_client_options())
+            .with_retry(streaming_retry_config());
 
         match (access_key, secret_key) {
             (Some(ak), Some(sk)) => {
@@ -104,15 +126,26 @@ impl ObjectStorage {
         service_account_path: Option<&str>,
         base_url: Option<&str>,
     ) -> Self {
-        let mut builder = GoogleCloudStorageBuilder::from_env().with_bucket_name(bucket);
+        let mut builder = GoogleCloudStorageBuilder::from_env()
+            .with_bucket_name(bucket)
+            .with_retry(streaming_retry_config());
+        // `with_client_options` would replace every env-derived client option
+        // (`GOOGLE_PROXY_URL`, ...), so merge only the timeout — and only when
+        // the operator has not set `GOOGLE_TIMEOUT` themselves.
+        if std::env::var_os("GOOGLE_TIMEOUT").is_none() {
+            builder = builder.with_config(
+                object_store::gcp::GoogleConfigKey::Client(object_store::ClientConfigKey::Timeout),
+                format!("{}s", STREAM_ATTEMPT_TIMEOUT.as_secs()),
+            );
+        }
         if let Some(path) = service_account_path {
             builder = builder.with_service_account_path(path);
         }
         if let Some(url) = base_url {
             let allow_http = url.starts_with("http://");
-            builder = builder.with_base_url(url).with_client_options(
-                object_store::ClientOptions::new().with_allow_http(allow_http),
-            );
+            builder = builder
+                .with_base_url(url)
+                .with_client_options(streaming_client_options().with_allow_http(allow_http));
             if allow_http {
                 builder = builder.with_skip_signature(true);
             }


### PR DESCRIPTION
## Symptom

Any download from an object-store backend (GCS/S3 mode) that cannot complete within ~180 seconds is reset mid-stream with an HTTP/2 RST, deterministically. Slow WAN clients pulling multi-GB artifacts hit this every attempt; fast clients never see it. Server logs show repeated `object_store::client::get` — "Encountered error while reading response body … Retrying in 0.1s" — before the reset.

## Cause

Downloads stream store → server → client under backpressure (`Body::from_stream` in the raw path and equivalents), so a slow download client paces the store read. Two `object_store` defaults interact:

- `ClientOptions` request timeout (**30s**) has total-request semantics — it covers the streamed body, so a client-paced GET is killed every 30s;
- each kill is transparently resumed with a ranged re-request (`client/get.rs` `retry_stream`), but every resume draws on one `RetryConfig::retry_timeout` deadline (**180s**) that starts at the *first* request (`RetryContext::exhausted`).

At 180s of wall clock the next resume is refused, the stream errors, and the response body aborts.

## Fix

Raise the per-attempt timeout to 1h and the retry deadline to 2h on both the GCS and S3 builders (`storage/object.rs`). On the GCS path the timeout is merged via `with_config` rather than `with_client_options` so env-derived client options (`GOOGLE_PROXY_URL`, …) survive, and an operator's explicit `GOOGLE_TIMEOUT` still wins.

Verified in production (GKE, GCS mode): with the equivalent `GOOGLE_TIMEOUT=3600s` an operator-side workaround, slow transfers complete; without it, curl dies at ~185s with exit 92 (`--limit-rate 3M` on a 1.66 GB object reproduces in ~3 min).

`cargo check -p nora-registry` clean.

## Related

While tracing this: the raw registry ignores HTTP `Range` headers (200 + full body). Range support would let interrupted CI pulls resume instead of restarting, but it interacts with the streaming integrity-pin gate (`VerifyingStream` can only verify a complete body), so it needs a design decision — happy to file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JyQLELHdpBGp8AjUTS94Ej