### PR TITLE
ci(release): publish to crates.io on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -649,3 +649,21 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ steps.helm_app.outputs.token }}
+
+  crates-publish:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: release
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+
+      - name: Publish to crates.io
+        run: cargo publish --manifest-path nora-registry/Cargo.toml
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `crates-publish` job to `release.yml` that runs `cargo publish` after the GitHub Release job succeeds
- Uses `CARGO_REGISTRY_TOKEN` secret (needs to be added to repo secrets)
- Runs on `ubuntu-latest`, installs stable Rust toolchain

Previously crates.io had to be published manually — last push was `0.2.35`, current is `1.2.0` (published manually today).

## Checklist

- [ ] Add `CARGO_REGISTRY_TOKEN` to repository secrets (Settings → Secrets → Actions)

Closes #924