### PR TITLE
security(ui): redact proxy_upstreams for anonymous callers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ar",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -2275,9 +2275,13 @@ Jd74nq6dNCjpWG4drIsyhqX+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod web_surface_gating_tests {
-    use crate::test_helpers::{create_test_context_with_auth, send, send_with_headers};
+    use crate::test_helpers::{
+        body_bytes, create_test_context_with_anonymous_read,
+        create_test_context_with_anonymous_read_and_config, create_test_context_with_auth, send,
+        send_with_headers,
+    };
     use axum::http::{Method, StatusCode};
-    use base64::Engine;
+    use base64::{engine::general_purpose::STANDARD, Engine};
 
     fn basic(user: &str, pass: &str) -> String {
         format!(
@@ -2368,5 +2372,153 @@ mod web_surface_gating_tests {
         });
         let resp = send(&ctx.app, Method::GET, "/api/ui/tokens", "").await;
         assert_ne!(resp.status(), StatusCode::OK);
+    }
+
+    // -- #934: opportunistic auth on open web surfaces --
+
+    /// try_basic_auth returns the username for valid htpasswd credentials.
+    #[test]
+    fn test_try_basic_auth_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("htpasswd");
+        let hash = bcrypt::hash("secret", 4).unwrap();
+        std::fs::write(&path, format!("admin:{hash}\n")).unwrap();
+        let htpasswd = super::HtpasswdAuth::from_file(&path).unwrap();
+        let encoded = STANDARD.encode("admin:secret");
+        assert_eq!(
+            super::try_basic_auth(&encoded, Some(&htpasswd)),
+            Some("admin".to_string())
+        );
+    }
+
+    /// try_basic_auth returns None for wrong password.
+    #[test]
+    fn test_try_basic_auth_wrong_password() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("htpasswd");
+        let hash = bcrypt::hash("secret", 4).unwrap();
+        std::fs::write(&path, format!("admin:{hash}\n")).unwrap();
+        let htpasswd = super::HtpasswdAuth::from_file(&path).unwrap();
+        let encoded = STANDARD.encode("admin:wrong");
+        assert_eq!(super::try_basic_auth(&encoded, Some(&htpasswd)), None);
+    }
+
+    /// try_basic_auth returns None when no htpasswd store is available.
+    #[test]
+    fn test_try_basic_auth_no_store() {
+        let encoded = STANDARD.encode("admin:secret");
+        assert_eq!(super::try_basic_auth(&encoded, None), None);
+    }
+
+    /// try_basic_auth returns None for garbage base64.
+    #[test]
+    fn test_try_basic_auth_invalid_base64() {
+        assert_eq!(super::try_basic_auth("%%%not-base64%%%", None), None);
+    }
+
+    /// On an open web surface (anonymous_read=true), valid Basic credentials
+    /// must produce a real AuthenticatedUser — not "anonymous". Verified via
+    /// /api/ui/dashboard: anonymous sees empty proxy_upstreams; authenticated
+    /// sees the configured npm upstream.
+    #[tokio::test]
+    async fn test_opportunistic_basic_auth_on_open_surface() {
+        let ctx = create_test_context_with_anonymous_read_and_config(&[("admin", "secret")], |c| {
+            c.npm.proxy = Some("https://registry.npmjs.org".into());
+        });
+
+        // Anonymous: proxy_upstreams redacted
+        let resp = send(&ctx.app, Method::GET, "/api/ui/dashboard", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        for mp in json["mount_points"].as_array().unwrap() {
+            assert!(
+                mp["proxy_upstreams"].as_array().unwrap().is_empty(),
+                "anonymous must see empty proxy_upstreams"
+            );
+        }
+
+        // Valid Basic creds: proxy_upstreams populated
+        let header_val = format!("Basic {}", STANDARD.encode("admin:secret"));
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/api/ui/dashboard",
+            vec![("authorization", &header_val)],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let npm = json["mount_points"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["registry"].as_str() == Some("npm"))
+            .expect("npm mount");
+        assert!(
+            !npm["proxy_upstreams"].as_array().unwrap().is_empty(),
+            "authenticated must see populated proxy_upstreams for npm"
+        );
+    }
+
+    /// On an open web surface, invalid Basic credentials fall through to
+    /// anonymous (the path is open — no 401).
+    #[tokio::test]
+    async fn test_opportunistic_bad_creds_fall_through_to_anonymous() {
+        let ctx = create_test_context_with_anonymous_read(&[("admin", "secret")]);
+
+        let bad = format!("Basic {}", STANDARD.encode("admin:wrong"));
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/api/ui/dashboard",
+            vec![("authorization", &bad)],
+            "",
+        )
+        .await;
+        // Open path — no 401 even with bad creds
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// On an open web surface, a valid Bearer token must produce a real
+    /// AuthenticatedUser, enabling proxy_upstreams disclosure.
+    #[tokio::test]
+    async fn test_opportunistic_bearer_auth_on_open_surface() {
+        let ctx = create_test_context_with_anonymous_read_and_config(&[("admin", "secret")], |c| {
+            c.npm.proxy = Some("https://registry.npmjs.org".into());
+        });
+
+        let token = ctx
+            .state
+            .tokens
+            .as_ref()
+            .unwrap()
+            .create_token("admin", 30, None, crate::tokens::Role::Write)
+            .unwrap();
+
+        let header_val = format!("Bearer {token}");
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/api/ui/dashboard",
+            vec![("authorization", &header_val)],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let npm = json["mount_points"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["registry"].as_str() == Some("npm"))
+            .expect("npm mount");
+        assert!(
+            !npm["proxy_upstreams"].as_array().unwrap().is_empty(),
+            "bearer-authenticated must see populated proxy_upstreams"
+        );
     }
 }

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -242,6 +242,41 @@ pub async fn auth_middleware(
             || (is_web_surface(path) && (config.anonymous_read || config.public_web_ui))
             || (path == "/metrics" && config.public_metrics);
         if open {
+            // Opportunistic auth: if the caller provided credentials on an
+            // open path, try to validate them so downstream handlers can
+            // distinguish "anonymous browse" from "authenticated browse"
+            // (e.g. to gate proxy_upstreams disclosure). If validation fails
+            // we fall through to anonymous — the path is open regardless.
+            if let Some(auth_val) = request
+                .headers()
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|h| h.to_str().ok())
+            {
+                if let Some(encoded) = auth_val.strip_prefix("Basic ") {
+                    if let Some(username) = try_basic_auth(encoded, state.auth.as_deref()) {
+                        request
+                            .extensions_mut()
+                            .insert(NamespaceAuthority::Unrestricted);
+                        request.extensions_mut().insert(AuthenticatedUser(username));
+                        request
+                            .extensions_mut()
+                            .insert(AuthenticatedRole(crate::tokens::Role::Write));
+                        return next.run(request).await;
+                    }
+                } else if let Some(token) = auth_val.strip_prefix("Bearer ") {
+                    if let Some(ref token_store) = state.tokens {
+                        if let Ok((user, role)) = token_store.verify_token(token) {
+                            request
+                                .extensions_mut()
+                                .insert(NamespaceAuthority::Unrestricted);
+                            request.extensions_mut().insert(AuthenticatedUser(user));
+                            request.extensions_mut().insert(AuthenticatedRole(role));
+                            return next.run(request).await;
+                        }
+                    }
+                }
+            }
+            // No credentials or validation failed — anonymous browse
             let mut request = request;
             request
                 .extensions_mut()
@@ -576,6 +611,23 @@ pub async fn auth_middleware(
         .extensions_mut()
         .insert(AuthenticatedRole(crate::tokens::Role::Write));
     next.run(request).await
+}
+
+/// Attempt to validate a Base64-encoded Basic auth credential against the
+/// htpasswd store. Returns the username on success, `None` on any failure.
+/// Used by the opportunistic-auth path on open web surfaces so that
+/// authenticated users get their real identity even on publicly browsable
+/// pages.
+fn try_basic_auth(encoded: &str, auth: Option<&HtpasswdAuth>) -> Option<String> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    let decoded = String::from_utf8(STANDARD.decode(encoded).ok()?).ok()?;
+    let (username, password) = decoded.split_once(':')?;
+    let htpasswd = auth?;
+    if htpasswd.authenticate(username, password) {
+        Some(username.to_string())
+    } else {
+        None
+    }
 }
 
 fn unauthorized_response(message: &str, realm: &str) -> Response {

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "1.2.0",
+        version = "1.2.1",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, Conan, RPM, and Debian",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -78,6 +78,14 @@ pub fn create_test_context_with_config(customize: impl FnOnce(&mut Config)) -> T
     build_context(false, &[], false, customize)
 }
 
