### PR TITLE
feat(docker): cross-repo blob mount (?mount=&from=)

### DIFF
--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -1110,6 +1110,9 @@ mod tests {
         )> {
             Err(crate::storage::StorageError::NotFound)
         }
+        async fn copy(&self, _src: &str, _dst: &str) -> crate::storage::Result<()> {
+            Err(crate::storage::StorageError::NotFound)
+        }
     }
 
     /// #610 (hardening for #584): an orphan whose age cannot be determined

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -455,14 +455,19 @@ pub async fn docker_manifest_delete() {}
 /// Start blob upload
 ///
 /// Initiates a resumable blob upload. Returns a Location header with the upload URL.
+/// With `mount` + `from`, links a blob the source repository already holds instead;
+/// if it cannot be mounted, an upload session is started as usual.
 #[utoipa::path(
     post,
     path = "/v2/{name}/blobs/uploads/",
     tag = "docker",
     params(
-        ("name" = String, Path, description = "Repository name")
+        ("name" = String, Path, description = "Repository name"),
+        ("mount" = Option<String>, Query, description = "Digest of an existing blob to mount (sha256:...)"),
+        ("from" = Option<String>, Query, description = "Repository that holds the blob to mount")
     ),
     responses(
+        (status = 201, description = "Blob mounted, Location header contains the blob URL"),
         (status = 202, description = "Upload started, Location header contains upload URL"),
         (status = 400, description = "Invalid input", body = ErrorResponse),
         (status = 429, description = "Rate limit exceeded. Retry-After header indicates wait time")

--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -1108,6 +1108,9 @@ mod tests {
             ) -> StorageResult<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
                 Err(StorageError::NotFound)
             }
+            async fn copy(&self, _src: &str, _dst: &str) -> StorageResult<()> {
+                Err(StorageError::NotFound)
+            }
         }
 
         let storage = Storage::from_backend(std::sync::Arc::new(FailingGetBackend));

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -905,6 +905,10 @@ async fn docker_v2_dispatch(
                             body,
                         )
                         .await
+                    } else if let (Some(digest), Some(from)) =
+                        (params.get("mount"), params.get("from"))
+                    {
+                        mount_blob(state, name, from, digest).await
                     } else {
                         start_upload(state, Path(name.to_string())).await
                     }
@@ -1425,6 +1429,97 @@ async fn download_blob(
     StatusCode::NOT_FOUND.into_response()
 }
 
