### PR TITLE
fix(cleanup): unify retention and GC into one scheduler so retention actually runs

### DIFF
--- a/nora-registry/src/cleanup.rs
+++ b/nora-registry/src/cleanup.rs
@@ -1,0 +1,249 @@
+//! Unified periodic cleanup scheduler.
+//!
+//! Retention and GC used to run as two independent tasks with the same
+//! default interval, sharing one `cleanup_lock`. Both ticked at the same
+//! instant every cycle and the periodic path used `try_lock`: GC won the
+//! race every time and retention logged "cleanup lock held ... skipping"
+//! with no retry, so age-based retention never ran on a default schedule.
+//!
+//! One task removes that race by construction — every due pass runs in
+//! order under a single lock acquisition, and the acquisition waits instead
+//! of skipping. Retention runs before GC because retention deletes expired
+//! versions, which creates the orphans GC then sweeps: one cycle now
+//! reclaims what the split design needed two cycles for.
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+use tracing::warn;
+
+pub(crate) struct CleanupPass {
+    pub name: &'static str,
+    pub interval: Duration,
+    /// Runs one pass. Owns its own start/done logging.
+    pub run: Box<dyn Fn() -> BoxFuture<'static, ()> + Send + Sync>,
+}
+
+pub(crate) fn spawn_cleanup_scheduler(
+    passes: Vec<CleanupPass>,
+    cleanup_lock: Arc<tokio::sync::Mutex<()>>,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        // Every pass is due at boot: a process restarting more often than its
+        // interval must still clean.
+        let mut due: Vec<Instant> = vec![Instant::now(); passes.len()];
+
+        loop {
+            let Some(next) = due.iter().min().copied() else {
+                return;
+            };
+
+            // CANCEL-SAFETY: sleep_until and cancelled() hold no state between
+            // polls, and pass work runs to completion inside one iteration.
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = tokio::time::sleep_until(next) => {}
+            }
+
+            // Waiting on the lock cannot starve the cycle: this task is the
+            // only periodic contender. Racing the wait against cancellation
+            // keeps SIGTERM prompt when a manual cleanup holds the lock.
+            let guard = tokio::select! {
+                _ = cancel.cancelled() => return,
+                g = cleanup_lock.lock() => g,
+            };
+
+            let now = Instant::now();
+            for (i, pass) in passes.iter().enumerate() {
+                if due[i] > now {
+                    continue;
+                }
+                // Wake-time based, so same-interval passes stay phase-locked
+                // and a pass overrunning its interval fires on the next loop.
+                due[i] = now + pass.interval;
+                if std::panic::AssertUnwindSafe((pass.run)())
+                    .catch_unwind()
+                    .await
+                    .is_err()
+                {
+                    warn!(
+                        pass = pass.name,
+                        "cleanup pass panicked — continuing with remaining passes"
+                    );
+                }
+            }
+
+            drop(guard);
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    type Recorder = Arc<parking_lot::Mutex<Vec<&'static str>>>;
+
+    fn recorder() -> Recorder {
+        Arc::new(parking_lot::Mutex::new(Vec::new()))
+    }
+
+    fn recording_pass(name: &'static str, interval: Duration, rec: &Recorder) -> CleanupPass {
+        let rec = rec.clone();
+        CleanupPass {
+            name,
+            interval,
+            run: Box::new(move || {
+                let rec = rec.clone();
+                async move {
+                    rec.lock().push(name);
+                }
+                .boxed()
+            }),
+        }
+    }
+
+    fn panicking_pass(name: &'static str, interval: Duration, rec: &Recorder) -> CleanupPass {
+        let rec = rec.clone();
+        CleanupPass {
+            name,
+            interval,
+            run: Box::new(move || {
+                let rec = rec.clone();
+                async move {
+                    rec.lock().push(name);
+                    panic!("pass exploded");
+                }
+                .boxed()
+            }),
+        }
+    }
+
+    async fn wait_for(rec: &Recorder, count: usize) -> Vec<&'static str> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let seen = rec.lock().clone();
+            if seen.len() >= count {
+                return seen;
+            }
+            assert!(Instant::now() < deadline, "only recorded {seen:?}");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    /// The first cycle runs at boot and chains retention → GC in order.
+    #[tokio::test]
+    async fn cycle_runs_passes_in_order_at_boot() {
+        let rec = recorder();
+        let interval = Duration::from_secs(10);
+        let cancel = CancellationToken::new();
+        let start = Instant::now();
+        let handle = spawn_cleanup_scheduler(
+            vec![
+                recording_pass("retention", interval, &rec),
+                recording_pass("gc", interval, &rec),
+            ],
+            Arc::new(tokio::sync::Mutex::new(())),
+            cancel.clone(),
+        );
+
+        let seen = wait_for(&rec, 2).await;
+        assert_eq!(&seen[..2], &["retention", "gc"]);
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "boot cycle waited for the interval"
+        );
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    /// A panicking pass must not skip the later passes of its own cycle, nor
+    /// kill the scheduler.
+    #[tokio::test]
+    async fn pass_panic_does_not_prevent_later_passes() {
+        let rec = recorder();
+        let interval = Duration::from_millis(100);
+        let cancel = CancellationToken::new();
+        let handle = spawn_cleanup_scheduler(
+            vec![
+                panicking_pass("retention", interval, &rec),
+                recording_pass("gc", interval, &rec),
+            ],
+            Arc::new(tokio::sync::Mutex::new(())),
+            cancel.clone(),
+        );
+
+        let seen = wait_for(&rec, 4).await;
+        assert_eq!(&seen[..4], &["retention", "gc", "retention", "gc"]);
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    /// The periodic cycle parks on a held cleanup lock instead of skipping —
+    /// the starvation the split schedulers had is gone.
+    #[tokio::test]
+    async fn cycle_waits_for_cleanup_lock_instead_of_skipping() {
+        let rec = recorder();
+        let interval = Duration::from_millis(100);
+        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = cleanup_lock.clone().lock_owned().await;
+
+        let cancel = CancellationToken::new();
+        let handle = spawn_cleanup_scheduler(
+            vec![
+                recording_pass("retention", interval, &rec),
+                recording_pass("gc", interval, &rec),
+            ],
+            cleanup_lock,
+            cancel.clone(),
+        );
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        assert!(rec.lock().is_empty(), "ran while the lock was held");
+
+        drop(held);
+        let seen = wait_for(&rec, 2).await;
+        assert_eq!(&seen[..2], &["retention", "gc"]);
+
+        cancel.cancel();
+        handle.await.unwrap();
+    }
+
+    /// A shutdown requested while the cycle is parked on the lock must break
+    /// promptly, not wait out the holder.
+    #[tokio::test]
+    async fn cancel_while_parked_on_lock_stops_scheduler() {
+        let rec = recorder();
+        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let held = cleanup_lock.clone().lock_owned().await;
+
+        let cancel = CancellationToken::new();
+        let handle = spawn_cleanup_scheduler(
+            vec![recording_pass(
+                "retention",
+                Duration::from_millis(100),
+                &rec,
+            )],
+            cleanup_lock,
+            cancel.clone(),
+        );
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("scheduler did not stop when cancelled while parked on the lock")
+            .unwrap();
+
+        assert!(rec.lock().is_empty());
+        drop(held);
+    }
+}

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -14,7 +14,7 @@
 //! - **Raw**: no orphan detection (no version/reference model)
 
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 use std::time::Instant;
 
 use prometheus::{
@@ -818,82 +818,6 @@ async fn clean_pypi_metadata(
 }
 
 // ============================================================================
-// Background scheduler
-// ============================================================================
-
-/// Spawn a background GC task that runs periodically.
-/// Accepts a shared cleanup lock to prevent concurrent runs with retention scheduler.
-/// Returns a `JoinHandle` so the caller can await graceful completion on shutdown.
-pub fn spawn_gc_scheduler(
-    storage: Storage,
-    publish_locks: PublishLocks,
-    interval_secs: u64,
-    dry_run: bool,
-    grace_secs: u64,
-    cleanup_lock: Arc<tokio::sync::Mutex<()>>,
-    cancel: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
-        // The interval's first tick fires immediately: GC runs once at boot,
-        // then every `interval_secs` — a process restarting more often than
-        // the interval otherwise never collects anything (see the matching
-        // note in `spawn_retention_scheduler`).
-        let mut boot_run = true;
-
-        loop {
-            // CANCEL-SAFETY: interval.tick() holds no state between polls.
-            // cancel.cancelled() is a CancellationToken — safe to drop at any point.
-            // GC work happens entirely within the tick handler below, not across awaits.
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    info!("GC scheduler: cancellation requested, stopping");
-                    break;
-                }
-                _ = interval.tick() => {}
-            }
-
-            if cancel.is_cancelled() {
-                break;
-            }
-
-            // Cross-scheduler lock: skip if GC or retention is already running.
-            // The boot run waits for the lock instead — retention's boot pass
-            // fires at the same instant, and skipping would postpone the first
-            // GC by a whole interval again.
-            let guard = if boot_run {
-                boot_run = false;
-                // CANCEL-SAFETY: the boot pass waits on the lock (vs skip-if-held) so it
-                // can't forfeit its first run to retention's simultaneous boot pass — but
-                // race the wait against cancellation, so a SIGTERM during boot contention
-                // breaks promptly instead of blocking behind the sibling's whole pass.
-                // Dropping the not-yet-acquired lock() future only removes this waiter.
-                tokio::select! {
-                    _ = cancel.cancelled() => break,
-                    g = cleanup_lock.lock() => Ok(g),
-                }
-            } else {
-                cleanup_lock.try_lock()
-            };
-            let Ok(guard) = guard else {
-                info!("GC: cleanup lock held (GC or retention running), skipping");
-                continue;
-            };
-
-            info!("GC scheduler: starting periodic run");
-            let result = run_gc(&storage, &publish_locks, dry_run, grace_secs).await;
-            info!(
-                "GC scheduler: done in {:.1}s — {} orphans, {} deleted, {} bytes freed, {} metadata phantoms, {} skipped (grace)",
-                result.duration_secs, result.orphaned, result.deleted, result.bytes_freed,
-                result.metadata_phantoms_removed, result.skipped_recent
-            );
-
-            drop(guard);
-        }
-    })
-}
-
-// ============================================================================
 // Tests
 // ============================================================================
 
