### PR TITLE
chore: release v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ar",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "1.2.0",
+        version = "1.2.1",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, Conan, RPM, and Debian",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")


### PR DESCRIPTION
## v1.2.1

Patch release with three bug fixes:

- **#926** fix(retention): `exclude_tags` no longer consumes `keep_last` budget (PR #928)
- **#925** fix(gc): skip npm phantom cleanup in proxy mode (PR #929)
- **#867** fix(npm): heal 304 body-miss revalidation loop (PR #929)
- **ci**: publish to crates.io on tag push (PR #930)

After merge, tag `v1.2.1` on the merge commit to trigger the release pipeline.