### PR TITLE
fix(docker): fail closed on transient storage errors in manifest reads

### DIFF
--- a/COMPAT.md
+++ b/COMPAT.md
@@ -27,6 +27,22 @@ This document describes which parts of each registry protocol are implemented in
 | Cross-repo blob mount | POST | — | Not implemented |
 | Referrers API | GET | — | OCI 1.1 referrers |
 
+### Proxy cache and tag freshness
+
+- Digest references (`sha256:…`) are content-addressed: cached forever, never
+  revalidated.
+- Tag references on **proxied** images are revalidated against the upstream on
+  every pull by default (`docker.metadata_ttl = -1`). A positive
+  `metadata_ttl` (seconds) is the staleness bound: within the window the
+  cached tag is served without an upstream round trip; after it, the next pull
+  revalidates. `0` or negative always revalidates.
+- If every configured upstream fails and `docker.serve_stale = true`
+  (default), the last cached manifest is served with `x-nora-stale: true`.
+- Locally **pushed** (hosted) images are authoritative: a pushed tag is served
+  as-is and never revalidated against an upstream. Pushing to a name that
+  would otherwise proxy pins that tag to the pushed copy — to keep a tag
+  tracking the upstream, do not push to it.
+
 ### Known Limitations
 - Max 2-level image path: `org/image:tag` works, `org/sub/path/image:tag` returns 404
 - Large monolithic blob PUT (>~500MB) may fail even with high body limit

--- a/dist/nora.env.example
+++ b/dist/nora.env.example
@@ -52,6 +52,10 @@ NORA_AUTH_TOKEN_STORAGE=/var/lib/nora/tokens
 
 # Docker proxy
 # NORA_DOCKER_PROXIES=https://registry-1.docker.io