@@ -901,6 +825,7 @@ pub fn spawn_gc_scheduler(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn test_publish_locks() -> PublishLocks {
         Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
@@ -1888,138 +1813,5 @@ mod tests {
         assert_eq!(result.orphaned, 1); // docker blob
         assert_eq!(result.deleted, 1);
         assert_eq!(result.metadata_phantoms_removed, 1); // npm phantom
-    }
-
-    /// The scheduler must run once at boot, not a full interval later — a
-    /// process that restarts more often than the interval otherwise never
-    /// collects anything.
-    #[tokio::test]
-    async fn test_gc_scheduler_runs_at_boot() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
-        // Orphan checksum sidecar: no primary artifact next to it.
-        storage
-            .put("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256", b"deadbeef")
-            .await
-            .unwrap();
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let handle = spawn_gc_scheduler(
-            storage.clone(),
-            test_publish_locks(),
-            86400, // the boot run must not wait for this
-            false,
-            0,
-            Arc::new(tokio::sync::Mutex::new(())),
-            cancel.clone(),
-        );
-
-        let deadline = Instant::now() + std::time::Duration::from_secs(10);
-        while storage
-            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
-            .await
-            .is_ok()
-        {
-            assert!(Instant::now() < deadline, "boot run never fired");
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-        cancel.cancel();
-        handle.await.unwrap();
-    }
-
-    /// The boot pass waits on the shared cleanup lock instead of the
-    /// periodic skip-if-held — losing the boot race to the sibling scheduler
-    /// must delay the first run, not forfeit it for a whole interval.
-    #[tokio::test]
-    async fn test_gc_boot_run_waits_for_cleanup_lock() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
-        storage
-            .put("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256", b"deadbeef")
-            .await
-            .unwrap();
-
-        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
-        let held = cleanup_lock.clone().lock_owned().await;
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let handle = spawn_gc_scheduler(
-            storage.clone(),
-            test_publish_locks(),
-            86400,
-            false,
-            0,
-            cleanup_lock,
-            cancel.clone(),
-        );
-
-        // While the lock is held the boot pass must be parked, not skipped.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        assert!(storage
-            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
-            .await
-            .is_ok());
-
-        drop(held);
-        let deadline = Instant::now() + std::time::Duration::from_secs(10);
-        while storage
-            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
-            .await
-            .is_ok()
-        {
-            assert!(
-                Instant::now() < deadline,
-                "boot run skipped instead of waiting for the lock"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-        cancel.cancel();
-        handle.await.unwrap();
-    }
-
-    /// A shutdown requested while the boot pass is parked on the cleanup lock
-    /// must break promptly — not wait out the lock holder and then run a full
-    /// pass after cancellation was already requested.
-    #[tokio::test]
-    async fn test_gc_boot_run_cancels_while_parked() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
-        // Orphan checksum sidecar the boot GC would collect if it ever ran.
-        storage
-            .put("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256", b"deadbeef")
-            .await
-            .unwrap();
-
-        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
-        let held = cleanup_lock.clone().lock_owned().await;
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let handle = spawn_gc_scheduler(
-            storage.clone(),
-            test_publish_locks(),
-            86400,
-            false,
-            0,
-            cleanup_lock,
-            cancel.clone(),
-        );
-
-        // Let the boot pass reach the parked lock().await, then ask to stop.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        cancel.cancel();
-
-        // The scheduler must stop even though the lock is still held — the boot
-        // acquire races cancellation, so it can't block behind the holder.
-        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-            .await
-            .expect("scheduler did not stop when cancelled while parked on the boot lock")
-            .unwrap();
-
-        // It never acquired the lock, so it never collected the orphan.
-        assert!(storage
-            .get("npm/lodash/tarballs/lodash-1.0.0.tgz.sha256")
-            .await
-            .is_ok());
-        drop(held);
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -26,6 +26,7 @@ mod auth;
 mod backup;
 mod cache_ttl;
 mod circuit_breaker;
+mod cleanup;
 mod config;
 mod curation;
 mod dashboard_metrics;
@@ -1611,23 +1612,99 @@ async fn run_server(mut config: Config, storage: Storage) {
     let registry_names: Vec<&str> = RegistryType::all().iter().map(|rt| rt.as_str()).collect();
     state.circuit_breaker.init_gauges(&registry_names);
 
-    // Shared lock: GC and Retention must not run concurrently (both call storage.delete)
+    // Shared lock: nothing that calls storage.delete may run concurrently.
+    // The periodic cleanup cycle takes it once per cycle and runs every due
+    // pass under it; it also serializes future manual/admin cleanup entry
+    // points against that cycle.
     let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
 
     let mut scheduler_handles: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
-    // Spawn background GC scheduler if enabled
-    if state.config.gc.enabled {
-        let handle = gc::spawn_gc_scheduler(
-            state.storage.clone(),
-            state.publish_locks.clone(),
-            state.config.gc.interval,
-            state.config.gc.dry_run,
-            state.config.gc.grace_secs,
-            cleanup_lock.clone(),
-            cancel_token.clone(),
+    // Retention is pushed first: it deletes expired versions, creating the
+    // orphans the GC pass then sweeps in the same cycle.
+    let mut cleanup_passes: Vec<cleanup::CleanupPass> = Vec::new();
+
+    if state.config.retention.enabled && !state.config.retention.rules.is_empty() {
+        let storage = state.storage.clone();
+        let publish_locks = state.publish_locks.clone();
+        let signer = state.signer.clone();
+        let rules = state.config.retention.rules.clone();
+        let dry_run = state.config.retention.dry_run;
+        let audit = state.audit.clone();
+        cleanup_passes.push(cleanup::CleanupPass {
+            name: "retention",
+            interval: std::time::Duration::from_secs(state.config.retention.interval),
+            run: Box::new(move || {
+                let storage = storage.clone();
+                let publish_locks = publish_locks.clone();
+                let signer = signer.clone();
+                let rules = rules.clone();
+                let audit = audit.clone();
+                async move {
+                    info!(
+                        dry_run = dry_run,
+                        "Retention scheduler: starting periodic run"
+                    );
+                    let result = retention::run_retention(
+                        &storage,
+                        &publish_locks,
+                        signer.as_deref(),
+                        &rules,
+                        dry_run,
+                    )
+                    .await;
+                    info!(
+                        "Retention scheduler: done in {:.1}s — {} versions, {} keys, {} bytes freed",
+                        result.duration_secs, result.planned, result.deleted_keys, result.bytes_freed
+                    );
+
+                    if result.planned > 0 {
+                        audit.log(audit::AuditEntry::new(
+                            "retention-apply",
+                            "scheduler",
+                            &format!("{} versions", result.planned),
+                            "*",
+                            &format!(
+                                "keys={} bytes_freed={} duration={:.1}s",
+                                result.deleted_keys, result.bytes_freed, result.duration_secs
+                            ),
+                        ));
+                    }
+                }
+                .boxed()
+            }),
+        });
+        info!(
+            interval_secs = state.config.retention.interval,
+            rules = state.config.retention.rules.len(),
+            dry_run = state.config.retention.dry_run,
+            "Retention scheduler started"
         );
-        scheduler_handles.push(handle);
+    }
+
+    if state.config.gc.enabled {
+        let storage = state.storage.clone();
+        let publish_locks = state.publish_locks.clone();
+        let dry_run = state.config.gc.dry_run;
+        let grace_secs = state.config.gc.grace_secs;
+        cleanup_passes.push(cleanup::CleanupPass {
+            name: "gc",
+            interval: std::time::Duration::from_secs(state.config.gc.interval),
+            run: Box::new(move || {
+                let storage = storage.clone();
+                let publish_locks = publish_locks.clone();
+                async move {
+                    info!("GC scheduler: starting periodic run");
+                    let result = gc::run_gc(&storage, &publish_locks, dry_run, grace_secs).await;
+                    info!(
+                        "GC scheduler: done in {:.1}s — {} orphans, {} deleted, {} bytes freed, {} metadata phantoms, {} skipped (grace)",
+                        result.duration_secs, result.orphaned, result.deleted, result.bytes_freed,
+                        result.metadata_phantoms_removed, result.skipped_recent
+                    );
+                }
+                .boxed()
+            }),
+        });
         info!(
             interval_secs = state.config.gc.interval,
             dry_run = state.config.gc.dry_run,
@@ -1635,26 +1712,12 @@ async fn run_server(mut config: Config, storage: Storage) {
         );
     }
 
-    // Spawn background retention scheduler if enabled
-    if state.config.retention.enabled && !state.config.retention.rules.is_empty() {
-        let handle = retention::spawn_retention_scheduler(
-            state.storage.clone(),
-            state.publish_locks.clone(),
-            state.signer.clone(),
-            state.config.retention.rules.clone(),
-            state.config.retention.interval,
-            state.config.retention.dry_run,
-            Some(state.audit.clone()),
-            cleanup_lock.clone(),
+    if !cleanup_passes.is_empty() {
+        scheduler_handles.push(cleanup::spawn_cleanup_scheduler(
+            cleanup_passes,
+            cleanup_lock,
             cancel_token.clone(),
-        );
-        scheduler_handles.push(handle);
-        info!(
-            interval_secs = state.config.retention.interval,
-            rules = state.config.retention.rules.len(),
-            dry_run = state.config.retention.dry_run,
-            "Retention scheduler started"
-        );
+        ));
     }
 
     let app = Router::new()

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -6,7 +6,7 @@
 //! Retention is per-registry and operates on "versions" (Maven versions,
 //! Docker tags, npm tarballs, PyPI files, Cargo versions, Go modules).
 
-use std::sync::{Arc, LazyLock};
+use std::sync::LazyLock;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use prometheus::{
@@ -935,104 +935,6 @@ fn find_matching_rule<'a>(
 }
 
 // ============================================================================
-// Background scheduler
-// ============================================================================
-
-/// Spawn a background retention task that runs periodically.
-/// Accepts a shared cleanup lock to prevent concurrent runs with GC scheduler.
-/// Returns a `JoinHandle` so the caller can await graceful completion on shutdown.
-#[allow(clippy::too_many_arguments)]
-pub fn spawn_retention_scheduler(
-    storage: Storage,
-    publish_locks: PublishLocks,
-    signer: Option<Arc<crate::signing::RepoSigner>>,
-    rules: Vec<RetentionRule>,
-    interval_secs: u64,
-    dry_run: bool,
-    audit: Option<Arc<crate::audit::AuditLog>>,
-    cleanup_lock: Arc<tokio::sync::Mutex<()>>,
-    cancel: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
-        // The interval's first tick fires immediately: retention runs once at
-        // boot, then every `interval_secs`. Waiting a full interval instead
-        // means a process that restarts more often than the interval NEVER
-        // runs retention — deploy-happy environments accumulated unbounded
-        // garbage exactly when the schedule looked configured.
-        let mut boot_run = true;
-
-        loop {
-            // CANCEL-SAFETY: Same as GC — interval.tick() is stateless between polls,
-            // cancel.cancelled() is a CancellationToken. Retention work runs to
-            // completion within each tick iteration, no partial state on drop.
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    info!("Retention scheduler: cancellation requested, stopping");
-                    break;
-                }
-                _ = interval.tick() => {}
-            }
-
-            if cancel.is_cancelled() {
-                break;
-            }
-
-            // Cross-scheduler lock: skip if GC or retention is already running.
-            // The boot run waits for the lock instead — GC's boot pass fires at
-            // the same instant, and skipping here would silently postpone the
-            // first retention by a whole interval again.
-            let guard = if boot_run {
-                boot_run = false;
-                // CANCEL-SAFETY: the boot pass waits on the lock (vs skip-if-held) so it
-                // can't forfeit its first run to GC's simultaneous boot pass — but race
-                // the wait against cancellation, so a SIGTERM during boot contention
-                // breaks promptly instead of blocking behind the sibling's whole pass.
-                // Dropping the not-yet-acquired lock() future only removes this waiter.
-                tokio::select! {
-                    _ = cancel.cancelled() => break,
-                    g = cleanup_lock.lock() => Ok(g),
-                }
-            } else {
-                cleanup_lock.try_lock()
-            };
-            let Ok(guard) = guard else {
-                info!("Retention: cleanup lock held (GC or retention running), skipping");
-                continue;
-            };
-
-            info!(
-                dry_run = dry_run,
-                "Retention scheduler: starting periodic run"
-            );
-            let result =
-                run_retention(&storage, &publish_locks, signer.as_deref(), &rules, dry_run).await;
-            info!(
-                "Retention scheduler: done in {:.1}s — {} versions, {} keys, {} bytes freed",
-                result.duration_secs, result.planned, result.deleted_keys, result.bytes_freed
-            );
-
-            if let Some(ref audit_log) = audit {
-                if result.planned > 0 {
-                    audit_log.log(crate::audit::AuditEntry::new(
-                        "retention-apply",
-                        "scheduler",
-                        &format!("{} versions", result.planned),
-                        "*",
-                        &format!(
-                            "keys={} bytes_freed={} duration={:.1}s",
-                            result.deleted_keys, result.bytes_freed, result.duration_secs
-                        ),
-                    ));
-                }
-            }
-
-            drop(guard);
-        }
-    })
-}
-
-// ============================================================================
 // Tests
 // ============================================================================
 
@@ -1040,6 +942,7 @@ pub fn spawn_retention_scheduler(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     fn test_publish_locks() -> PublishLocks {
         Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new()))
@@ -1265,163 +1168,6 @@ mod tests {
             .get("maven/com/example/lib/3.0/lib-3.0.jar")
             .await
             .is_ok());
-    }
-
-    /// The scheduler must run once at boot, not a full interval later — a
-    /// process that restarts more often than the interval otherwise never
-    /// runs retention at all.
-    #[tokio::test]
-    async fn test_scheduler_runs_at_boot() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
-        storage
-            .put("maven/com/test/a/1.0/a.jar", b"data")
-            .await
-            .unwrap();
-        storage
-            .put("maven/com/test/a/2.0/a.jar", b"data")
-            .await
-            .unwrap();
-
-        let rules = vec![RetentionRule {
-            registry: "maven".to_string(),
-            name_glob: None,
-            keep_last: Some(1),
-            older_than_days: None,
-            exclude_tags: vec![],
-        }];
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let handle = spawn_retention_scheduler(
-            storage.clone(),
-            test_publish_locks(),
-            None,
-            rules,
-            86400, // the boot run must not wait for this
-            false,
-            None,
-            Arc::new(tokio::sync::Mutex::new(())),
-            cancel.clone(),
-        );
-
-        let deadline = Instant::now() + std::time::Duration::from_secs(10);
-        while storage.get("maven/com/test/a/1.0/a.jar").await.is_ok() {
-            assert!(Instant::now() < deadline, "boot run never fired");
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-        assert!(storage.get("maven/com/test/a/2.0/a.jar").await.is_ok());
-        cancel.cancel();
-        handle.await.unwrap();
-    }
-
-    /// The boot pass waits on the shared cleanup lock instead of the
-    /// periodic skip-if-held — losing the boot race to GC must delay the
-    /// first run, not forfeit it for a whole interval.
-    #[tokio::test]
-    async fn test_boot_run_waits_for_cleanup_lock() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
-        storage
-            .put("maven/com/test/a/1.0/a.jar", b"data")
-            .await
-            .unwrap();
-        storage
-            .put("maven/com/test/a/2.0/a.jar", b"data")
-            .await
-            .unwrap();
-
-        let rules = vec![RetentionRule {
-            registry: "maven".to_string(),
-            name_glob: None,
-            keep_last: Some(1),
-            older_than_days: None,
-            exclude_tags: vec![],
-        }];
-        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
-        let held = cleanup_lock.clone().lock_owned().await;
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let handle = spawn_retention_scheduler(
-            storage.clone(),
-            test_publish_locks(),
-            None,
-            rules,
-            86400,
-            false,
-            None,
-            cleanup_lock,
-            cancel.clone(),
-        );
-
-        // While the lock is held the boot pass must be parked, not skipped.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        assert!(storage.get("maven/com/test/a/1.0/a.jar").await.is_ok());
-
-        drop(held);
-        let deadline = Instant::now() + std::time::Duration::from_secs(10);
-        while storage.get("maven/com/test/a/1.0/a.jar").await.is_ok() {
-            assert!(
-                Instant::now() < deadline,
-                "boot run skipped instead of waiting for the lock"
-            );
-            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        }
-        cancel.cancel();
-        handle.await.unwrap();
-    }
-
-    /// A shutdown requested while the boot pass is parked on the cleanup lock
-    /// must break promptly — not wait out the lock holder and then run a full
-    /// pass after cancellation was already requested.
-    #[tokio::test]
-    async fn test_retention_boot_run_cancels_while_parked() {
-        let dir = tempfile::tempdir().unwrap();
-        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
-        storage
-            .put("maven/com/test/a/1.0/a.jar", b"data")
-            .await
-            .unwrap();
-        storage
-            .put("maven/com/test/a/2.0/a.jar", b"data")
-            .await
-            .unwrap();
-
-        let rules = vec![RetentionRule {
-            registry: "maven".to_string(),
-            name_glob: None,
-            keep_last: Some(1),
-            older_than_days: None,
-            exclude_tags: vec![],
-        }];
-        let cleanup_lock = Arc::new(tokio::sync::Mutex::new(()));
-        let held = cleanup_lock.clone().lock_owned().await;
-
-        let cancel = tokio_util::sync::CancellationToken::new();
-        let handle = spawn_retention_scheduler(
-            storage.clone(),
-            test_publish_locks(),
-            None,
-            rules,
-            86400,
-            false,
-            None,
-            cleanup_lock,
-            cancel.clone(),
-        );
-
-        // Let the boot pass reach the parked lock().await, then ask to stop.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-        cancel.cancel();
-
-        // The scheduler must stop even though the lock is still held — the boot
-        // acquire races cancellation, so it can't block behind the holder.
-        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
-            .await
-            .expect("scheduler did not stop when cancelled while parked on the boot lock")
-            .unwrap();
-
-        // It never acquired the lock, so it never pruned the dominated version.
-        assert!(storage.get("maven/com/test/a/1.0/a.jar").await.is_ok());
-        drop(held);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

GC and retention ran as two independent tokio tasks with identical default intervals (24h), sharing one `cleanup_lock`. Both ticked at the same instant every cycle; the periodic path used `try_lock`, so GC took the lock and retention skipped with no retry:

```
19:40:00.838634  INFO nora::gc         GC scheduler: starting periodic run
19:40:00.838689  INFO nora::retention  Retention: cleanup lock held (GC or retention running), skipping
```

Same millisecond, identical on consecutive days. In a production deployment with both schedulers on the default 24h interval, age-based retention never ran.

## Fix

One periodic cleanup task replaces both schedulers (`nora-registry/src/cleanup.rs`):

- **One task, one lock hold per cycle.** Each cycle acquires `cleanup_lock` once and runs every due pass under it. The acquisition **waits** instead of `try_lock`-and-skip — the starvation race is gone by construction, since this task is now the only periodic contender. The lock is kept because the `cleanup_lock` → `publish_lock` ordering invariant and any future manual/admin cleanup entry point still need a guard. Both the sleep and the lock acquire race cancellation, so SIGTERM stays prompt.
- **Retention → GC order.** Retention deletes expired versions and files, creating exactly the orphans the GC pass then sweeps, so one cycle reclaims what the split design needed two cycles for.
- **Per-pass intervals honored.** Each pass keeps its own configured interval; the next wake is the earliest due time. Due times are computed from the wake instant, so same-interval passes stay phase-locked and chain in every cycle, and a pass overrunning its interval fires again on the next loop.
- **Boot cycle preserved.** Every pass is due at boot — a process restarting more often than its interval must still clean.
- **Panic isolation.** A panicking pass is caught: it can neither skip the later passes of its own cycle nor kill the scheduler.

Per-pass logging and the retention audit entry are unchanged. `spawn_gc_scheduler` and `spawn_retention_scheduler` are deleted along with their scheduler tests; `run_gc` and `run_retention` are untouched.

## Tests

- `cycle_runs_passes_in_order_at_boot` — the first cycle fires at boot (well under the interval) and records retention before GC.
- `pass_panic_does_not_prevent_later_passes` — a pass that panics every cycle does not stop the later pass in the same cycle, and the scheduler survives into the next cycle.
- `cycle_waits_for_cleanup_lock_instead_of_skipping` — with the lock held nothing runs; on release both passes run, so the periodic path parks instead of skipping.
- `cancel_while_parked_on_lock_stops_scheduler` — cancellation while parked on the lock stops the task promptly, with no pass run.