+/// 201 for a blob that is now present in `name`, in the shape `upload_blob`
+/// returns.
+fn blob_created(name: &str, digest: &str) -> Response {
+    (
+        StatusCode::CREATED,
+        [
+            (header::LOCATION, format!("/v2/{}/blobs/{}", name, digest)),
+            (
+                HeaderName::from_static("docker-content-digest"),
+                digest.to_string(),
+            ),
+        ],
+    )
+        .into_response()
+}
+
+/// Cross-repo blob mount: `POST /v2/{name}/blobs/uploads/?mount=<digest>&from=<repo>`
+/// links a blob that `from` already holds into `name` with no re-upload.
+///
+/// Every reason a mount cannot happen — unknown digest, unusable source repo,
+/// storage failure, a digest still held by quarantine — degrades to a normal
+/// upload session (202) instead of an error, as the OCI distribution spec
+/// requires: the client then pushes the blob itself.
+async fn mount_blob(state: State<AppState>, raw_name: &str, from: &str, digest: &str) -> Response {
+    let c = canonicalize(raw_name, &state.config.docker);
+    if let Some(r) = c.denied_response() {
+        return r;
+    }
+    let name = c.name;
+    if let Err(e) = validate_docker_name(&name) {
+        return (StatusCode::BAD_REQUEST, e.to_string()).into_response();
+    }
+
+    let Some(hex) = digest.strip_prefix("sha256:") else {
+        return start_upload(state, Path(raw_name.to_string())).await;
+    };
+    if validate_digest(digest).is_err() {
+        return start_upload(state, Path(raw_name.to_string())).await;
+    }
+
+    // Reads are never namespace-gated (see docker_v2_dispatch); the write scope
+    // on `name` was already enforced there.
+    let c_from = canonicalize(from, &state.config.docker);
+    if c_from.denied || validate_docker_name(&c_from.name).is_err() {
+        return start_upload(state, Path(raw_name.to_string())).await;
+    }
+
+    // Must match the key upload finalization writes.
+    let dst_key = format!("docker/{}/blobs/{}", name, digest);
+    if state.storage.stat(&dst_key).await.is_some() {
+        return blob_created(&name, digest);
+    }
+
+    // A digest still inside its proxy cooldown must not be laundered into a
+    // local repository by a mount.
+    if quarantine_cache_serve_gate(&state, digest).is_some() {
+        return start_upload(state, Path(raw_name.to_string())).await;
+    }
+
+    let ns_key = blob_key(c_from.namespace.as_deref(), &c_from.name, digest);
+    let legacy_key = blob_key(None, &c_from.name, digest);
+    let src_key = if state.storage.stat(&ns_key).await.is_some() {
+        ns_key
+    } else if ns_key != legacy_key && state.storage.stat(&legacy_key).await.is_some() {
+        legacy_key
+    } else {
+        return start_upload(state, Path(raw_name.to_string())).await;
+    };
+
+    if let Err(e) = state.storage.copy(&src_key, &dst_key, Some(hex)).await {
+        tracing::warn!(error = %e, src = %src_key, dst = %dst_key, "Blob mount failed, falling back to upload");
+        return start_upload(state, Path(raw_name.to_string())).await;
+    }
+
+    state.audit.log(AuditEntry::new(
+        "mount",
+        "api",
+        &format!("{}@{}", name, digest),
+        "docker",
+        "blob",
+    ));
+    state.activity.push(ActivityEntry::new(
+        ActionType::Push,
+        format!("{}@{}", name, &digest[..19.min(digest.len())]),
+        crate::registry_type::RegistryType::Docker,
+        "LOCAL",
+    ));
+    state.repo_index.invalidate("docker");
+    blob_created(&name, digest)
+}
+
 async fn start_upload(State(state): State<AppState>, Path(name): Path<String>) -> Response {
     let c = canonicalize(&name, &state.config.docker);
     if let Some(r) = c.denied_response() {
@@ -1890,18 +1985,7 @@ async fn upload_blob(
                 "LOCAL",
             ));
             state.repo_index.invalidate("docker");
-            let location = format!("/v2/{}/blobs/{}", name, digest);
-            (
-                StatusCode::CREATED,
-                [
-                    (header::LOCATION, location),
-                    (
-                        HeaderName::from_static("docker-content-digest"),
-                        digest.to_string(),
-                    ),
-                ],
-            )
-                .into_response()
+            blob_created(&name, digest)
         }
         Err(e) => {
             tracing::error!(error = %e, key = %key, name = %name, "Failed to store blob");
@@ -4227,6 +4311,116 @@ mod integration_tests {
             StatusCode::OK,
             "blob must exist after a single-POST upload"
         );
+    }
+
+    #[tokio::test]
+    async fn test_docker_cross_repo_blob_mount() {
+        let ctx = create_test_context();
+        let blob_data = b"cross-repo mounted layer";
+        let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(blob_data)));
+
+        let resp = send(
+            &ctx.app,
+            Method::POST,
+            &format!("/v2/srcrepo/blobs/uploads/?digest={}", digest),
+            Body::from(&blob_data[..]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let mount_url = format!("/v2/dstrepo/blobs/uploads/?mount={}&from=srcrepo", digest);
+        let resp = send(&ctx.app, Method::POST, &mount_url, Body::empty()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::CREATED,
+            "a blob the source repo holds must mount without an upload"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(header::LOCATION)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            format!("/v2/dstrepo/blobs/{}", digest)
+        );
+        assert_eq!(
+            resp.headers()
+                .get("docker-content-digest")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            digest
+        );
+
+        let get = send(
+            &ctx.app,
+            Method::GET,
+            &format!("/v2/dstrepo/blobs/{}", digest),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(get.status(), StatusCode::OK);
+        assert_eq!(&body_bytes(get).await[..], &blob_data[..]);
+
+        // Already in the destination: answered from the destination copy, so a
+        // source that holds nothing still yields 201.
+        let resp = send(
+            &ctx.app,
+            Method::POST,
+            &format!("/v2/dstrepo/blobs/uploads/?mount={}&from=otherrepo", digest),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    async fn test_docker_mount_unknown_blob_falls_back_to_upload() {
+        let ctx = create_test_context();
+        let digest = format!("sha256:{}", "b".repeat(64));
+
+        let resp = send(
+            &ctx.app,
+            Method::POST,
+            &format!("/v2/dstrepo/blobs/uploads/?mount={}&from=srcrepo", digest),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::ACCEPTED,
+            "an unmountable blob must degrade to a normal upload session"
+        );
+        assert!(resp.headers().contains_key("docker-upload-uuid"));
+    }
+
+    #[tokio::test]
+    async fn test_docker_mount_invalid_source_repo_falls_back_to_upload() {
+        let ctx = create_test_context();
+        let blob_data = b"blob behind an unusable source name";
+        let digest = format!("sha256:{}", hex::encode(sha2::Sha256::digest(blob_data)));
+        let resp = send(
+            &ctx.app,
+            Method::POST,
+            &format!("/v2/srcrepo/blobs/uploads/?digest={}", digest),
+            Body::from(&blob_data[..]),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+
+        let resp = send(
+            &ctx.app,
+            Method::POST,
+            &format!("/v2/dstrepo/blobs/uploads/?mount={}&from=SRCREPO", digest),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::ACCEPTED,
+            "an invalid source repository must degrade to an upload session, not 4xx"
+        );
+        assert!(resp.headers().contains_key("docker-upload-uuid"));
     }
 
     #[tokio::test]

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -5731,6 +5731,9 @@ mod integration_tests {
         fn backend_name(&self) -> &'static str {
             "failing-prefix-test"
         }
+        async fn copy(&self, src: &str, dst: &str) -> crate::storage::Result<()> {
+            self.inner.copy(src, dst).await
+        }
         async fn put_from_path(
             &self,
             key: &str,

--- a/nora-registry/src/repo_index.rs
+++ b/nora-registry/src/repo_index.rs
@@ -1049,6 +1049,9 @@ mod tests {
             )> {
                 Err(crate::storage::StorageError::NotFound)
             }
+            async fn copy(&self, _src: &str, _dst: &str) -> crate::storage::Result<()> {
+                Err(crate::storage::StorageError::NotFound)
+            }
         }
 
         let stat_calls = Arc::new(AtomicUsize::new(0));

--- a/nora-registry/src/storage/local.rs
+++ b/nora-registry/src/storage/local.rs
@@ -321,6 +321,38 @@ impl StorageBackend for LocalStorage {
         }
     }
 
+    async fn copy(&self, src: &str, dst: &str) -> Result<()> {
+        let src_path = self.key_to_path(src);
+        let dst_path = self.key_to_path(dst);
+        if let Some(parent) = dst_path.parent() {
+            fs::create_dir_all(parent).await?;
+        }
+        // Hard link: the two keys share one inode, so a mounted blob costs no
+        // extra bytes and cannot drift from its source.
+        let linked = match fs::hard_link(&src_path, &dst_path).await {
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                fs::remove_file(&dst_path).await?;
+                fs::hard_link(&src_path, &dst_path).await
+            }
+            other => other,
+        };
+        match linked {
+            Ok(()) => sync_parent_dir(&dst_path).await,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(StorageError::NotFound),
+            // Cross-device, or a filesystem without links — copy the bytes.
+            Err(_) => {
+                fs::copy(&src_path, &dst_path).await.map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        StorageError::NotFound
+                    } else {
+                        StorageError::Io(e)
+                    }
+                })?;
+                sync_parent_dir(&dst_path).await
+            }
+        }
+    }
+
     async fn get_reader(&self, key: &str) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
         let path = self.key_to_path(key);
         let file = fs::File::open(&path).await.map_err(|e| {

--- a/nora-registry/src/storage/mod.rs
+++ b/nora-registry/src/storage/mod.rs
@@ -121,6 +121,13 @@ pub trait StorageBackend: Send + Sync {
     /// The caller is responsible for deleting `src` on error.
     async fn put_from_path(&self, key: &str, src: &Path) -> Result<()>;
 
+    /// Server-side copy of `src` to `dst` inside the backend — the bytes never
+    /// transit this process.
+    ///
+    /// Returns [`StorageError::NotFound`] when `src` does not exist; an existing
+    /// `dst` is overwritten.
+    async fn copy(&self, src: &str, dst: &str) -> Result<()>;
+
     /// Open an artifact for streaming read without loading it into memory (#580).
     ///
     /// Returns `(size_bytes, reader)`. The caller converts the reader to a
@@ -630,6 +637,61 @@ impl Storage {
         }
     }
 
+    /// Server-side copy of `src` to `dst` (see [`StorageBackend::copy`]).
+    ///
+    /// `sha256` is the lowercase hex digest of the copied bytes; when present it
+    /// is pinned for `dst` without reading the object back. When it is `None`,
+    /// `dst` inherits the pin of `src` if `src` carries one, and otherwise stays
+    /// open-world — as [`put_from_path`](Self::put_from_path) does.
+    pub async fn copy(&self, src: &str, dst: &str, sha256: Option<&str>) -> Result<()> {
+        validate_storage_key(src)?;
+        validate_storage_key(dst)?;
+        match self.inner.copy(src, dst).await {
+            Ok(()) => {
+                STORAGE_OPERATIONS.with_label_values(&["copy", "ok"]).inc();
+                let hash = sha256
+                    .map(str::to_ascii_lowercase)
+                    .or_else(|| self.get_pin_hash(src));
+                if let (Some(hash), Some(ref pins)) = (hash, &self.pin_store) {
+                    let pins = Arc::clone(pins);
+                    let key_owned = dst.to_string();
+                    // Fail closed like `put`/`put_from_path`: a copied-but-unpinned
+                    // blob would be served without verification (#582/#604).
+                    match tokio::task::spawn_blocking(move || pins.record_hash(&key_owned, &hash))
+                        .await
+                    {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            STORAGE_OPERATIONS
+                                .with_label_values(&["copy", "pin_error"])
+                                .inc();
+                            tracing::error!(error = %e, key = %dst, "hash-pin record failed");
+                            return Err(StorageError::Io(std::io::Error::other(format!(
+                                "hash-pin record failed: {e}"
+                            ))));
+                        }
+                        Err(e) => {
+                            STORAGE_OPERATIONS
+                                .with_label_values(&["copy", "pin_error"])
+                                .inc();
+                            tracing::error!(error = %e, key = %dst, "hash-pin record task panicked");
+                            return Err(StorageError::Io(std::io::Error::other(format!(
+                                "hash-pin record failed: {e}"
+                            ))));
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => {
+                STORAGE_OPERATIONS
+                    .with_label_values(&["copy", "error"])
+                    .inc();
+                Err(e)
+            }
+        }
+    }
+
     /// Open an artifact for streaming read without loading into memory (#580).
     ///
     /// Returns `(size_bytes, reader)`. Pin-store integrity is NOT checked here
@@ -728,6 +790,49 @@ mod tests {
         );
         // And the recorded pin must match the bytes (a subsequent get verifies).
         assert_eq!(&storage.get("raw/x/app.bin").await.unwrap()[..], b"payload");
+    }
+
+    /// A cross-repo copy must land the same bytes AND arrive pinned, so the
+    /// destination is served verified rather than open-world.
+    #[tokio::test]
+    async fn copy_duplicates_bytes_and_pins_destination() {
+        use nora_registry::verified::GateOutcome;
+
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+        let hash = hex::encode(Sha256::digest(b"layer"));
+
+        storage.put("docker/src/blobs/x", b"layer").await.unwrap();
+        storage
+            .copy("docker/src/blobs/x", "docker/dst/blobs/x", Some(&hash))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            &storage.get("docker/dst/blobs/x").await.unwrap()[..],
+            b"layer"
+        );
+        assert_eq!(
+            storage.get_pin_hash("docker/dst/blobs/x").as_deref(),
+            Some(hash.as_str())
+        );
+        assert!(matches!(
+            storage.get_verified("docker/dst/blobs/x").await.unwrap(),
+            GateOutcome::Verified(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn copy_missing_source_is_not_found() {
+        let dir = TempDir::new().unwrap();
+        let storage = Storage::new_local(dir.path().to_str().unwrap());
+
+        assert!(matches!(
+            storage
+                .copy("docker/src/blobs/gone", "docker/dst/blobs/gone", None)
+                .await,
+            Err(StorageError::NotFound)
+        ));
     }
 
     #[test]

--- a/nora-registry/src/storage/object.rs
+++ b/nora-registry/src/storage/object.rs
@@ -401,6 +401,14 @@ impl StorageBackend for ObjectStorage {
         Ok(())
     }
 
+    async fn copy(&self, src: &str, dst: &str) -> Result<()> {
+        // Store-side copy (S3 CopyObject / GCS rewrite) — no bytes cross the
+        // network through this process.
+        let from_path = Path::from(encode_object_key(src));
+        let to_path = Path::from(encode_object_key(dst));
+        self.store.copy(&from_path, &to_path).await.map_err(map_err)
+    }
+
     async fn get_reader(&self, key: &str) -> Result<(u64, Pin<Box<dyn AsyncRead + Send + Unpin>>)> {
         let encoded = encode_object_key(key);
         let path = Path::from(encoded);


### PR DESCRIPTION
## Summary
- Implements Docker cross-repo blob mount (`?mount=<digest>&from=<repo>`) per OCI distribution spec
- Allows pushing layers that already exist in another repository without re-uploading
- Uses `StorageBackend::copy` to efficiently duplicate blobs across repos

Replaces #915 (reopened from main repo branch to resolve verified signatures + code owner review).

Original author: @jgrund

## Test plan
- [ ] Integration tests pass
- [ ] Cross-repo mount works end-to-end
- [ ] Falls back to regular upload when source blob doesn't exist