### PR TITLE
docs: document docker_anon_pull in env example and llms.txt

### DIFF
--- a/dist/nora.env.example
+++ b/dist/nora.env.example
@@ -27,6 +27,13 @@ NORA_STORAGE_PATH=/var/lib/nora
 # Auth (optional)
 # NORA_AUTH_ENABLED=true
 # NORA_AUTH_HTPASSWD_FILE=/etc/nora/users.htpasswd
+# Allow anonymous pull for non-Docker registries (npm/maven/pypi/raw/…).
+# Docker has its own switch below — anonymous_read never exposes container images.
+# NORA_AUTH_ANONYMOUS_READ=false
+# Allow anonymous Docker/OCI pull (docker pull without docker login).
+# Separate from anonymous_read so enabling anonymous npm/maven never
+# silently exposes container images. Default false.
+# NORA_AUTH_DOCKER_ANON_PULL=false
 # Serve the browse UI + API docs without auth (default false — a private
 # registry's UI enumerates every repo/package). Metrics default public.
 # NORA_AUTH_PUBLIC_WEB_UI=false

--- a/llms.txt
+++ b/llms.txt
@@ -124,7 +124,7 @@ NORA is a multi-protocol artifact registry written in Rust. It serves Docker ima
 - S3 storage backend (AWS S3, Ceph RGW, any S3-compatible) and native Google Cloud Storage backend (Workload Identity / service account / ambient credentials) with migration CLI
 - Web UI with dashboard, search, browse, i18n (English and Russian)
 - Authentication: Basic Auth (htpasswd) + revocable API tokens with RBAC (read/write/admin roles)
-- Anonymous read mode for public registries
+- Anonymous read mode for public registries (`anonymous_read` for non-Docker, `docker_anon_pull` for Docker/OCI)
 - Prometheus metrics at `/metrics`, health and readiness probes at `/health` and `/ready`
 - OpenAPI/Swagger UI at `/api-docs`
 - Backup and restore CLI (`nora backup`, `nora restore`)


### PR DESCRIPTION
## Summary
- Add `NORA_AUTH_ANONYMOUS_READ` and `NORA_AUTH_DOCKER_ANON_PULL` to `dist/nora.env.example` with comments explaining the separation
- Update `llms.txt` to mention both flags

## Context
`docker_anon_pull` was added in #778 but never documented outside CHANGELOG. Users set `anonymous_read = true` expecting Docker pulls to work anonymously, but since v1.1.0 Docker is governed by a separate flag. Report from a production deployment (af.pivlab.space).

Closes #898