### PR TITLE
fix(auth): atomic token-file writes; store errors answer 503, not 401

### DIFF
--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -398,6 +398,19 @@ pub async fn auth_middleware(
                     request.extensions_mut().insert(AuthenticatedRole(role));
                     return next.run(request).await;
                 }
+                // A store I/O/parse failure is not a credential verdict. Only an
+                // `nra_`-prefixed token reaches disk (anything else returns
+                // `InvalidFormat` first), so there is no OIDC identity to fall
+                // through to: answer 503 so the client retries, instead of a 401
+                // that makes valid creds flap during a storage blip.
+                Err(crate::tokens::TokenError::Storage(e)) => {
+                    tracing::error!(error = %e, "token store read failed during Bearer auth");
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "Token verification unavailable",
+                    )
+                        .into_response();
+                }
                 Err(_) => {
                     // Token verification failed — fall through to OIDC
                 }
@@ -496,11 +509,19 @@ pub async fn auth_middleware(
     // password and never use Bearer (the `/v2/` challenge is Basic), so the Basic
     // path must fall through to token verification for token auth to work at all. (#736)
     if !auth.authenticate(username, password) {
-        if let Some((token_user, role)) = state
-            .tokens
-            .as_ref()
-            .and_then(|ts| ts.verify_token(password).ok())
-        {
+        let token_result = state.tokens.as_ref().map(|ts| ts.verify_token(password));
+        // Same fail-closed rule as the Bearer path: a store I/O/parse failure is
+        // not "wrong password". A 401 here makes valid token creds flap and feeds
+        // the failure tracker toward lockout for the duration of a storage blip.
+        if let Some(Err(crate::tokens::TokenError::Storage(ref e))) = token_result {
+            tracing::error!(error = %e, "token store read failed during Basic auth fallback");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Token verification unavailable",
+            )
+                .into_response();
+        }
+        if let Some(Ok((token_user, role))) = token_result {
             if let Some(ip) = client_ip {
                 state.auth_failures.record_success(&ip);
             }
@@ -1165,6 +1186,73 @@ mod integration_tests {
         )
         .await;
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    /// Path of a stored token's on-disk file inside a test context.
+    fn token_file_path(ctx: &crate::test_helpers::TestContext, token: &str) -> std::path::PathBuf {
+        use sha2::Digest;
+        let prefix = hex::encode(sha2::Sha256::digest(token.as_bytes()));
+        ctx._tempdir
+            .path()
+            .join("tokens")
+            .join(format!("{}.json", &prefix[..16]))
+    }
+
+    /// A token-store read failure (torn/corrupt file, I/O error) is an outage,
+    /// not a credential verdict: Basic auth with a valid-format token must
+    /// answer 503 (retryable), never 401 — a 401 makes valid creds flap and
+    /// walks the per-IP failure tracker toward lockout for the duration of a
+    /// storage blip. Regression for the 2026-08 same-creds 200↔401 flap.
+    #[tokio::test]
+    async fn test_basic_auth_token_store_error_returns_503_not_401() {
+        let ctx = create_test_context_with_auth(&[("admin", "secret")]);
+        let token = ctx
+            .state
+            .tokens
+            .as_ref()
+            .unwrap()
+            .create_token("ci", 30, None, crate::tokens::Role::Read)
+            .unwrap();
+        // Corrupt the file the way a torn in-place rewrite would. The token was
+        // never verified, so the in-memory cache is cold and the disk is read.
+        std::fs::write(token_file_path(&ctx, &token), "{\"token_ha").unwrap();
+
+        let header_val = format!("Basic {}", STANDARD.encode(format!("ci:{token}")));
+        let response = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/raw/test.txt",
+            vec![("authorization", &header_val)],
+            Vec::new(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// Same rule on the Bearer path: an `nra_` token that cannot be verified
+    /// because the store read failed must 503, not fall through to OIDC and 401.
+    #[tokio::test]
+    async fn test_bearer_token_store_error_returns_503_not_401() {
+        let ctx = create_test_context_with_auth(&[("admin", "secret")]);
+        let token = ctx
+            .state
+            .tokens
+            .as_ref()
+            .unwrap()
+            .create_token("ci", 30, None, crate::tokens::Role::Read)
+            .unwrap();
+        std::fs::write(token_file_path(&ctx, &token), "{\"token_ha").unwrap();
+
+        let header_val = format!("Bearer {token}");
+        let response = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/raw/test.txt",
+            vec![("authorization", &header_val)],
+            Vec::new(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 
     #[tokio::test]

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -951,9 +951,7 @@ mod tests {
     fn verify_reports_storage_error_on_corrupt_file() {
         let temp_dir = TempDir::new().unwrap();
         let store = TokenStore::new(temp_dir.path());
-        let token = store
-            .create_token("ci", 30, None, Role::Read)
-            .unwrap();
+        let token = store.create_token("ci", 30, None, Role::Read).unwrap();
 
         // Corrupt the on-disk file the way a torn in-place write would.
         let file = temp_dir
@@ -974,9 +972,7 @@ mod tests {
     async fn flush_last_used_replaces_file_atomically() {
         let temp_dir = TempDir::new().unwrap();
         let store = TokenStore::new(temp_dir.path());
-        let token = store
-            .create_token("ci", 30, None, Role::Read)
-            .unwrap();
+        let token = store.create_token("ci", 30, None, Role::Read).unwrap();
 
         // Schedules a pending last_used update.
         store.verify_token(&token).unwrap();

--- a/nora-registry/src/tokens.rs
+++ b/nora-registry/src/tokens.rs
@@ -179,8 +179,7 @@ impl TokenStore {
         let file_path = self.storage_path.join(format!("{}.json", &file_id[..16]));
         let json =
             serde_json::to_string_pretty(&info).map_err(|e| TokenError::Storage(e.to_string()))?;
-        fs::write(&file_path, &json).map_err(|e| TokenError::Storage(e.to_string()))?;
-        set_file_permissions_600(&file_path);
+        write_token_file(&file_path, &json).map_err(|e| TokenError::Storage(e.to_string()))?;
 
         Ok(raw_token)
     }
@@ -242,8 +241,7 @@ impl TokenStore {
                 if let Ok(new_hash) = hash_token_argon2(token) {
                     info.token_hash = new_hash;
                     if let Ok(json) = serde_json::to_string_pretty(&info) {
-                        let _ = fs::write(&file_path, &json);
-                        set_file_permissions_600(&file_path);
+                        let _ = write_token_file(&file_path, &json);
                     }
                 }
                 true
@@ -354,9 +352,18 @@ impl TokenStore {
                 Err(_) => continue,
             };
             info.last_used = Some(*timestamp);
+            // Atomic replace (write temp + rename), NOT an in-place `fs::write`:
+            // this runs every 30s for every active token while `verify_token`
+            // reads the same file on its cache-miss path. An in-place write
+            // truncates first, so a concurrent read can observe a torn/empty
+            // file — a VALID token then 401s ("Invalid username or password")
+            // until a clean read repopulates the verify cache.
             if let Ok(json) = serde_json::to_string_pretty(&info) {
-                let _ = tokio::fs::write(&file_path, &json).await;
-                set_file_permissions_600(&file_path);
+                let tmp = file_path.with_extension("json.tmp");
+                if tokio::fs::write(&tmp, &json).await.is_ok() {
+                    set_file_permissions_600(&tmp);
+                    let _ = tokio::fs::rename(&tmp, &file_path).await;
+                }
             }
         }
 
@@ -462,6 +469,19 @@ fn set_file_permissions_600(path: &Path) {
     {
         let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
     }
+}
+
+/// Write a token file atomically: temp file in the same directory, permissions
+/// fixed, then rename over the target. `verify_token` reads these files on its
+/// cache-miss path while background rewrites happen, and a plain `fs::write`
+/// truncates in place — a concurrent reader can observe a torn/empty file and
+/// fail a valid token. Listings skip the temp name (extension is `tmp`, not
+/// `json`), and `is_valid_hash_prefix` keeps it out of revoke paths.
+fn write_token_file(path: &Path, json: &str) -> std::io::Result<()> {
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, json)?;
+    set_file_permissions_600(&tmp);
+    fs::rename(&tmp, path)
 }
 
 #[derive(Debug, Error)]
@@ -921,6 +941,59 @@ mod tests {
         assert!(!is_valid_hash_prefix("../../etc/passwd")); // path traversal
         assert!(!is_valid_hash_prefix("..%2f..%2fetcpwd")); // encoded traversal
         assert!(!is_valid_hash_prefix("zzzzzzzzzzzzzzzz")); // non-hex
+    }
+
+    /// A corrupt/torn token file must surface as `Storage`, not `NotFound` —
+    /// the auth middleware maps `Storage` to 503 (retryable outage) and
+    /// everything else to 401 (credential verdict). Misclassifying a torn file
+    /// as `NotFound` turns a storage blip into an auth denial.
+    #[test]
+    fn verify_reports_storage_error_on_corrupt_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = TokenStore::new(temp_dir.path());
+        let token = store
+            .create_token("ci", 30, None, Role::Read)
+            .unwrap();
+
+        // Corrupt the on-disk file the way a torn in-place write would.
+        let file = temp_dir
+            .path()
+            .join(format!("{}.json", &sha256_hex(&token)[..16]));
+        std::fs::write(&file, "{\"token_ha").unwrap();
+
+        assert!(matches!(
+            store.verify_token(&token),
+            Err(TokenError::Storage(_))
+        ));
+    }
+
+    /// `flush_last_used` must leave the token file whole (atomic replace) with
+    /// the timestamp applied, and clean up its temp file — a verify racing the
+    /// flush then can never observe a truncated file from NORA's own writes.
+    #[tokio::test]
+    async fn flush_last_used_replaces_file_atomically() {
+        let temp_dir = TempDir::new().unwrap();
+        let store = TokenStore::new(temp_dir.path());
+        let token = store
+            .create_token("ci", 30, None, Role::Read)
+            .unwrap();
+
+        // Schedules a pending last_used update.
+        store.verify_token(&token).unwrap();
+        store.flush_last_used().await;
+
+        let prefix = &sha256_hex(&token)[..16];
+        let file = temp_dir.path().join(format!("{prefix}.json"));
+        let info: TokenInfo =
+            serde_json::from_str(&std::fs::read_to_string(&file).unwrap()).unwrap();
+        assert!(info.last_used.is_some(), "flush must apply the timestamp");
+        assert!(
+            !temp_dir.path().join(format!("{prefix}.json.tmp")).exists(),
+            "temp file must be renamed away, not left behind"
+        );
+        // And the token still verifies from disk (fresh store = no warm cache).
+        let cold = TokenStore::new(temp_dir.path());
+        assert!(cold.verify_token(&token).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Symptom

Valid API tokens intermittently 401 (`Invalid username or password`) for ~seconds-to-a-minute, then recover — same creds, unchanged path. Only token-authenticated requests are affected (htpasswd loads at boot; OIDC is network-side), which makes it look like per-account auth flapping.

## Two defects

**1. Non-atomic token-file rewrites.** Three writers rewrite `{prefix}.json` in place with `fs::write` (truncate + write): the 30s `flush_last_used` background loop (every active token, every 30s), the SHA256→Argon2 migration on the verify path, and `create_token`. `verify_token`'s cache-miss path reads the same file concurrently — a reader between truncate and write sees a torn/empty file. Compounding: a failed verify never populates the verify cache, so every subsequent request re-reads disk until a clean read lands (a *burst* of 401s, not one), and `flush_last_used` skips unparseable files (`continue`), so a file left corrupt by an interrupted write is never repaired.

Fix: `write_token_file` — same-directory temp file, permissions set, `rename` over the target (atomic on POSIX). Listings skip the temp name (extension `tmp` ≠ `json`) and `is_valid_hash_prefix` keeps it out of revoke paths.

**2. Store errors read as credential verdicts.** Both the Bearer and Basic middleware paths collapse `TokenError::Storage` (I/O or parse failure) into the invalid-credentials 401 — and record it in the per-IP failure tracker, so a storage blip additionally walks well-behaved clients toward brute-force lockout. Both paths now answer **503** on `Storage` without recording a failure. Safe on the Bearer path: only `nra_`-prefixed tokens reach disk (`InvalidFormat` returns first), so a legitimate OIDC JWT can never be swallowed by the 503.

## Tests

- `verify_reports_storage_error_on_corrupt_file` — torn file ⇒ `Storage`, not `NotFound` (the classification the middleware depends on).
- `flush_last_used_replaces_file_atomically` — flush applies `last_used`, leaves a whole file, no temp leftover, token still verifies cold.
- `test_basic_auth_token_store_error_returns_503_not_401` / `test_bearer_token_store_error_returns_503_not_401` — full middleware paths via the test router.

Related: #911 (same fail-closed theme on the Docker manifest read path).