### PR TITLE
fix(gc,npm): skip proxy phantom cleanup and heal 304 body-miss loop

### DIFF
--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -120,6 +120,7 @@ pub async fn run_gc(
     publish_locks: &PublishLocks,
     dry_run: bool,
     grace_secs: u64,
+    npm_is_proxy: bool,
 ) -> GcResult {
     let start = Instant::now();
     info!(
@@ -235,7 +236,7 @@ pub async fn run_gc(
     // Metadata phantom cleanup (npm/PyPI) — acquires per-key publish_lock
     // to prevent lost-update race with concurrent publish (#529).
     let metadata_phantoms_removed =
-        detect_and_clean_metadata_phantoms(storage, publish_locks, dry_run).await;
+        detect_and_clean_metadata_phantoms(storage, publish_locks, dry_run, npm_is_proxy).await;
     if metadata_phantoms_removed > 0 {
         if !dry_run {
             GC_METADATA_PHANTOMS.inc_by(metadata_phantoms_removed as u64);
@@ -594,30 +595,39 @@ async fn detect_and_clean_metadata_phantoms(
     storage: &Storage,
     publish_locks: &PublishLocks,
     dry_run: bool,
+    npm_is_proxy: bool,
 ) -> usize {
     let mut total_removed = 0usize;
 
-    // npm metadata cleanup
-    let npm_keys = storage.list("npm/").await.unwrap_or_else(|e| {
-        tracing::error!("GC: storage.list(npm/) failed: {}", e);
-        Vec::new()
-    });
-    let mut npm_meta_keys: Vec<String> = Vec::new();
-    let mut npm_tarball_keys: HashSet<String> = HashSet::new();
-
-    for key in &npm_keys {
-        if ends_with_ci(key, "/metadata.json") {
-            npm_meta_keys.push(key.clone());
-        } else if key.contains("/tarballs/") {
-            npm_tarball_keys.insert(key.clone());
-        }
+    // npm metadata cleanup — skip when npm is configured as a proxy (#925).
+    // Proxy metadata is upstream-authoritative: absence of a local tarball is
+    // expected (on-demand caching), not an orphan signal.
+    if npm_is_proxy {
+        info!("GC: skipping npm phantom cleanup (proxy mode — tarballs are cached on demand)");
     }
+    if !npm_is_proxy {
+        let npm_keys = storage.list("npm/").await.unwrap_or_else(|e| {
+            tracing::error!("GC: storage.list(npm/) failed: {}", e);
+            Vec::new()
+        });
+        let mut npm_meta_keys: Vec<String> = Vec::new();
+        let mut npm_tarball_keys: HashSet<String> = HashSet::new();
 
-    for meta_key in &npm_meta_keys {
-        if let Some(removed) =
-            clean_npm_metadata(storage, publish_locks, meta_key, &npm_tarball_keys, dry_run).await
-        {
-            total_removed += removed;
+        for key in &npm_keys {
+            if ends_with_ci(key, "/metadata.json") {
+                npm_meta_keys.push(key.clone());
+            } else if key.contains("/tarballs/") {
+                npm_tarball_keys.insert(key.clone());
+            }
+        }
+
+        for meta_key in &npm_meta_keys {
+            if let Some(removed) =
+                clean_npm_metadata(storage, publish_locks, meta_key, &npm_tarball_keys, dry_run)
+                    .await
+            {
+                total_removed += removed;
+            }
         }
     }
 
@@ -875,7 +885,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.total_candidates, 0);
         assert_eq!(result.orphaned, 0);
         assert_eq!(result.deleted, 0);
@@ -906,7 +916,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.orphaned, 0);
     }
 
@@ -939,7 +949,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 0);
         assert!(result.orphan_keys[0].contains("orphan999"));
@@ -968,7 +978,7 @@ mod tests {
             .unwrap();
 
         // Generous grace: the orphan is detected but must NOT be deleted.
-        let result = run_gc(&storage, &test_publish_locks(), false, 3600).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 3600, false).await;
         assert_eq!(result.orphaned, 1, "orphan should be detected");
         assert_eq!(
             result.deleted, 0,
@@ -985,7 +995,7 @@ mod tests {
 
         // Dry-run honors grace too, so the preview matches `--apply`: a
         // protected orphan is reported as skipped, not as "would delete".
-        let preview = run_gc(&storage, &test_publish_locks(), true, 3600).await;
+        let preview = run_gc(&storage, &test_publish_locks(), true, 3600, false).await;
         assert_eq!(preview.skipped_recent, 1);
         assert_eq!(
             preview.bytes_freed, 0,
@@ -993,7 +1003,7 @@ mod tests {
         );
 
         // grace=0 (no concurrent writes): the same orphan is now collected.
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.deleted, 1, "grace=0 deletes the orphan");
         assert!(storage
             .get("docker/test/blobs/sha256:fresh000")
@@ -1025,7 +1035,7 @@ mod tests {
 
         // A short grace: a normal old orphan would be deleted, but a future
         // mtime must still be treated as "too young" and kept.
-        let result = run_gc(&storage, &test_publish_locks(), false, 60).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 60, false).await;
         assert_eq!(
             result.skipped_recent, 1,
             "future-mtime orphan must be protected (saturating_sub)"
@@ -1046,7 +1056,7 @@ mod tests {
         let key = "maven/com/example/1.0/old.jar.sha256";
         storage.put(key, b"deadbeef").await.unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 3600).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 3600, false).await;
         assert_eq!(result.orphaned, 1, "checksum orphan should be detected");
         assert_eq!(
             result.deleted, 0,
@@ -1128,7 +1138,7 @@ mod tests {
 
         // grace=0 would collect any normal orphan; the un-stattable one must
         // still survive because its age is unknown.
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
 
         assert_eq!(result.orphaned, 1, "the blob is detected as an orphan");
         assert_eq!(
@@ -1180,7 +1190,7 @@ mod tests {
             }
         };
 
-        let (_gc, ()) = tokio::join!(run_gc(&storage, &locks, false, 0), writer);
+        let (_gc, ()) = tokio::join!(run_gc(&storage, &locks, false, 0, false), writer);
 
         // Every key is either reaped by GC or present with exactly one of the two
         // intended bodies — atomic writes guarantee no partial/torn content.
@@ -1225,7 +1235,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert!(result.deleted >= 1);
 
         assert!(
@@ -1267,7 +1277,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 1);
         assert!(result.bytes_freed > 0);
@@ -1308,7 +1318,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.orphaned, 0);
     }
 
@@ -1330,7 +1340,7 @@ mod tests {
         // Raw: no GC coverage
         storage.put("raw/some-file.txt", b"raw-data").await.unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         // Cargo crate without index entry = 1 orphan
         // Go .zip without .info = 1 orphan (incomplete version)
         assert_eq!(result.orphaned, 2);
@@ -1359,7 +1369,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(
             result.orphaned, 0,
             "complete Go version should have no orphans"
@@ -1377,7 +1387,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.orphaned, 1);
         assert!(result.orphan_keys[0].ends_with(".mod"));
     }
@@ -1396,7 +1406,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(
             result.orphaned, 0,
             "cargo with matching index should have no orphans"
@@ -1414,7 +1424,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.orphaned, 1);
         assert!(result.orphan_keys[0].contains("index"));
     }
@@ -1445,7 +1455,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.orphaned, 2);
         assert_eq!(result.deleted, 2);
         // Non-orphan checksum still exists
@@ -1476,7 +1486,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 1);
         assert!(storage
@@ -1504,7 +1514,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 1);
     }
@@ -1541,7 +1551,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.orphaned, 2); // 1 docker blob + 1 maven checksum
         assert_eq!(result.deleted, 2);
     }
@@ -1572,7 +1582,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         // 4 checksums scanned, 0 orphans
         assert_eq!(result.total_candidates, 4);
         assert_eq!(result.orphaned, 0);
@@ -1600,7 +1610,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.deleted, 1);
         assert_eq!(result.bytes_freed, 5); // "12345" = 5 bytes
     }