+/// Build a test context with auth + anonymous_read + custom config tweaks.
+pub fn create_test_context_with_anonymous_read_and_config(
+    users: &[(&str, &str)],
+    customize: impl FnOnce(&mut Config),
+) -> TestContext {
+    build_context(true, users, true, customize)
+}
+
 fn build_context(
     auth_enabled: bool,
     users: &[(&str, &str)],

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -4,6 +4,7 @@
 use super::components::{format_size, format_timestamp, html_escape, sanitize_href};
 use super::templates::encode_uri_component;
 use crate::activity_log::ActivityEntry;
+use crate::auth::AuthenticatedUser;
 use crate::registry_type::RegistryType;
 use crate::repo_index::RepoInfo;
 use crate::validation::ends_with_ci;
@@ -12,6 +13,7 @@ use crate::Storage;
 use axum::{
     extract::{Path, Query, State},
     response::Json,
+    Extension,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -179,7 +181,19 @@ pub async fn api_stats(State(state): State<AppState>) -> Json<RegistryStats> {
     })
 }
 
-pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardResponse> {
+pub async fn api_dashboard(
+    State(state): State<AppState>,
+    user: Option<Extension<AuthenticatedUser>>,
+) -> Json<DashboardResponse> {
+    let authenticated = user.map(|Extension(u)| u.0 != "anonymous").unwrap_or(false);
+    Json(build_dashboard_response(&state, authenticated).await)
+}
+
+/// Build the dashboard JSON payload.
+///
+/// When `authenticated` is false, `proxy_upstreams` is redacted (empty vec)
+/// to avoid leaking upstream registry topology to anonymous callers.
+pub async fn build_dashboard_response(state: &AppState, authenticated: bool) -> DashboardResponse {
     let mut total_storage: u64 = 0;
     let mut total_artifacts: usize = 0;
     let mut registry_card_stats = Vec::new();
@@ -206,40 +220,46 @@ pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardRespo
             size_bytes: size,
         });
 