+# Tag revalidation window in seconds: -1/0 = revalidate on every pull
+# (default), positive = serve the cached tag within the window. Digests are
+# immutable and never revalidated. See COMPAT.md "Proxy cache and tag freshness".
+# NORA_DOCKER_METADATA_TTL=-1
 
 # npm proxy
 # NORA_NPM_PROXY=https://registry.npmjs.org

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -208,19 +208,25 @@ pub(crate) fn canonicalize(
 /// Try to get content from namespaced key, falling back to legacy (non-namespaced) key.
 ///
 /// This provides backward compatibility during migration from flat to namespaced storage.
+/// The fallback fires ONLY on `NotFound`: the two keys can hold different bytes (a
+/// proxied-current copy vs a pre-migration one), so falling back on a transient backend
+/// error would make which copy is served depend on backend weather — a per-request
+/// divergent answer for the same reference. Transient errors propagate instead.
 async fn storage_get_with_fallback(
     storage: &Storage,
     ns_key: &str,
     legacy_key: &str,
 ) -> Result<Bytes, crate::storage::StorageError> {
     match storage.get(ns_key).await {
-        Ok(data) => Ok(data),
-        Err(_) if ns_key != legacy_key => storage.get(legacy_key).await,
-        Err(e) => Err(e),
+        Err(crate::storage::StorageError::NotFound) if ns_key != legacy_key => {
+            storage.get(legacy_key).await
+        }
+        other => other,
     }
 }
 
 /// Open a streaming reader for a blob, trying namespaced then legacy key (#580).
+/// Legacy fallback on `NotFound` only, like [`storage_get_with_fallback`].
 async fn storage_get_reader_with_fallback(
     storage: &Storage,
     ns_key: &str,
@@ -233,9 +239,10 @@ async fn storage_get_reader_with_fallback(
     crate::storage::StorageError,
 > {
     match storage.get_reader(ns_key).await {
-        Ok(reader) => Ok(reader),
-        Err(_) if ns_key != legacy_key => storage.get_reader(legacy_key).await,
-        Err(e) => Err(e),
+        Err(crate::storage::StorageError::NotFound) if ns_key != legacy_key => {
+            storage.get_reader(legacy_key).await
+        }
+        other => other,
     }
 }
 
@@ -2145,10 +2152,29 @@ async fn get_manifest(
     // bare key is what `put_manifest` writes — a bare-key hit is a locally pushed (hosted)
     // manifest. (Pre-#349 flat-keyed proxy caches are consequently read as hosted; the cost
     // is skipped tag revalidation on those legacy entries.)
+    // Provenance decides freshness below, so a transient storage error must fail closed
+    // (500) rather than fall through to the legacy key or the proxy: an error-driven
+    // fallback silently flips WHICH copy answers (proxied-current vs legacy/hosted), and
+    // an error-driven proxy would resolve a hosted name against an upstream that may be
+    // squatted. Only `NotFound` may advance to the next source.
+    use crate::storage::StorageError;
     let (cached, hosted) = match state.storage.get(&key).await {
         Ok(data) => (Some(data), key == legacy_key),
-        Err(_) if key != legacy_key => (state.storage.get(&legacy_key).await.ok(), true),
-        Err(_) => (None, true),
+        Err(StorageError::NotFound) if key != legacy_key => {
+            match state.storage.get(&legacy_key).await {
+                Ok(data) => (Some(data), true),
+                Err(StorageError::NotFound) => (None, true),
+                Err(e) => {
+                    tracing::error!(error = %e, key = %legacy_key, "manifest read failed");
+                    return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+                }
+            }
+        }
+        Err(StorageError::NotFound) => (None, true),
+        Err(e) => {
+            tracing::error!(error = %e, key = %key, "manifest read failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
     };
     // Digest references are immutable (content-addressed) → the cache is authoritative forever.
     // Tag references on PROXIED copies are MUTABLE: a tag can be re-pushed to point at a
@@ -5471,5 +5497,154 @@ mod integration_tests {
             ctx.state.storage.get(&key).await.is_ok(),
             "verified blob must be cached"
         );
+    }
+
+    /// Storage backend that delegates to local storage but fails `get`/`get_reader`
+    /// with a transient (non-`NotFound`) error for keys under a given prefix —
+    /// models an object-store blip on the namespaced key while the legacy key
+    /// stays readable.
+    struct FailingPrefixBackend {
+        inner: crate::storage::LocalStorage,
+        fail_prefix: String,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::storage::StorageBackend for FailingPrefixBackend {
+        async fn put(&self, key: &str, data: &[u8]) -> crate::storage::Result<()> {
+            self.inner.put(key, data).await
+        }
+        async fn get(&self, key: &str) -> crate::storage::Result<axum::body::Bytes> {
+            if key.starts_with(&self.fail_prefix) {
+                return Err(crate::storage::StorageError::Network("injected".into()));
+            }
+            self.inner.get(key).await
+        }
+        async fn delete(&self, key: &str) -> crate::storage::Result<()> {
+            self.inner.delete(key).await
+        }
+        async fn list(&self, prefix: &str) -> crate::storage::Result<Vec<String>> {
+            self.inner.list(prefix).await
+        }
+        async fn stat(&self, key: &str) -> Option<crate::storage::FileMeta> {
+            self.inner.stat(key).await
+        }
+        async fn health_check(&self) -> bool {
+            true
+        }
+        async fn total_size(&self) -> u64 {
+            self.inner.total_size().await
+        }
+        fn backend_name(&self) -> &'static str {
+            "failing-prefix-test"
+        }
+        async fn put_from_path(
+            &self,
+            key: &str,
+            src: &std::path::Path,
+        ) -> crate::storage::Result<()> {
+            self.inner.put_from_path(key, src).await
+        }
+        async fn get_reader(
+            &self,
+            key: &str,
+        ) -> crate::storage::Result<(
+            u64,
+            std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
+        )> {
+            if key.starts_with(&self.fail_prefix) {
+                return Err(crate::storage::StorageError::Network("injected".into()));
+            }
+            self.inner.get_reader(key).await
+        }
+    }
+
+    fn unreachable_upstream() -> crate::config::DockerUpstream {
+        crate::config::DockerUpstream {
+            // Reserved port on localhost — connect fails fast, no real network.
+            url: "http://127.0.0.1:9".to_string(),
+            auth: None,
+            namespace: None,
+            prefix: None,
+        }
+    }
+
+    async fn get_manifest_via_dispatch(
+        state: &crate::AppState,
+        path: &str,
+    ) -> axum::response::Response {
+        use axum::extract::{Path, State};
+        use axum::http::Uri;
+        use axum::Extension;
+        super::docker_v2_dispatch(
+            State(state.clone()),
+            Method::GET,
+            Path(path.to_string()),
+            Extension(crate::auth::NamespaceAuthority::Unrestricted),
+            format!("/v2/{path}").parse::<Uri>().unwrap(),
+            axum::http::HeaderMap::new(),
+            Body::empty(),
+        )
+        .await
+    }
+
+    /// A transient storage error on the namespaced manifest key must fail closed
+    /// (500) — NOT silently serve the legacy (flat-key) copy. The two keys can
+    /// hold different bytes (proxied-current vs pre-migration), so an
+    /// error-driven fallback makes tag resolution flip per request with backend
+    /// weather. Drives the real `get_manifest` read via `docker_v2_dispatch`.
+    #[tokio::test]
+    async fn manifest_get_fails_closed_on_transient_storage_error() {
+        use std::sync::Arc;
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.docker.upstreams = vec![unreachable_upstream()];
+        });
+
+        // Legacy (flat) copy exists and is readable.
+        ctx.state
+            .storage
+            .put("docker/app/manifests/latest.json", b"{\"legacy\":true}")
+            .await
+            .unwrap();
+
+        // Same files, but the namespaced key errors transiently. Namespace for
+        // an http://127.0.0.1:9 upstream is "127.0.0.1".
+        let mut flaky = ctx.state.clone();
+        flaky.storage = crate::storage::Storage::from_backend(Arc::new(FailingPrefixBackend {
+            inner: crate::storage::LocalStorage::new(ctx._tempdir.path().to_str().unwrap()),
+            fail_prefix: "docker/127.0.0.1/".to_string(),
+        }));
+
+        let resp = get_manifest_via_dispatch(&flaky, "app/manifests/latest").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "transient error on the namespaced key must fail closed, not fall back"
+        );
+    }
+
+    /// The legacy-key fallback still works for the case it exists for: the
+    /// namespaced key is genuinely absent (`NotFound`) and a flat-key hosted
+    /// copy exists. Served as locally authoritative — no upstream round trip,
+    /// so no `x-nora-stale` even though the configured upstream is unreachable.
+    #[tokio::test]
+    async fn manifest_get_serves_hosted_legacy_on_ns_not_found() {
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.docker.upstreams = vec![unreachable_upstream()];
+        });
+
+        ctx.state
+            .storage
+            .put("docker/app/manifests/latest.json", b"{\"legacy\":true}")
+            .await
+            .unwrap();
+
+        let resp = get_manifest_via_dispatch(&ctx.state, "app/manifests/latest").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(
+            resp.headers().get("x-nora-stale").is_none(),
+            "hosted copy is authoritative — must not be served via the stale path"
+        );
+        let body = body_bytes(resp).await;
+        assert_eq!(body.as_ref(), b"{\"legacy\":true}");
     }
 }


