### PR TITLE
perf(rpm,deb): read index-rebuild sidecars concurrently

### DIFF
--- a/nora-registry/src/registry/deb.rs
+++ b/nora-registry/src/registry/deb.rs
@@ -513,21 +513,7 @@ pub(crate) async fn regenerate_indexes(
     repo: &str,
 ) -> Result<(), String> {
     let meta_prefix = format!("deb/{repo}/{META_DIR}/");
-    let keys = storage
-        .list(&meta_prefix)
-        .await
-        .map_err(|e| format!("list sidecars: {e}"))?;
-
-    let mut pkgs = Vec::with_capacity(keys.len());
-    for key in &keys {
-        let data = storage
-            .get(key)
-            .await
-            .map_err(|e| format!("read sidecar {key}: {e}"))?;
-        let rec: PkgRecord =
-            serde_json::from_slice(&data).map_err(|e| format!("parse sidecar {key}: {e}"))?;
-        pkgs.push(rec);
-    }
+    let mut pkgs: Vec<PkgRecord> = super::read_json_sidecars(storage, &meta_prefix).await?;
     // Deterministic output: same package set → byte-identical indexes
     // (modulo the Release Date field).
     pkgs.sort_by(|a, b| {

--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -63,6 +63,38 @@ pub(crate) fn method_not_allowed(allow: &'static str) -> Response {
     (StatusCode::METHOD_NOT_ALLOWED, [(header::ALLOW, allow)]).into_response()
 }
 
+/// How many JSON sidecars an index rebuild fetches from storage at once.
+/// The rpm/deb rebuild runs inside every publish request; sequential reads
+/// made each PUT O(repo size) in storage round-trips (~2 min per upload at
+/// ~1.7k packages on GCS).
+const SIDECAR_READ_CONCURRENCY: usize = 32;
+
+/// Read and parse every JSON sidecar under `prefix`, fetching concurrently.
+///
+/// Returns records in arbitrary order — callers sort for deterministic
+/// index output, so ordering here is free to follow fetch completion.
+pub(crate) async fn read_json_sidecars<T: serde::de::DeserializeOwned>(
+    storage: &crate::storage::Storage,
+    prefix: &str,
+) -> Result<Vec<T>, String> {
+    use futures::TryStreamExt;
+    let keys = storage
+        .list(prefix)
+        .await
+        .map_err(|e| format!("list sidecars: {e}"))?;
+    futures::stream::iter(keys)
+        .map(|key| async move {
+            let data = storage
+                .get(&key)
+                .await
+                .map_err(|e| format!("read sidecar {key}: {e}"))?;
+            serde_json::from_slice::<T>(&data).map_err(|e| format!("parse sidecar {key}: {e}"))
+        })
+        .buffer_unordered(SIDECAR_READ_CONCURRENCY)
+        .try_collect()
+        .await
+}
+
 /// 409 for a write against a pull-through repo (rpm/deb `proxies` entry) —
 /// its content mirrors the upstream; local publish/delete/reindex would
 /// diverge from (and be clobbered by) the next upstream metadata refresh.

--- a/nora-registry/src/registry/rpm.rs
+++ b/nora-registry/src/registry/rpm.rs
@@ -592,21 +592,7 @@ pub(crate) async fn regenerate_repodata(
     repo: &str,
 ) -> Result<(), String> {
     let meta_prefix = format!("rpm/{repo}/{META_DIR}/");
-    let keys = storage
-        .list(&meta_prefix)
-        .await
-        .map_err(|e| format!("list sidecars: {e}"))?;
-
-    let mut pkgs = Vec::with_capacity(keys.len());
-    for key in &keys {
-        let data = storage
-            .get(key)
-            .await
-            .map_err(|e| format!("read sidecar {key}: {e}"))?;
-        let rec: PkgRecord =
-            serde_json::from_slice(&data).map_err(|e| format!("parse sidecar {key}: {e}"))?;
-        pkgs.push(rec);
-    }
+    let mut pkgs: Vec<PkgRecord> = super::read_json_sidecars(storage, &meta_prefix).await?;
     // Deterministic output: same package set → byte-identical repodata.
     pkgs.sort_by(|a, b| {
         (&a.name, a.epoch, &a.version, &a.release, &a.arch)


### PR DESCRIPTION
## Problem

`regenerate_repodata` (rpm) and `regenerate_indexes` (deb) run inside every publish request, and read one JSON sidecar per package from storage **sequentially**. Each PUT is therefore O(repo size) in storage round-trips. On an object-store backend this dominates: with ~1.7k packages at ~60ms per GET, every upload takes ~2 minutes server-side regardless of file size, and publishing a 40-package build spends over an hour in sidecar reads alone. Observed in production (GCS backend): uniform ~114s per uploaded RPM.

## Fix

Shared `read_json_sidecars` helper in `registry/mod.rs` — lists the sidecar prefix, fetches with `buffer_unordered(32)`, parses each. Completion order is unconstrained because both callers already sort records before generating indexes (the documented byte-identical determinism contract), so output is unchanged. ~1.7k reads drop from ~114s to a few seconds.

No behavior change beyond latency: same fail-closed contract (any read/parse error aborts the rebuild), same deterministic output. Existing rpm/deb suites cover the rebuild path (63 tests green).