-        let proxy_upstreams: Vec<String> = match reg {
-            RegistryType::Docker => state
-                .config
-                .docker
-                .upstreams
-                .iter()
-                .map(|u| u.url.clone())
-                .collect(),
-            RegistryType::Maven => state
-                .config
-                .maven
-                .proxies
-                .iter()
-                .map(|p| p.url().to_string())
-                .collect(),
-            RegistryType::Npm => state.config.npm.proxy.clone().into_iter().collect(),
-            RegistryType::Cargo => state.config.cargo.proxy.clone().into_iter().collect(),
-            RegistryType::PyPI => state
-                .config
-                .pypi
-                .upstreams()
-                .iter()
-                .map(|u| u.url().to_string())
-                .collect(),
-            RegistryType::Go => state.config.go.proxy.clone().into_iter().collect(),
-            RegistryType::Raw => vec![],
-            RegistryType::Gems => state.config.gems.proxy.clone().into_iter().collect(),
-            RegistryType::Terraform => state.config.terraform.proxy.clone().into_iter().collect(),
-            RegistryType::Ansible => state.config.ansible.proxy.clone().into_iter().collect(),
-            RegistryType::Nuget => state.config.nuget.proxy.clone().into_iter().collect(),
-            RegistryType::PubDart => state.config.pub_dart.proxy.clone().into_iter().collect(),
-            RegistryType::Conan => state.config.conan.proxy.clone().into_iter().collect(),
-            RegistryType::Rpm => vec![],
-            RegistryType::Deb => vec![],
+        let proxy_upstreams: Vec<String> = if authenticated {
+            match reg {
+                RegistryType::Docker => state
+                    .config
+                    .docker
+                    .upstreams
+                    .iter()
+                    .map(|u| u.url.clone())
+                    .collect(),
+                RegistryType::Maven => state
+                    .config
+                    .maven
+                    .proxies
+                    .iter()
+                    .map(|p| p.url().to_string())
+                    .collect(),
+                RegistryType::Npm => state.config.npm.proxy.clone().into_iter().collect(),
+                RegistryType::Cargo => state.config.cargo.proxy.clone().into_iter().collect(),
+                RegistryType::PyPI => state
+                    .config
+                    .pypi
+                    .upstreams()
+                    .iter()
+                    .map(|u| u.url().to_string())
+                    .collect(),
+                RegistryType::Go => state.config.go.proxy.clone().into_iter().collect(),
+                RegistryType::Raw => vec![],
+                RegistryType::Gems => state.config.gems.proxy.clone().into_iter().collect(),
+                RegistryType::Terraform => {
+                    state.config.terraform.proxy.clone().into_iter().collect()
+                }
+                RegistryType::Ansible => state.config.ansible.proxy.clone().into_iter().collect(),
+                RegistryType::Nuget => state.config.nuget.proxy.clone().into_iter().collect(),
+                RegistryType::PubDart => state.config.pub_dart.proxy.clone().into_iter().collect(),
+                RegistryType::Conan => state.config.conan.proxy.clone().into_iter().collect(),
+                RegistryType::Rpm => vec![],
+                RegistryType::Deb => vec![],
+            }
+        } else {
+            vec![]
         };
 
         mount_points.push(MountPoint {
@@ -260,14 +280,14 @@ pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardRespo
     let activity = state.activity.recent(20);
     let uptime_seconds = state.start_time.elapsed().as_secs();
 
-    Json(DashboardResponse {
+    DashboardResponse {
         global_stats,
         registry_stats: registry_card_stats,
         mount_points,
         activity,
         uptime_seconds,
         startup_duration_ms: state.startup_duration_ms,
-    })
+    }
 }
 
 pub async fn api_list(

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -251,13 +251,15 @@ async fn dashboard(
     State(state): State<AppState>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
+    user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
     let lang = extract_lang(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
     let auth_enabled = state.auth.is_some();
-    let response = api_dashboard(State(state)).await.0;
+    let authenticated = user.map(|Extension(u)| u.0 != "anonymous").unwrap_or(false);
+    let response = build_dashboard_response(&state, authenticated).await;
     Html(render_dashboard(&response, lang, auth_enabled))
 }
 


### PR DESCRIPTION
## Summary

- Extract `build_dashboard_response(state, authenticated)` from `api_dashboard` — when the caller is unauthenticated, `proxy_upstreams` is an empty vec for every mount point, preventing upstream registry topology disclosure
- Add opportunistic auth on the middleware's open web-surface path: if credentials are present on a publicly-browsable page (`anonymous_read=true`), validate them and insert the real identity so downstream handlers can distinguish authenticated from anonymous
- Add `dashboard-upstreams-auth-gated` contract

Closes #934

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] 1763 tests pass, 0 fail
- [x] Contract gate: 6/6 GREEN
- [x] Black-box: anonymous `GET /api/ui/dashboard` → all `proxy_upstreams` empty
- [x] Black-box: authenticated `GET /api/ui/dashboard` → upstreams populated
- [x] Black-box: invalid creds → treated as anonymous, upstreams empty