### PR DESCRIPTION
## Problem

The Docker manifest read path falls back from the namespaced storage key to the legacy (flat) key on **any** storage error, not just `NotFound` (`storage_get_with_fallback`, `storage_get_reader_with_fallback`, and the inline read in `get_manifest`).

When both keys hold copies — a proxied-current one under `docker/{ns}/…` and a pre-migration or hosted one under `docker/{name}/…` — a transient object-store error (S3/GCS 5xx, network blip) on the namespaced key silently swaps in the legacy copy **and** reclassifies the manifest as hosted, skipping tag revalidation. The same tag GET can answer with different bytes request-to-request, gated on backend weather. Downstream systems that pin the resolved digest see the tag flap.

A transient error on a hosted name's read could likewise fall through to the upstream proxy under the default-allow fallback, resolving a locally-owned name against an upstream where it may be squatted.

## Fix

Key fallback advances only on `StorageError::NotFound`; any other storage error fails closed with 500. Clients retry 5xx; they cannot un-see wrong bytes.

## Also

- `COMPAT.md`: new "Proxy cache and tag freshness" section documenting tag revalidation semantics (`docker.metadata_ttl`: -1/0 = revalidate every pull, positive = staleness window; digests immutable; `serve_stale` behavior; pushed tags are authoritative and never revalidated).
- `dist/nora.env.example`: document `NORA_DOCKER_METADATA_TTL`.

## Tests

- `manifest_get_fails_closed_on_transient_storage_error` — injected non-NotFound error on the namespaced key with a readable legacy copy must 500, not serve the legacy bytes (fails before this change).
- `manifest_get_serves_hosted_legacy_on_ns_not_found` — genuine NotFound still falls back to the hosted flat-key copy, served authoritatively with no upstream round trip and no `x-nora-stale`.