@@ -1629,7 +1639,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.metadata_phantoms_removed, 0);
     }
 
@@ -1661,7 +1671,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.metadata_phantoms_removed, 1);
 
         // Dry run: metadata should be unchanged
@@ -1697,7 +1707,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.metadata_phantoms_removed, 1);
 
         // Verify phantom was removed
@@ -1731,7 +1741,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
         assert_eq!(result.metadata_phantoms_removed, 0);
     }
 
@@ -1759,7 +1769,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.metadata_phantoms_removed, 1);
 
         // Verify phantom was removed
@@ -1812,9 +1822,50 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
         assert_eq!(result.orphaned, 1); // docker blob
         assert_eq!(result.deleted, 1);
         assert_eq!(result.metadata_phantoms_removed, 1); // npm phantom
+    }
+
+    /// npm phantom cleanup must be skipped when npm is in proxy mode (#925).
+    /// Proxy metadata is upstream-authoritative; missing local tarballs are
+    /// expected (on-demand caching), not orphan signals.
+    #[tokio::test]
+    async fn test_gc_npm_proxy_skips_phantom_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // npm metadata with 2 versions, but only 1 tarball — a "phantom" in
+        // hosted mode, but legitimate in proxy mode.
+        let meta = serde_json::json!({
+            "versions": {"1.0.0": {}, "2.0.0": {}},
+            "time": {"1.0.0": "2024-01-01T00:00:00Z", "2.0.0": "2024-06-01T00:00:00Z"}
+        });
+        storage
+            .put(
+                "npm/express/metadata.json",
+                serde_json::to_vec(&meta).unwrap().as_slice(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("npm/express/tarballs/express-2.0.0.tgz", b"tarball")
+            .await
+            .unwrap();
+
+        // Hosted mode: phantom is cleaned
+        let hosted = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        assert_eq!(
+            hosted.metadata_phantoms_removed, 1,
+            "hosted: phantom detected"
+        );
+
+        // Proxy mode: phantom cleanup is skipped entirely
+        let proxy = run_gc(&storage, &test_publish_locks(), true, 0, true).await;
+        assert_eq!(
+            proxy.metadata_phantoms_removed, 0,
+            "proxy: npm phantom cleanup must be skipped"
+        );
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -657,8 +657,14 @@ async fn main() {
             let cli_publish_locks: PublishLocks = Arc::new(parking_lot::Mutex::new(HashMap::new()));
             // Grace applies to manual GC too: `nora gc --apply` is often run while
             // traffic is live, when in-flight pushes are most likely (#584).
-            let result =
-                gc::run_gc(&storage, &cli_publish_locks, dry_run, config.gc.grace_secs).await;
+            let result = gc::run_gc(
+                &storage,
+                &cli_publish_locks,
+                dry_run,
+                config.gc.grace_secs,
+                config.npm.proxy.is_some(),
+            )
+            .await;
             println!("GC Summary{}:", if dry_run { " (dry-run)" } else { "" });
             println!("  Candidates:       {}", result.total_candidates);
             println!("  Orphaned:          {}", result.orphaned);
@@ -1687,6 +1693,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         let publish_locks = state.publish_locks.clone();
         let dry_run = state.config.gc.dry_run;
         let grace_secs = state.config.gc.grace_secs;
+        let npm_is_proxy = state.config.npm.proxy.is_some();
         cleanup_passes.push(cleanup::CleanupPass {
             name: "gc",
             interval: std::time::Duration::from_secs(state.config.gc.interval),
@@ -1695,7 +1702,7 @@ async fn run_server(mut config: Config, storage: Storage) {
                 let publish_locks = publish_locks.clone();
                 async move {
                     info!("GC scheduler: starting periodic run");
-                    let result = gc::run_gc(&storage, &publish_locks, dry_run, grace_secs).await;
+                    let result = gc::run_gc(&storage, &publish_locks, dry_run, grace_secs, npm_is_proxy).await;
                     info!(
                         "GC scheduler: done in {:.1}s — {} orphans, {} deleted, {} bytes freed, {} metadata phantoms, {} skipped (grace)",
                         result.duration_secs, result.orphaned, result.deleted, result.bytes_freed,

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -7,7 +7,8 @@ use crate::auth::{enforce_namespace_scope, AuthenticatedUser, NamespaceAuthority
 use crate::metrics::METADATA_CORRUPT_TOTAL;
 use crate::registry::{
     circuit_open_response, method_not_allowed, nora_base_url, proxy_fetch, proxy_fetch_conditional,
-    proxy_forward_post, read_validators, write_validators, ProxyError, Revalidation, Validators,
+    proxy_forward_post, read_validators, validators_key, write_validators, ProxyError,
+    Revalidation, Validators,
 };
 use crate::registry_type::RegistryType;
 use crate::secrets::expose_opt;
@@ -703,22 +704,37 @@ async fn refetch_metadata(state: &AppState, path: &str, key: &str) -> Option<Vec
         // refresh its freshness so we don't revalidate again until the next TTL
         // window. No body was downloaded.
         Ok(Revalidation::NotModified) => {
-            let cached = state.storage.get(key).await.ok()?; // body gone → fail-open
-            crate::metrics::PROXY_UPSTREAM_304_TOTAL
-                .with_label_values(&["npm"])
-                .inc();
-            crate::metrics::PROXY_REVALIDATION_BYTES_SAVED_TOTAL
-                .with_label_values(&["npm"])
-                .inc_by(cached.len() as u64);
-            // Re-put bumps the file mtime (the freshness source) without an
-            // upstream download.
-            let storage = state.storage.clone();
-            let key_clone = key.to_string();
-            let body = cached.clone();
-            tokio::spawn(async move {
-                let _ = storage.put(&key_clone, &body).await;
-            });
-            Some(cached.to_vec())
+            match state.storage.get(key).await {
+                Ok(cached) => {
+                    crate::metrics::PROXY_UPSTREAM_304_TOTAL
+                        .with_label_values(&["npm"])
+                        .inc();
+                    crate::metrics::PROXY_REVALIDATION_BYTES_SAVED_TOTAL
+                        .with_label_values(&["npm"])
+                        .inc_by(cached.len() as u64);
+                    // Re-put bumps the file mtime (the freshness source) without an
+                    // upstream download.
+                    let storage = state.storage.clone();
+                    let key_clone = key.to_string();
+                    let body = cached.clone();
+                    tokio::spawn(async move {
+                        let _ = storage.put(&key_clone, &body).await;
+                    });
+                    Some(cached.to_vec())
+                }
+                Err(_) => {
+                    // Body gone (GC, retention, corruption). Delete the stale
+                    // validator sidecar so the next revalidation cycle does a
+                    // full unconditional fetch instead of looping on 304 (#867).
+                    let vkey = validators_key(key);
+                    let _ = state.storage.delete(&vkey).await;
+                    tracing::warn!(
+                        key = %key,
+                        "304 but cached body missing; cleared validators for full refetch"
+                    );
+                    None
+                }
+            }
         }
         // New body — rewrite, cache it, then persist the fresh validators.
         Ok(Revalidation::Modified { body, validators }) => {
@@ -3152,5 +3168,78 @@ mod spec_conformance_tests {
         // A non-audit npm POST is not read-eligible → still requires auth.
         let other = send(&ctx.app, Method::POST, "/npm/somepkg", "x").await;
         assert_eq!(other.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// #867: when a 304 revalidation finds the cached body missing (deleted by
+    /// GC, retention, or corruption between the handler's `get_verified` and
+    /// `refetch_metadata`'s second read), the stale `.meta` validator sidecar
+    /// must be deleted so the next revalidation cycle does a full unconditional
+    /// GET instead of looping on 304 forever.
+    ///
+    /// The handler's cache-hit gate (`get_verified`) requires the body to be
+    /// present, so the GC race can't be reproduced through the HTTP layer.
+    /// We call `refetch_metadata` directly with `.meta` seeded but body absent.
+    #[tokio::test]
+    async fn test_867_304_body_miss_clears_validators() {
+        use crate::registry::{read_validators, write_validators, Validators};
+        use crate::test_helpers::create_test_context_with_config;
+        use wiremock::matchers::{header_exists, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let upstream = MockServer::start().await;
+        // Respond 304 to any conditional request (has If-None-Match).
+        Mock::given(method("GET"))
+            .and(header_exists("if-none-match"))
+            .respond_with(ResponseTemplate::new(304))
+            .mount(&upstream)
+            .await;
+
+        let ctx = create_test_context_with_config(|cfg| {
+            cfg.npm.proxy = Some(upstream.uri());
+            cfg.npm.metadata_ttl = 0;
+            cfg.npm.revalidate = true;
+            cfg.npm.serve_stale = false;
+        });
+
+        let key = "npm/ghost-pkg/metadata.json";
+
+        // Seed validator sidecar WITHOUT the body — simulates GC/retention
+        // deleting the cached body while .meta survives.
+        write_validators(
+            &ctx.state.storage,
+            key,
+            &Validators {
+                etag: Some("\"stale-etag\"".to_string()),
+                last_modified: None,
+            },
+        )
+        .await;
+
+        // Preconditions: .meta exists, body does not.
+        assert!(
+            read_validators(&ctx.state.storage, key).await.is_some(),
+            "precondition: .meta must exist"
+        );
+        assert!(
+            ctx.state.storage.get(key).await.is_err(),
+            "precondition: body must be absent"
+        );
+
+        // Call refetch_metadata directly — simulates the race where the handler
+        // entered the cache-hit path (body was present at get_verified), TTL
+        // expired, but GC deleted the body before refetch_metadata re-reads it.
+        let result = refetch_metadata(&ctx.state, "ghost-pkg", key).await;
+        assert!(
+            result.is_none(),
+            "must return None when body is missing on 304"
+        );
+
+        // The critical assertion: .meta must be gone after the 304 body-miss.
+        // Before the fix, `.ok()?` silently returned None but left .meta intact,
+        // causing an infinite 304 loop on every subsequent TTL expiry.
+        assert!(
+            read_validators(&ctx.state.storage, key).await.is_none(),
+            "#867: validators must be cleared after 304 body-miss to break the infinite loop"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two lifecycle bugs where GC and revalidation don't account for proxy-mode semantics:

- **#925**: `clean_npm_metadata()` treats missing local tarballs as orphan signals and prunes them from metadata. In proxy mode, tarballs are cached on demand — their absence is expected, not an error. Fix: skip npm phantom cleanup when `npm.proxy` is configured.

- **#867**: `refetch_metadata()` on 304 Not Modified silently returns `None` when the cached body is missing, but leaves the `.meta` validator sidecar intact. Next TTL cycle reads stale validators, gets 304 again — infinite loop with no self-healing. Fix: on 304 body-miss, delete `.meta` before returning `None` so the next cycle does a full unconditional GET.

## Changes

### gc.rs (#925)
- Add `npm_is_proxy: bool` parameter to `run_gc()` and `detect_and_clean_metadata_phantoms()`
- When `true`, skip the entire npm phantom detection loop (PyPI cleanup unaffected)
- New test: `test_gc_npm_proxy_skips_phantom_cleanup` — same metadata yields 1 phantom in hosted mode, 0 in proxy mode

### npm.rs (#867)
- Replace `.ok()?` on `storage.get(key)` with explicit `match`
- `Err` branch: delete the validator sidecar (`<key>.meta`) and log a warning before returning `None`
- Import `validators_key` from the parent module

### main.rs
- Pass `config.npm.proxy.is_some()` to both `run_gc` callsites (CLI and scheduler)

## Risk Assessment

- **#925**: Zero risk to hosted npm. Proxy mode gets strictly fewer deletions (skip, not add). PyPI phantom cleanup is unaffected.
- **#867**: Only touches the 304 error path (body missing). Happy path (304 with body present) is unchanged. The fix is fail-safe: deleting a `.meta` sidecar triggers a full fetch, which is the correct recovery.
- Full suite: 1753 tests, 0 failures.

Closes #925, closes #867
