### PR TITLE
feat(gc): tag-rooted Docker GC + epic-927 lifecycle hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "ar",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # NORA
 
-A lightweight, open-source artifact registry. 15 formats in a single binary (< 27 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++), RPM (yum/dnf, hosted), Debian/APT (hosted). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
+A lightweight, open-source artifact registry. 15 formats in a single binary (< 30 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++), RPM (yum/dnf, hosted), Debian/APT (hosted). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
 
 > The artifact registry that grows with you. Zero-config to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
 
@@ -187,16 +187,16 @@ cd nora && cargo build --release
 |--------|------|-------|-------------------|
 | Startup | < 3s | 30-60s | 30-60s |
 | Memory | < 50 MB idle | 2-4 GB | 2-4 GB |
-| Binary | < 27 MB | 600+ MB | 1+ GB |
+| Binary | < 30 MB | 600+ MB | 1+ GB |
 | Dependencies | None | Java 11+ | Java 11+ |
 | Database | None (filesystem) | Embedded/PostgreSQL | Embedded/PostgreSQL |
 
 ## How NORA compares to alternatives
 
-- vs Sonatype Nexus: NORA is over 20x smaller (< 27 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
+- vs Sonatype Nexus: NORA is over 20x smaller (< 30 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
 - vs JFrog Artifactory: NORA is free and open-source with no feature gating. Artifactory has more enterprise features (replication, Xray scanning, RBAC)
-- vs Docker Distribution (registry:2): NORA adds 12 more formats, Web UI, upstream proxy, backup/restore, metrics. Distribution is Docker-only
-- vs Verdaccio: Verdaccio is npm-only. NORA handles npm plus 12 other formats
+- vs Docker Distribution (registry:2): NORA adds 14 more formats, Web UI, upstream proxy, backup/restore, metrics. Distribution is Docker-only
+- vs Verdaccio: Verdaccio is npm-only. NORA handles npm plus 14 other formats
 - vs Gitea Packages: Gitea packages require Gitea. NORA is standalone
 - vs Harbor: Harbor is container-only with more enterprise features (vulnerability scanning, replication, RBAC). NORA is multi-format and simpler
 - vs AWS ECR / GHCR / Docker Hub: NORA is self-hosted, no vendor lock-in, air-gapped ready. Hosted registries need internet

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -2275,9 +2275,13 @@ Jd74nq6dNCjpWG4drIsyhqX+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod web_surface_gating_tests {
-    use crate::test_helpers::{create_test_context_with_auth, send, send_with_headers};
+    use crate::test_helpers::{
+        body_bytes, create_test_context_with_anonymous_read,
+        create_test_context_with_anonymous_read_and_config, create_test_context_with_auth, send,
+        send_with_headers,
+    };
     use axum::http::{Method, StatusCode};
-    use base64::Engine;
+    use base64::{engine::general_purpose::STANDARD, Engine};
 
     fn basic(user: &str, pass: &str) -> String {
         format!(
@@ -2368,5 +2372,153 @@ mod web_surface_gating_tests {
         });
         let resp = send(&ctx.app, Method::GET, "/api/ui/tokens", "").await;
         assert_ne!(resp.status(), StatusCode::OK);
+    }
+
+    // -- #934: opportunistic auth on open web surfaces --
+
+    /// try_basic_auth returns the username for valid htpasswd credentials.
+    #[test]
+    fn test_try_basic_auth_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("htpasswd");
+        let hash = bcrypt::hash("secret", 4).unwrap();
+        std::fs::write(&path, format!("admin:{hash}\n")).unwrap();
+        let htpasswd = super::HtpasswdAuth::from_file(&path).unwrap();
+        let encoded = STANDARD.encode("admin:secret");
+        assert_eq!(
+            super::try_basic_auth(&encoded, Some(&htpasswd)),
+            Some("admin".to_string())
+        );
+    }
+
+    /// try_basic_auth returns None for wrong password.
+    #[test]
+    fn test_try_basic_auth_wrong_password() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("htpasswd");
+        let hash = bcrypt::hash("secret", 4).unwrap();
+        std::fs::write(&path, format!("admin:{hash}\n")).unwrap();
+        let htpasswd = super::HtpasswdAuth::from_file(&path).unwrap();
+        let encoded = STANDARD.encode("admin:wrong");
+        assert_eq!(super::try_basic_auth(&encoded, Some(&htpasswd)), None);
+    }
+
+    /// try_basic_auth returns None when no htpasswd store is available.
+    #[test]
+    fn test_try_basic_auth_no_store() {
+        let encoded = STANDARD.encode("admin:secret");
+        assert_eq!(super::try_basic_auth(&encoded, None), None);
+    }
+
+    /// try_basic_auth returns None for garbage base64.
+    #[test]
+    fn test_try_basic_auth_invalid_base64() {
+        assert_eq!(super::try_basic_auth("%%%not-base64%%%", None), None);
+    }
+
+    /// On an open web surface (anonymous_read=true), valid Basic credentials
+    /// must produce a real AuthenticatedUser — not "anonymous". Verified via
+    /// /api/ui/dashboard: anonymous sees empty proxy_upstreams; authenticated
+    /// sees the configured npm upstream.
+    #[tokio::test]
+    async fn test_opportunistic_basic_auth_on_open_surface() {
+        let ctx = create_test_context_with_anonymous_read_and_config(&[("admin", "secret")], |c| {
+            c.npm.proxy = Some("https://registry.npmjs.org".into());
+        });
+
+        // Anonymous: proxy_upstreams redacted
+        let resp = send(&ctx.app, Method::GET, "/api/ui/dashboard", "").await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        for mp in json["mount_points"].as_array().unwrap() {
+            assert!(
+                mp["proxy_upstreams"].as_array().unwrap().is_empty(),
+                "anonymous must see empty proxy_upstreams"
+            );
+        }
+
+        // Valid Basic creds: proxy_upstreams populated
+        let header_val = format!("Basic {}", STANDARD.encode("admin:secret"));
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/api/ui/dashboard",
+            vec![("authorization", &header_val)],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let npm = json["mount_points"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["registry"].as_str() == Some("npm"))
+            .expect("npm mount");
+        assert!(
+            !npm["proxy_upstreams"].as_array().unwrap().is_empty(),
+            "authenticated must see populated proxy_upstreams for npm"
+        );
+    }
+
+    /// On an open web surface, invalid Basic credentials fall through to
+    /// anonymous (the path is open — no 401).
+    #[tokio::test]
+    async fn test_opportunistic_bad_creds_fall_through_to_anonymous() {
+        let ctx = create_test_context_with_anonymous_read(&[("admin", "secret")]);
+
+        let bad = format!("Basic {}", STANDARD.encode("admin:wrong"));
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/api/ui/dashboard",
+            vec![("authorization", &bad)],
+            "",
+        )
+        .await;
+        // Open path — no 401 even with bad creds
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    /// On an open web surface, a valid Bearer token must produce a real
+    /// AuthenticatedUser, enabling proxy_upstreams disclosure.
+    #[tokio::test]
+    async fn test_opportunistic_bearer_auth_on_open_surface() {
+        let ctx = create_test_context_with_anonymous_read_and_config(&[("admin", "secret")], |c| {
+            c.npm.proxy = Some("https://registry.npmjs.org".into());
+        });
+
+        let token = ctx
+            .state
+            .tokens
+            .as_ref()
+            .unwrap()
+            .create_token("admin", 30, None, crate::tokens::Role::Write)
+            .unwrap();
+
+        let header_val = format!("Bearer {token}");
+        let resp = send_with_headers(
+            &ctx.app,
+            Method::GET,
+            "/api/ui/dashboard",
+            vec![("authorization", &header_val)],
+            "",
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let npm = json["mount_points"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["registry"].as_str() == Some("npm"))
+            .expect("npm mount");
+        assert!(
+            !npm["proxy_upstreams"].as_array().unwrap().is_empty(),
+            "bearer-authenticated must see populated proxy_upstreams"
+        );
     }
 }

--- a/nora-registry/src/auth/mod.rs
+++ b/nora-registry/src/auth/mod.rs
@@ -242,6 +242,41 @@ pub async fn auth_middleware(
             || (is_web_surface(path) && (config.anonymous_read || config.public_web_ui))
             || (path == "/metrics" && config.public_metrics);
         if open {
+            // Opportunistic auth: if the caller provided credentials on an
+            // open path, try to validate them so downstream handlers can
+            // distinguish "anonymous browse" from "authenticated browse"
+            // (e.g. to gate proxy_upstreams disclosure). If validation fails
+            // we fall through to anonymous — the path is open regardless.
+            if let Some(auth_val) = request
+                .headers()
+                .get(axum::http::header::AUTHORIZATION)
+                .and_then(|h| h.to_str().ok())
+            {
+                if let Some(encoded) = auth_val.strip_prefix("Basic ") {
+                    if let Some(username) = try_basic_auth(encoded, state.auth.as_deref()) {
+                        request
+                            .extensions_mut()
+                            .insert(NamespaceAuthority::Unrestricted);
+                        request.extensions_mut().insert(AuthenticatedUser(username));
+                        request
+                            .extensions_mut()
+                            .insert(AuthenticatedRole(crate::tokens::Role::Write));
+                        return next.run(request).await;
+                    }
+                } else if let Some(token) = auth_val.strip_prefix("Bearer ") {
+                    if let Some(ref token_store) = state.tokens {
+                        if let Ok((user, role)) = token_store.verify_token(token) {
+                            request
+                                .extensions_mut()
+                                .insert(NamespaceAuthority::Unrestricted);
+                            request.extensions_mut().insert(AuthenticatedUser(user));
+                            request.extensions_mut().insert(AuthenticatedRole(role));
+                            return next.run(request).await;
+                        }
+                    }
+                }
+            }
+            // No credentials or validation failed — anonymous browse
             let mut request = request;
             request
                 .extensions_mut()
@@ -576,6 +611,23 @@ pub async fn auth_middleware(
         .extensions_mut()
         .insert(AuthenticatedRole(crate::tokens::Role::Write));
     next.run(request).await
+}
+
+/// Attempt to validate a Base64-encoded Basic auth credential against the
+/// htpasswd store. Returns the username on success, `None` on any failure.
+/// Used by the opportunistic-auth path on open web surfaces so that
+/// authenticated users get their real identity even on publicly browsable
+/// pages.
+fn try_basic_auth(encoded: &str, auth: Option<&HtpasswdAuth>) -> Option<String> {
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    let decoded = String::from_utf8(STANDARD.decode(encoded).ok()?).ok()?;
+    let (username, password) = decoded.split_once(':')?;
+    let htpasswd = auth?;
+    if htpasswd.authenticate(username, password) {
+        Some(username.to_string())
+    } else {
+        None
+    }
 }
 
 fn unauthorized_response(message: &str, realm: &str) -> Response {

--- a/nora-registry/src/config/gc.rs
+++ b/nora-registry/src/config/gc.rs
@@ -26,6 +26,11 @@ pub struct GcConfig {
     /// only during a read-only maintenance window with no concurrent writes.
     #[serde(default = "default_gc_grace")]
     pub grace_secs: u64,
+    /// Maximum bytes for proxy-cached artifacts (rpm/deb). When total proxy
+    /// cache exceeds this cap, GC evicts the oldest files (by mtime) until
+    /// usage is within budget. 0 = disabled (default). Env: `NORA_GC_PROXY_CACHE_MAX_BYTES`.
+    #[serde(default)]
+    pub proxy_cache_max_bytes: u64,
 }
 
 fn default_gc_interval() -> u64 {
@@ -47,6 +52,7 @@ impl Default for GcConfig {
             interval: 86400,
             dry_run: false,
             grace_secs: default_gc_grace(),
+            proxy_cache_max_bytes: 0,
         }
     }
 }
@@ -65,6 +71,13 @@ impl GcConfig {
         }
         if let Ok(val) = env::var("NORA_GC_GRACE") {
             super::parse_env_warn("NORA_GC_GRACE", &val, &mut self.grace_secs);
+        }
+        if let Ok(val) = env::var("NORA_GC_PROXY_CACHE_MAX_BYTES") {
+            super::parse_env_warn(
+                "NORA_GC_PROXY_CACHE_MAX_BYTES",
+                &val,
+                &mut self.proxy_cache_max_bytes,
+            );
         }
     }
 }

--- a/nora-registry/src/gc.rs
+++ b/nora-registry/src/gc.rs
@@ -68,6 +68,22 @@ pub static GC_METADATA_PHANTOMS: LazyLock<IntCounter> = LazyLock::new(|| {
     .expect("gc_metadata_phantoms metric")
 });
 
+pub static GC_PROXY_CACHE_EVICTED: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "nora_gc_proxy_cache_evicted_total",
+        "Total proxy-cached files evicted by size-based GC"
+    )
+    .expect("gc_proxy_cache_evicted metric")
+});
+
+pub static GC_PROXY_CACHE_BYTES_FREED: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "nora_gc_proxy_cache_bytes_freed_total",
+        "Total bytes freed by proxy-cache eviction"
+    )
+    .expect("gc_proxy_cache_bytes_freed metric")
+});
+
 pub static GC_STAT_FAILURES: LazyLock<IntCounter> = LazyLock::new(|| {
     register_int_counter!(
         "nora_gc_stat_failures_total",
@@ -99,6 +115,8 @@ pub struct GcResult {
     /// silently). Tracked separately from `skipped_recent` and metered via
     /// `nora_gc_stat_failures_total` so it can be alerted on.
     pub stat_failures: usize,
+    /// Proxy-cache eviction result (#866).
+    pub proxy_cache_eviction: ProxyCacheEviction,
 }
 
 // ============================================================================
@@ -121,6 +139,7 @@ pub async fn run_gc(
     dry_run: bool,
     grace_secs: u64,
     npm_is_proxy: bool,
+    proxy_cache_max_bytes: u64,
 ) -> GcResult {
     let start = Instant::now();
     info!(
@@ -248,6 +267,11 @@ pub async fn run_gc(
         );
     }
 
+    // Proxy-cache eviction (#866): size-based LRU for rpm/deb proxy-cached
+    // files that have no sidecar and are not indexes.
+    let proxy_cache_eviction =
+        evict_proxy_cache(storage, publish_locks, proxy_cache_max_bytes, dry_run).await;
+
     // Detect registries with data but no GC coverage
     // Raw has no version model and no reference graph — nothing to GC by design
     // Terraform/Pub/Ansible/NuGet store only cached metadata — no orphan graph,
@@ -295,6 +319,7 @@ pub async fn run_gc(
         metadata_phantoms_removed,
         skipped_recent,
         stat_failures,
+        proxy_cache_eviction,
     }
 }
 
@@ -307,6 +332,63 @@ struct DetectionResult {
     orphans: Vec<String>,
 }
 
+/// Extract config.digest + layers[].digest into `referenced`, and
+/// manifests[].digest (manifest list entries) into `sub_manifests`.
+fn collect_manifest_refs(
+    json: &serde_json::Value,
+    referenced: &mut HashSet<String>,
+    sub_manifests: &mut HashSet<String>,
+) {
+    // config digest
+    if let Some(digest) = json
+        .get("config")
+        .and_then(|c| c.get("digest"))
+        .and_then(|v| v.as_str())
+    {
+        referenced.insert(digest.to_string());
+    }
+    // layer digests
+    if let Some(layers) = json.get("layers").and_then(|v| v.as_array()) {
+        for layer in layers {
+            if let Some(digest) = layer.get("digest").and_then(|v| v.as_str()) {
+                referenced.insert(digest.to_string());
+            }
+        }
+    }
+    // manifest list / image index: sub-manifest digests
+    if let Some(manifests) = json.get("manifests").and_then(|v| v.as_array()) {
+        for m in manifests {
+            if let Some(digest) = m.get("digest").and_then(|v| v.as_str()) {
+                sub_manifests.insert(digest.to_string());
+            }
+        }
+    }
+}
+
+/// Extract config.digest + layers[].digest into `referenced` (blob refs only,
+/// no sub-manifest traversal).
+fn collect_blob_refs(json: &serde_json::Value, referenced: &mut HashSet<String>) {
+    if let Some(digest) = json
+        .get("config")
+        .and_then(|c| c.get("digest"))
+        .and_then(|v| v.as_str())
+    {
+        referenced.insert(digest.to_string());
+    }
+    if let Some(layers) = json.get("layers").and_then(|v| v.as_array()) {
+        for layer in layers {
+            if let Some(digest) = layer.get("digest").and_then(|v| v.as_str()) {
+                referenced.insert(digest.to_string());
+            }
+        }
+    }
+}
+
+/// True if `ref_name` is a digest reference (sha256:… or sha512:…), not a tag.
+fn is_digest_ref(ref_name: &str) -> bool {
+    ref_name.starts_with("sha256:") || ref_name.starts_with("sha512:")
+}
+
 async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
     let keys = storage.list("docker/").await.unwrap_or_else(|e| {
         tracing::error!("GC: storage.list(docker/) failed: {}", e);
@@ -314,55 +396,71 @@ async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
     });
 
     let mut blobs: Vec<String> = Vec::new();
-    let mut referenced = HashSet::new();
+    let mut all_manifest_keys: Vec<String> = Vec::new();
 
     for key in &keys {
         if key.contains("/blobs/") {
             blobs.push(key.clone());
+        } else if key.contains("/manifests/")
+            && ends_with_ci(key, ".json")
+            && !ends_with_ci(key, ".meta.json")
+        {
+            all_manifest_keys.push(key.clone());
         }
     }
 
-    // Parse manifests for referenced digests
-    for key in &keys {
-        if !key.contains("/manifests/")
-            || !ends_with_ci(key, ".json")
-            || ends_with_ci(key, ".meta.json")
-        {
-            continue;
-        }
+    // Step 1: Identify tag manifests (filename does NOT start with sha256:/sha512:)
+    let tag_manifests: Vec<&String> = all_manifest_keys
+        .iter()
+        .filter(|k| {
+            let filename = k.rsplit('/').next().unwrap_or("");
+            let ref_name = filename.strip_suffix(".json").unwrap_or(filename);
+            !is_digest_ref(ref_name)
+        })
+        .collect();
 
+    // Step 2: Read tag manifests, collect referenced blob digests.
+    // For manifest lists, also collect sub-manifest digests to resolve in step 3.
+    let mut referenced = HashSet::new();
+    let mut sub_manifest_digests: HashSet<String> = HashSet::new();
+
+    for key in &tag_manifests {
         if let Ok(data) = storage.get(key).await {
             if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&data) {
-                // config digest
-                if let Some(digest) = json
-                    .get("config")
-                    .and_then(|c| c.get("digest"))
-                    .and_then(|v| v.as_str())
-                {
-                    referenced.insert(digest.to_string());
-                }
-                // layer digests
-                if let Some(layers) = json.get("layers").and_then(|v| v.as_array()) {
-                    for layer in layers {
-                        if let Some(digest) = layer.get("digest").and_then(|v| v.as_str()) {
-                            referenced.insert(digest.to_string());
-                        }
-                    }
-                }
-                // manifest list digests
-                if let Some(manifests) = json.get("manifests").and_then(|v| v.as_array()) {
-                    for m in manifests {
-                        if let Some(digest) = m.get("digest").and_then(|v| v.as_str()) {
-                            referenced.insert(digest.to_string());
-                        }
-                    }
+                collect_manifest_refs(&json, &mut referenced, &mut sub_manifest_digests);
+            }
+        }
+    }
+
+    // Step 3: Resolve sub-manifests (manifest list entries) — these are
+    // digest-keyed but reachable from a tag, so their blobs must be kept.
+    for key in &all_manifest_keys {
+        let filename = key.rsplit('/').next().unwrap_or("");
+        let ref_name = filename.strip_suffix(".json").unwrap_or(filename);
+        if sub_manifest_digests.contains(ref_name) {
+            if let Ok(data) = storage.get(key).await {
+                if let Ok(json) = serde_json::from_slice::<serde_json::Value>(&data) {
+                    // Only collect blob refs, not further sub-manifests (2 levels deep enough)
+                    collect_blob_refs(&json, &mut referenced);
                 }
             }
         }
     }
 
+    // Step 4: Detect orphaned digest manifests — digest-keyed manifests not
+    // reachable from any tag (neither directly tagged nor a sub-manifest of a
+    // tagged manifest list).
+    let mut orphan_digest_manifests: Vec<String> = Vec::new();
+    for key in &all_manifest_keys {
+        let filename = key.rsplit('/').next().unwrap_or("");
+        let ref_name = filename.strip_suffix(".json").unwrap_or(filename);
+        if is_digest_ref(ref_name) && !sub_manifest_digests.contains(ref_name) {
+            orphan_digest_manifests.push(key.clone());
+        }
+    }
+
     let total = blobs.len();
-    let orphans: Vec<String> = blobs
+    let mut orphans: Vec<String> = blobs
         .into_iter()
         .filter(|key| {
             key.rsplit('/')
@@ -371,6 +469,10 @@ async fn detect_docker_orphans(storage: &Storage) -> DetectionResult {
                 .unwrap_or(false)
         })
         .collect();
+
+    // Append orphaned digest manifests — they will be sorted after blobs by
+    // the caller (run_gc's #305 invariant: blobs before manifests).
+    orphans.extend(orphan_digest_manifests);
 
     DetectionResult { total, orphans }
 }
@@ -828,6 +930,159 @@ async fn clean_pypi_metadata(
 }
 
 // ============================================================================
+// Proxy-cache eviction (#866)
+// ============================================================================
+
+/// Result of proxy-cache eviction.
+#[derive(Debug, Clone, Default)]
+pub struct ProxyCacheEviction {
+    /// Total proxy-cached bytes before eviction.
+    pub total_bytes: u64,
+    /// Number of files evicted.
+    pub evicted_files: usize,
+    /// Bytes freed by eviction.
+    pub bytes_freed: u64,
+}
+
+/// Index files that must never be evicted — they are regenerated indexes,
+/// not proxy-cached packages.
+fn is_index_file(key: &str) -> bool {
+    // rpm: repodata/
+    if key.contains("/repodata/") {
+        return true;
+    }
+    // deb: Packages, Packages.gz, Release, InRelease, etc.
+    let filename = key.rsplit('/').next().unwrap_or(key);
+    matches!(
+        filename,
+        "Packages"
+            | "Packages.gz"
+            | "Packages.bz2"
+            | "Packages.xz"
+            | "Release"
+            | "Release.gpg"
+            | "InRelease"
+    )
+}
+
+/// Evict proxy-cached artifacts (rpm/deb) when total size exceeds `max_bytes`.
+///
+/// Proxy-cached files = files under `rpm/` or `deb/` that:
+/// - have NO corresponding `.nora-meta/` sidecar (hosted packages have one)
+/// - are NOT themselves under `.nora-meta/`
+/// - are NOT index files (repodata/, Packages, Release, etc.)
+///
+/// Eviction order: oldest by mtime first (LRU approximation; immutable files
+/// are never re-written, so mtime ≈ "least recently cached").
+async fn evict_proxy_cache(
+    storage: &Storage,
+    publish_locks: &PublishLocks,
+    max_bytes: u64,
+    dry_run: bool,
+) -> ProxyCacheEviction {
+    if max_bytes == 0 {
+        return ProxyCacheEviction::default();
+    }
+
+    let mut proxy_files: Vec<(String, u64, u64)> = Vec::new(); // (key, size, mtime)
+    let mut sidecar_covered: HashSet<String> = HashSet::new();
+
+    for prefix in ["rpm/", "deb/"] {
+        let entries = match storage.list_with_meta(prefix).await {
+            Ok(e) => e,
+            Err(e) => {
+                tracing::error!("GC proxy-cache: list_with_meta({prefix}) failed: {e}");
+                continue;
+            }
+        };
+
+        // First pass: collect sidecar-covered paths
+        for (key, _meta) in &entries {
+            // {registry}/{repo}/.nora-meta/{path}.json → covers {registry}/{repo}/{path}
+            if let Some(rest) = key.strip_prefix(prefix) {
+                if let Some((repo, meta_rest)) = rest.split_once("/.nora-meta/") {
+                    if let Some(pkg_path) = meta_rest.strip_suffix(".json") {
+                        let covered = format!("{prefix}{repo}/{pkg_path}");
+                        sidecar_covered.insert(covered);
+                    }
+                }
+            }
+        }
+
+        // Second pass: identify proxy-only files
+        for (key, meta) in &entries {
+            // Skip .nora-meta/ entries themselves
+            if key.contains("/.nora-meta/") {
+                continue;
+            }
+            // Skip index files
+            if is_index_file(key) {
+                continue;
+            }
+            // Skip hosted files (have sidecar)
+            if sidecar_covered.contains(key) {
+                continue;
+            }
+            proxy_files.push((key.clone(), meta.size, meta.modified));
+        }
+    }
+
+    let total_bytes: u64 = proxy_files.iter().map(|(_, s, _)| s).sum();
+
+    if total_bytes <= max_bytes {
+        return ProxyCacheEviction {
+            total_bytes,
+            evicted_files: 0,
+            bytes_freed: 0,
+        };
+    }
+
+    // Sort by mtime ascending (oldest first) for LRU eviction
+    proxy_files.sort_by_key(|&(_, _, mtime)| mtime);
+
+    let mut bytes_freed = 0u64;
+    let mut evicted = 0usize;
+    let bytes_to_free = total_bytes - max_bytes;
+
+    for (key, size, _mtime) in &proxy_files {
+        if bytes_freed >= bytes_to_free {
+            break;
+        }
+        if dry_run {
+            info!("[dry-run] proxy-cache evict: {} ({} bytes)", key, size);
+        } else {
+            let lock = crate::acquire_publish_lock(publish_locks, key);
+            let _guard = lock.lock().await;
+            if storage.delete(key).await.is_ok() {
+                info!("proxy-cache evicted: {} ({} bytes)", key, size);
+            }
+        }
+        bytes_freed += size;
+        evicted += 1;
+    }
+
+    if !dry_run && evicted > 0 {
+        GC_PROXY_CACHE_EVICTED.inc_by(evicted as u64);
+        GC_PROXY_CACHE_BYTES_FREED.inc_by(bytes_freed);
+    }
+
+    info!(
+        "Proxy-cache eviction{}: {} files, {} bytes freed (was {} / cap {})",
+        if dry_run { " (dry-run)" } else { "" },
+        evicted,
+        bytes_freed,
+        total_bytes,
+        max_bytes
+    );
+
+    ProxyCacheEviction {
+        total_bytes,
+        evicted_files: evicted,
+        bytes_freed,
+    }
+}
+
+// ============================================================================
 // Tests
 // ============================================================================
 
@@ -854,6 +1109,7 @@ mod tests {
             metadata_phantoms_removed: 0,
             skipped_recent: 0,
             stat_failures: 0,
+            proxy_cache_eviction: ProxyCacheEviction::default(),
         };
         assert_eq!(result.total_candidates, 0);
         assert!(result.orphan_keys.is_empty());
@@ -885,7 +1141,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.total_candidates, 0);
         assert_eq!(result.orphaned, 0);
         assert_eq!(result.deleted, 0);
@@ -916,7 +1172,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.orphaned, 0);
     }
 
@@ -949,7 +1205,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 0);
         assert!(result.orphan_keys[0].contains("orphan999"));
@@ -978,7 +1234,7 @@ mod tests {
             .unwrap();
 
         // Generous grace: the orphan is detected but must NOT be deleted.
-        let result = run_gc(&storage, &test_publish_locks(), false, 3600, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 3600, false, 0).await;
         assert_eq!(result.orphaned, 1, "orphan should be detected");
         assert_eq!(
             result.deleted, 0,
@@ -995,7 +1251,7 @@ mod tests {
 
         // Dry-run honors grace too, so the preview matches `--apply`: a
         // protected orphan is reported as skipped, not as "would delete".
-        let preview = run_gc(&storage, &test_publish_locks(), true, 3600, false).await;
+        let preview = run_gc(&storage, &test_publish_locks(), true, 3600, false, 0).await;
         assert_eq!(preview.skipped_recent, 1);
         assert_eq!(
             preview.bytes_freed, 0,
@@ -1003,7 +1259,7 @@ mod tests {
         );
 
         // grace=0 (no concurrent writes): the same orphan is now collected.
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.deleted, 1, "grace=0 deletes the orphan");
         assert!(storage
             .get("docker/test/blobs/sha256:fresh000")
@@ -1035,7 +1291,7 @@ mod tests {
 
         // A short grace: a normal old orphan would be deleted, but a future
         // mtime must still be treated as "too young" and kept.
-        let result = run_gc(&storage, &test_publish_locks(), false, 60, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 60, false, 0).await;
         assert_eq!(
             result.skipped_recent, 1,
             "future-mtime orphan must be protected (saturating_sub)"
@@ -1056,7 +1312,7 @@ mod tests {
         let key = "maven/com/example/1.0/old.jar.sha256";
         storage.put(key, b"deadbeef").await.unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 3600, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 3600, false, 0).await;
         assert_eq!(result.orphaned, 1, "checksum orphan should be detected");
         assert_eq!(
             result.deleted, 0,
@@ -1138,7 +1394,7 @@ mod tests {
 
         // grace=0 would collect any normal orphan; the un-stattable one must
         // still survive because its age is unknown.
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
 
         assert_eq!(result.orphaned, 1, "the blob is detected as an orphan");
         assert_eq!(
@@ -1190,7 +1446,7 @@ mod tests {
             }
         };
 
-        let (_gc, ()) = tokio::join!(run_gc(&storage, &locks, false, 0, false), writer);
+        let (_gc, ()) = tokio::join!(run_gc(&storage, &locks, false, 0, false, 0), writer);
 
         // Every key is either reaped by GC or present with exactly one of the two
         // intended bodies — atomic writes guarantee no partial/torn content.
@@ -1235,7 +1491,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert!(result.deleted >= 1);
 
         assert!(
@@ -1277,7 +1533,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 1);
         assert!(result.bytes_freed > 0);
@@ -1291,16 +1547,27 @@ mod tests {
             .is_ok());
     }
 
+    /// Manifest list (image index) tag transitively protects sub-manifest blobs.
     #[tokio::test]
     async fn test_gc_manifest_list_references() {
         let dir = tempfile::tempdir().unwrap();
         let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
 
+        // Manifest list (image index) references two sub-manifests by digest.
         let manifest = serde_json::json!({
             "manifests": [
                 {"digest": "sha256:platformA", "size": 100},
                 {"digest": "sha256:platformB", "size": 200}
             ]
+        });
+        // Sub-manifests (stored as digest-keyed files) reference actual blobs.
+        let sub_a = serde_json::json!({
+            "config": {"digest": "sha256:cfg_a"},
+            "layers": [{"digest": "sha256:layer_a", "size": 50}]
+        });
+        let sub_b = serde_json::json!({
+            "config": {"digest": "sha256:cfg_b"},
+            "layers": [{"digest": "sha256:layer_b", "size": 60}]
         });
         storage
             .put(
@@ -1310,16 +1577,354 @@ mod tests {
             .await
             .unwrap();
         storage
-            .put("docker/multi/blobs/sha256:platformA", b"arch-a")
+            .put(
+                "docker/multi/manifests/sha256:platformA.json",
+                sub_a.to_string().as_bytes(),
+            )
             .await
             .unwrap();
         storage
-            .put("docker/multi/blobs/sha256:platformB", b"arch-b")
+            .put(
+                "docker/multi/manifests/sha256:platformB.json",
+                sub_b.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:cfg_a", b"cfg-a")
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:layer_a", b"layer-a")
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:cfg_b", b"cfg-b")
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:layer_b", b"layer-b")
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.orphaned, 0);
+    }
+
+    // -- #655: Tag-rooted Docker GC tests --
+
+    /// #655 (part 2): Two tags with different blobs — all blobs are tag-reachable,
+    /// no orphans detected.
+    #[tokio::test]
+    async fn test_gc_tag_rooted_no_orphans_for_tagged_blobs() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let manifest_a = serde_json::json!({
+            "config": {"digest": "sha256:cfg_a"},
+            "layers": [{"digest": "sha256:layer_a", "size": 100}]
+        });
+        let manifest_b = serde_json::json!({
+            "config": {"digest": "sha256:cfg_b"},
+            "layers": [{"digest": "sha256:layer_b", "size": 200}]
+        });
+        storage
+            .put(
+                "docker/repo/manifests/v1.json",
+                manifest_a.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put(
+                "docker/repo/manifests/v2.json",
+                manifest_b.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:cfg_a", b"config-a")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:layer_a", b"layer-a")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:cfg_b", b"config-b")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:layer_b", b"layer-b")
+            .await
+            .unwrap();
+
+        let result = detect_docker_orphans(&storage).await;
+        assert_eq!(result.orphans.len(), 0, "all blobs are tag-referenced");
+    }
+
+    /// #655 (part 2): Re-pushing a tag with new content makes the OLD digest
+    /// manifest and its exclusive blobs orphaned.
+    #[tokio::test]
+    async fn test_gc_tag_rooted_repush_orphans_old_blobs() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // Simulate: tag "latest" was pushed with content A, then re-pushed with B.
+        // After re-push, the tag manifest points to B's content. The old digest
+        // manifest (sha256:old_digest) still exists alongside B.
+
+        let old_manifest = serde_json::json!({
+            "config": {"digest": "sha256:old_config"},
+            "layers": [{"digest": "sha256:old_layer", "size": 100}]
+        });
+        let new_manifest = serde_json::json!({
+            "config": {"digest": "sha256:new_config"},
+            "layers": [{"digest": "sha256:new_layer", "size": 200}]
+        });
+
+        // Current tag points to new content
+        storage
+            .put(
+                "docker/repo/manifests/latest.json",
+                new_manifest.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        // Old digest manifest lingers from previous push
+        storage
+            .put(
+                "docker/repo/manifests/sha256:old_digest.json",
+                old_manifest.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        // New digest manifest (current)
+        storage
+            .put(
+                "docker/repo/manifests/sha256:new_digest.json",
+                new_manifest.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        // Blobs for both versions
+        storage
+            .put("docker/repo/blobs/sha256:old_config", b"old-cfg")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:old_layer", b"old-layer")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:new_config", b"new-cfg")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:new_layer", b"new-layer")
+            .await
+            .unwrap();
+
+        let result = detect_docker_orphans(&storage).await;
+
+        // Old blobs (old_config, old_layer) are orphaned because only the tag
+        // manifest (latest.json) is consulted, and it references new_* blobs.
+        let orphan_blobs: Vec<&String> = result
+            .orphans
+            .iter()
+            .filter(|k| k.contains("/blobs/"))
+            .collect();
+        assert_eq!(orphan_blobs.len(), 2, "old config + old layer are orphaned");
+        assert!(
+            orphan_blobs.iter().any(|k| k.contains("old_config")),
+            "old config blob must be orphaned"
+        );
+        assert!(
+            orphan_blobs.iter().any(|k| k.contains("old_layer")),
+            "old layer blob must be orphaned"
+        );
+
+        // New blobs must NOT be orphaned
+        assert!(
+            !result.orphans.iter().any(|k| k.contains("new_config")),
+            "new config blob must be kept"
+        );
+        assert!(
+            !result.orphans.iter().any(|k| k.contains("new_layer")),
+            "new layer blob must be kept"
+        );
+
+        // The old digest manifest itself should be detected as orphaned
+        let orphan_manifests: Vec<&String> = result
+            .orphans
+            .iter()
+            .filter(|k| k.contains("/manifests/"))
+            .collect();
+        assert_eq!(
+            orphan_manifests.len(),
+            2,
+            "both orphan digest manifests (old + new, new is not tag-reachable as sub-manifest)"
+        );
+        assert!(
+            orphan_manifests
+                .iter()
+                .any(|k| k.contains("sha256:old_digest")),
+            "old digest manifest must be orphaned"
+        );
+    }
+
+    /// #655 (part 2): A manifest list tag transitively protects sub-manifests'
+    /// blobs. Digest-keyed sub-manifests referenced by the index are resolved
+    /// in step 3 and their blobs kept.
+    #[tokio::test]
+    async fn test_gc_tag_rooted_manifest_list_transitive() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // Tag "latest" is a manifest list (image index)
+        let index = serde_json::json!({
+            "manifests": [
+                {"digest": "sha256:sub_amd64", "size": 100, "platform": {"architecture": "amd64"}},
+                {"digest": "sha256:sub_arm64", "size": 100, "platform": {"architecture": "arm64"}}
+            ]
+        });
+        // Sub-manifest for amd64
+        let sub_amd64 = serde_json::json!({
+            "config": {"digest": "sha256:cfg_amd64"},
+            "layers": [{"digest": "sha256:layer_amd64", "size": 500}]
+        });
+        // Sub-manifest for arm64
+        let sub_arm64 = serde_json::json!({
+            "config": {"digest": "sha256:cfg_arm64"},
+            "layers": [{"digest": "sha256:layer_arm64", "size": 600}]
+        });
+
+        storage
+            .put(
+                "docker/multi/manifests/latest.json",
+                index.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put(
+                "docker/multi/manifests/sha256:sub_amd64.json",
+                sub_amd64.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put(
+                "docker/multi/manifests/sha256:sub_arm64.json",
+                sub_arm64.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:cfg_amd64", b"cfg-amd64")
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:layer_amd64", b"layer-amd64")
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:cfg_arm64", b"cfg-arm64")
+            .await
+            .unwrap();
+        storage
+            .put("docker/multi/blobs/sha256:layer_arm64", b"layer-arm64")
+            .await
+            .unwrap();
+
+        let result = detect_docker_orphans(&storage).await;
+        assert_eq!(
+            result.orphans.len(),
+            0,
+            "all blobs and sub-manifests are transitively reachable from the tag"
+        );
+    }
+
+    /// #655 (part 2): A digest manifest with no tag pointing to it (and not a
+    /// sub-manifest of any tagged manifest list) is detected as an orphan.
+    #[tokio::test]
+    async fn test_gc_tag_rooted_orphan_digest_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let tagged = serde_json::json!({
+            "config": {"digest": "sha256:live_cfg"},
+            "layers": [{"digest": "sha256:live_layer", "size": 100}]
+        });
+        let orphan = serde_json::json!({
+            "config": {"digest": "sha256:dead_cfg"},
+            "layers": [{"digest": "sha256:dead_layer", "size": 200}]
+        });
+
+        // A proper tagged manifest
+        storage
+            .put(
+                "docker/repo/manifests/v1.json",
+                tagged.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+        // A digest-only manifest — no tag points to it
+        storage
+            .put(
+                "docker/repo/manifests/sha256:orphan_digest.json",
+                orphan.to_string().as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        // Blobs for both
+        storage
+            .put("docker/repo/blobs/sha256:live_cfg", b"cfg")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:live_layer", b"layer")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:dead_cfg", b"dead-cfg")
+            .await
+            .unwrap();
+        storage
+            .put("docker/repo/blobs/sha256:dead_layer", b"dead-layer")
+            .await
+            .unwrap();
+
+        let result = detect_docker_orphans(&storage).await;
+
+        // The orphan digest manifest itself
+        assert!(
+            result
+                .orphans
+                .iter()
+                .any(|k| k.contains("sha256:orphan_digest")),
+            "digest manifest with no tag must be orphaned"
+        );
+        // Its exclusive blobs
+        assert!(
+            result.orphans.iter().any(|k| k.contains("dead_cfg")),
+            "blob only referenced by orphaned digest manifest must be orphaned"
+        );
+        assert!(
+            result.orphans.iter().any(|k| k.contains("dead_layer")),
+            "blob only referenced by orphaned digest manifest must be orphaned"
+        );
+        // Live blobs must NOT be orphaned
+        assert!(
+            !result.orphans.iter().any(|k| k.contains("live_cfg")),
+            "tag-referenced blob must be kept"
+        );
+        assert!(
+            !result.orphans.iter().any(|k| k.contains("live_layer")),
+            "tag-referenced blob must be kept"
+        );
     }
 
     #[tokio::test]
@@ -1340,7 +1945,7 @@ mod tests {
         // Raw: no GC coverage
         storage.put("raw/some-file.txt", b"raw-data").await.unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         // Cargo crate without index entry = 1 orphan
         // Go .zip without .info = 1 orphan (incomplete version)
         assert_eq!(result.orphaned, 2);
@@ -1369,7 +1974,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(
             result.orphaned, 0,
             "complete Go version should have no orphans"
@@ -1387,7 +1992,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.orphaned, 1);
         assert!(result.orphan_keys[0].ends_with(".mod"));
     }
@@ -1406,7 +2011,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(
             result.orphaned, 0,
             "cargo with matching index should have no orphans"
@@ -1424,7 +2029,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.orphaned, 1);
         assert!(result.orphan_keys[0].contains("index"));
     }
@@ -1455,7 +2060,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.orphaned, 2);
         assert_eq!(result.deleted, 2);
         // Non-orphan checksum still exists
@@ -1486,7 +2091,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 1);
         assert!(storage
@@ -1514,7 +2119,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.orphaned, 1);
         assert_eq!(result.deleted, 1);
     }
@@ -1551,7 +2156,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.orphaned, 2); // 1 docker blob + 1 maven checksum
         assert_eq!(result.deleted, 2);
     }
@@ -1582,7 +2187,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         // 4 checksums scanned, 0 orphans
         assert_eq!(result.total_candidates, 4);
         assert_eq!(result.orphaned, 0);
@@ -1610,7 +2215,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.deleted, 1);
         assert_eq!(result.bytes_freed, 5); // "12345" = 5 bytes
     }
@@ -1639,7 +2244,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.metadata_phantoms_removed, 0);
     }
 
@@ -1671,7 +2276,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.metadata_phantoms_removed, 1);
 
         // Dry run: metadata should be unchanged
@@ -1707,7 +2312,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.metadata_phantoms_removed, 1);
 
         // Verify phantom was removed
@@ -1741,7 +2346,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(result.metadata_phantoms_removed, 0);
     }
 
@@ -1769,7 +2374,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.metadata_phantoms_removed, 1);
 
         // Verify phantom was removed
@@ -1822,7 +2427,7 @@ mod tests {
             .await
             .unwrap();
 
-        let result = run_gc(&storage, &test_publish_locks(), false, 0, false).await;
+        let result = run_gc(&storage, &test_publish_locks(), false, 0, false, 0).await;
         assert_eq!(result.orphaned, 1); // docker blob
         assert_eq!(result.deleted, 1);
         assert_eq!(result.metadata_phantoms_removed, 1); // npm phantom
@@ -1855,17 +2460,185 @@ mod tests {
             .unwrap();
 
         // Hosted mode: phantom is cleaned
-        let hosted = run_gc(&storage, &test_publish_locks(), true, 0, false).await;
+        let hosted = run_gc(&storage, &test_publish_locks(), true, 0, false, 0).await;
         assert_eq!(
             hosted.metadata_phantoms_removed, 1,
             "hosted: phantom detected"
         );
 
         // Proxy mode: phantom cleanup is skipped entirely
-        let proxy = run_gc(&storage, &test_publish_locks(), true, 0, true).await;
+        let proxy = run_gc(&storage, &test_publish_locks(), true, 0, true, 0).await;
         assert_eq!(
             proxy.metadata_phantoms_removed, 0,
             "proxy: npm phantom cleanup must be skipped"
         );
+    }
+
+    // -- #866: Proxy-cache eviction tests --
+
+    /// Basic eviction: 5 proxy files at 100 bytes each = 500 bytes total.
+    /// Cap = 300 → 2 oldest files evicted (freeing 200 bytes → 300 remaining).
+    #[tokio::test]
+    async fn test_evict_proxy_cache_basic() {
+        let dir = tempfile::tempdir().unwrap();
+        let data = dir.path().join("data");
+        let storage = Storage::new_local(data.to_str().unwrap());
+
+        // Create 5 proxy files with staggered mtime
+        let payload = vec![0u8; 100];
+        for i in 0..5u32 {
+            let key = format!("rpm/repo/Packages/{}-1.0.rpm", i);
+            storage.put(&key, &payload).await.unwrap();
+            // Set mtime: file 0 is oldest, file 4 is newest
+            let mtime = std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(1_000_000 + u64::from(i) * 1000);
+            std::fs::File::options()
+                .write(true)
+                .open(data.join(&key))
+                .unwrap()
+                .set_modified(mtime)
+                .unwrap();
+        }
+
+        let result = evict_proxy_cache(&storage, &test_publish_locks(), 300, false).await;
+        assert_eq!(result.total_bytes, 500);
+        assert_eq!(result.evicted_files, 2, "2 oldest files evicted");
+        assert_eq!(result.bytes_freed, 200);
+
+        // Files 0 and 1 (oldest) should be gone
+        assert!(storage.get("rpm/repo/Packages/0-1.0.rpm").await.is_err());
+        assert!(storage.get("rpm/repo/Packages/1-1.0.rpm").await.is_err());
+        // Files 2-4 still present
+        assert!(storage.get("rpm/repo/Packages/2-1.0.rpm").await.is_ok());
+        assert!(storage.get("rpm/repo/Packages/3-1.0.rpm").await.is_ok());
+        assert!(storage.get("rpm/repo/Packages/4-1.0.rpm").await.is_ok());
+    }
+
+    /// Files WITH .nora-meta/ sidecars (hosted packages) must never be evicted.
+    #[tokio::test]
+    async fn test_evict_proxy_cache_skips_hosted() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let payload = vec![0u8; 200];
+        // Hosted package (has sidecar)
+        storage
+            .put("rpm/myrepo/Packages/hosted-1.0.rpm", &payload)
+            .await
+            .unwrap();
+        storage
+            .put("rpm/myrepo/.nora-meta/Packages/hosted-1.0.rpm.json", b"{}")
+            .await
+            .unwrap();
+        // Proxy package (no sidecar)
+        storage
+            .put("rpm/myrepo/Packages/proxy-1.0.rpm", &payload)
+            .await
+            .unwrap();
+
+        // Cap = 100 → only proxy file can be evicted
+        let result = evict_proxy_cache(&storage, &test_publish_locks(), 100, false).await;
+        assert_eq!(result.evicted_files, 1);
+        // Hosted file must survive
+        assert!(storage
+            .get("rpm/myrepo/Packages/hosted-1.0.rpm")
+            .await
+            .is_ok());
+        // Proxy file evicted
+        assert!(storage
+            .get("rpm/myrepo/Packages/proxy-1.0.rpm")
+            .await
+            .is_err());
+    }
+
+    /// cap=0 means eviction is disabled — nothing evicted regardless of size.
+    #[tokio::test]
+    async fn test_evict_proxy_cache_disabled() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        storage
+            .put("rpm/repo/Packages/big-1.0.rpm", &vec![0u8; 1000])
+            .await
+            .unwrap();
+
+        let result = evict_proxy_cache(&storage, &test_publish_locks(), 0, false).await;
+        assert_eq!(result.evicted_files, 0);
+        assert_eq!(result.total_bytes, 0); // disabled returns immediately
+        assert!(storage.get("rpm/repo/Packages/big-1.0.rpm").await.is_ok());
+    }
+
+    /// Index files (repodata/repomd.xml, Packages, Release) must never be evicted.
+    #[tokio::test]
+    async fn test_evict_proxy_cache_skips_index_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let payload = vec![0u8; 100];
+        // Index files
+        storage
+            .put("rpm/repo/repodata/repomd.xml", &payload)
+            .await
+            .unwrap();
+        storage
+            .put("deb/repo/dists/stable/main/binary-amd64/Packages", &payload)
+            .await
+            .unwrap();
+        storage
+            .put("deb/repo/dists/stable/Release", &payload)
+            .await
+            .unwrap();
+        storage
+            .put("deb/repo/dists/stable/InRelease", &payload)
+            .await
+            .unwrap();
+        // One real proxy package
+        storage
+            .put("rpm/repo/Packages/evictme-1.0.rpm", &payload)
+            .await
+            .unwrap();
+
+        // Cap = 1 → aggressive, but index files must be immune
+        let result = evict_proxy_cache(&storage, &test_publish_locks(), 1, false).await;
+        assert_eq!(
+            result.evicted_files, 1,
+            "only the non-index proxy file evicted"
+        );
+        assert!(storage.get("rpm/repo/repodata/repomd.xml").await.is_ok());
+        assert!(storage
+            .get("deb/repo/dists/stable/main/binary-amd64/Packages")
+            .await
+            .is_ok());
+        assert!(storage.get("deb/repo/dists/stable/Release").await.is_ok());
+        assert!(storage.get("deb/repo/dists/stable/InRelease").await.is_ok());
+    }
+
+    /// Both rpm/ and deb/ proxy files count toward the same cap.
+    #[tokio::test]
+    async fn test_evict_proxy_cache_mixed_rpm_deb() {
+        let dir = tempfile::tempdir().unwrap();
+        let data = dir.path().join("data");
+        let storage = Storage::new_local(data.to_str().unwrap());
+
+        let payload = vec![0u8; 100];
+        // 2 rpm + 2 deb = 400 bytes total
+        for (i, prefix) in ["rpm", "deb", "rpm", "deb"].iter().enumerate() {
+            let key = format!("{}/repo/Packages/pkg{}-1.0.pkg", prefix, i);
+            storage.put(&key, &payload).await.unwrap();
+            let mtime = std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(1_000_000 + i as u64 * 1000);
+            std::fs::File::options()
+                .write(true)
+                .open(data.join(&key))
+                .unwrap()
+                .set_modified(mtime)
+                .unwrap();
+        }
+
+        // Cap = 200 → evict 2 oldest (200 bytes freed)
+        let result = evict_proxy_cache(&storage, &test_publish_locks(), 200, false).await;
+        assert_eq!(result.total_bytes, 400);
+        assert_eq!(result.evicted_files, 2);
+        assert_eq!(result.bytes_freed, 200);
     }
 }

--- a/nora-registry/src/main.rs
+++ b/nora-registry/src/main.rs
@@ -663,6 +663,7 @@ async fn main() {
                 dry_run,
                 config.gc.grace_secs,
                 config.npm.proxy.is_some(),
+                config.gc.proxy_cache_max_bytes,
             )
             .await;
             println!("GC Summary{}:", if dry_run { " (dry-run)" } else { "" });
@@ -689,6 +690,15 @@ async fn main() {
                     println!("  {}", key);
                 }
                 println!("\nRun with --apply to delete orphans.");
+            }
+            if result.proxy_cache_eviction.evicted_files > 0
+                || result.proxy_cache_eviction.total_bytes > 0
+            {
+                let e = &result.proxy_cache_eviction;
+                println!(
+                    "  Proxy cache:       {} bytes total, {} files evicted, {} bytes freed",
+                    e.total_bytes, e.evicted_files, e.bytes_freed
+                );
             }
             if !result.uncovered.is_empty() {
                 let parts: Vec<String> = result
@@ -1694,6 +1704,7 @@ async fn run_server(mut config: Config, storage: Storage) {
         let dry_run = state.config.gc.dry_run;
         let grace_secs = state.config.gc.grace_secs;
         let npm_is_proxy = state.config.npm.proxy.is_some();
+        let proxy_cache_max_bytes = state.config.gc.proxy_cache_max_bytes;
         cleanup_passes.push(cleanup::CleanupPass {
             name: "gc",
             interval: std::time::Duration::from_secs(state.config.gc.interval),
@@ -1702,7 +1713,7 @@ async fn run_server(mut config: Config, storage: Storage) {
                 let publish_locks = publish_locks.clone();
                 async move {
                     info!("GC scheduler: starting periodic run");
-                    let result = gc::run_gc(&storage, &publish_locks, dry_run, grace_secs, npm_is_proxy).await;
+                    let result = gc::run_gc(&storage, &publish_locks, dry_run, grace_secs, npm_is_proxy, proxy_cache_max_bytes).await;
                     info!(
                         "GC scheduler: done in {:.1}s — {} orphans, {} deleted, {} bytes freed, {} metadata phantoms, {} skipped (grace)",
                         result.duration_secs, result.orphaned, result.deleted, result.bytes_freed,

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "1.2.0",
+        version = "1.2.1",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, Conan, RPM, and Debian",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -2630,7 +2630,12 @@ async fn list_tags(State(state): State<AppState>, Path(name): Path<String>) -> R
                 .and_then(|t| t.strip_suffix(".json"))
                 .map(String::from)
         })
-        .filter(|t| !ends_with_ci(t, ".meta") && !t.contains(".meta."))
+        .filter(|t| {
+            !t.starts_with("sha256:")
+                && !t.starts_with("sha512:")
+                && !ends_with_ci(t, ".meta")
+                && !t.contains(".meta.")
+        })
         .collect();
     (StatusCode::OK, Json(json!({"name": name, "tags": tags}))).into_response()
 }
@@ -4134,6 +4139,59 @@ mod integration_tests {
         assert_eq!(json["name"], "alpine");
         let tags = json["tags"].as_array().unwrap();
         assert!(tags.contains(&serde_json::json!("latest")));
+    }
+
+    /// #932: tags/list must not include digest references (sha256:…).
+    /// put_manifest stores both {tag}.json and {digest}.json — only tags
+    /// belong in the OCI tags API response.
+    #[tokio::test]
+    async fn test_list_tags_excludes_digests() {
+        let ctx = create_test_context();
+        let manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "config": {
+                "mediaType": "application/vnd.docker.container.image.v1+json",
+                "size": 0,
+                "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "layers": []
+        });
+        seed_zero_config(&ctx.state, "nginx").await;
+        // Push two tags — each also stores a digest copy
+        for tag in ["stable", "mainline"] {
+            send(
+                &ctx.app,
+                Method::PUT,
+                &format!("/v2/nginx/manifests/{}", tag),
+                Body::from(serde_json::to_vec(&manifest).unwrap()),
+            )
+            .await;
+        }
+
+        let resp = send(&ctx.app, Method::GET, "/v2/nginx/tags/list", Body::empty()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let tags = json["tags"].as_array().unwrap();
+        // Must contain the real tags
+        assert!(
+            tags.iter().any(|t| t.as_str() == Some("stable")),
+            "{tags:?}"
+        );
+        assert!(
+            tags.iter().any(|t| t.as_str() == Some("mainline")),
+            "{tags:?}"
+        );
+        // Must NOT contain any digest reference
+        for tag in tags {
+            let t = tag.as_str().unwrap_or("");
+            assert!(
+                !t.starts_with("sha256:") && !t.starts_with("sha512:"),
+                "digest leaked into tags list: {}",
+                t
+            );
+        }
     }
 
     #[tokio::test]

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -501,6 +501,12 @@ async fn collect_docker_versions(storage: &Storage) -> Vec<(String, Vec<VersionE
                 let tag_file = &rest[idx + "/manifests/".len()..];
                 if ends_with_ci(tag_file, ".json") && !ends_with_ci(tag_file, ".meta.json") {
                     let tag = tag_file.strip_suffix(".json").unwrap_or(tag_file);
+                    // Skip digest references (sha256:…, sha512:…) — they are
+                    // stored alongside the tag file by put_manifest and must not
+                    // consume keep_last budget (#932).
+                    if tag.starts_with("sha256:") || tag.starts_with("sha512:") {
+                        continue;
+                    }
                     repos
                         .entry(repo.to_string())
                         .or_default()
@@ -944,6 +950,7 @@ fn find_matching_rule<'a>(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use sha2::Digest as _;
     use std::sync::Arc;
 
     fn test_publish_locks() -> PublishLocks {
@@ -1579,6 +1586,133 @@ mod tests {
         assert_eq!(plans.len(), 1);
         assert!(plans[0].reason.contains("keep_last"));
         assert!(plans[0].reason.contains("older than"));
+    }
+
+    // -- #932: Docker retention must count tags only, not digest references --
+
+    /// collect_docker_versions must skip sha256:/sha512: digest files so that
+    /// keep_last counts real OCI tags, not tag+digest pairs.
+    #[tokio::test]
+    async fn test_collect_docker_versions_skips_digests() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // 4 tags + 4 digest copies (as put_manifest stores them)
+        for tag in ["v1", "v2", "v3", "v4"] {
+            let manifest = serde_json::json!({"tag": tag});
+            let body = serde_json::to_vec(&manifest).unwrap();
+            let digest = format!(
+                "sha256:{}",
+                hex::encode(sha2::Digest::finalize(sha2::Sha256::new_with_prefix(&body)))
+            );
+            storage
+                .put(&format!("docker/myapp/manifests/{}.json", tag), &body)
+                .await
+                .unwrap();
+            storage
+                .put(&format!("docker/myapp/manifests/{}.json", digest), &body)
+                .await
+                .unwrap();
+        }
+
+        let groups = super::collect_docker_versions(&storage).await;
+        let myapp = groups
+            .iter()
+            .find(|(g, _)| g == "docker:myapp")
+            .expect("group exists");
+        assert_eq!(myapp.1.len(), 4, "exactly 4 tag entries, no digests");
+        for entry in &myapp.1 {
+            assert!(
+                !entry.name.starts_with("sha256:"),
+                "digest leaked: {}",
+                entry.name
+            );
+        }
+    }
+
+    /// With digests filtered, keep_last=3 on 4 tags correctly deletes 1 tag.
+    /// Before fix: 4 tags + 4 digests = 8 entries, keep_last=3 → 5 deleted
+    /// (only ceil(3/2) = 2 tags survived).
+    #[tokio::test]
+    async fn test_docker_keep_last_correct_with_digests() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        for (i, tag) in ["v1", "v2", "v3", "v4"].iter().enumerate() {
+            let manifest = serde_json::json!({"tag": tag, "i": i});
+            let body = serde_json::to_vec(&manifest).unwrap();
+            let digest = format!(
+                "sha256:{}",
+                hex::encode(sha2::Digest::finalize(sha2::Sha256::new_with_prefix(&body)))
+            );
+            storage
+                .put(&format!("docker/img/manifests/{}.json", tag), &body)
+                .await
+                .unwrap();
+            storage
+                .put(&format!("docker/img/manifests/{}.json", digest), &body)
+                .await
+                .unwrap();
+        }
+
+        let rules = vec![RetentionRule {
+            registry: "docker".to_string(),
+            name_glob: None,
+            keep_last: Some(3),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+
+        let result =
+            super::run_retention(&storage, &test_publish_locks(), None, &rules, true).await;
+        assert_eq!(
+            result.planned, 1,
+            "exactly 1 tag should be planned for deletion"
+        );
+    }
+
+    /// 4 tags pointing at the same manifest (1 shared digest) — keep_last=3
+    /// must still count 4 tags and delete 1, not be confused by the shared digest.
+    #[tokio::test]
+    async fn test_docker_tag_aliasing_keep_last() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let body = b"{\"shared\": true}";
+        let digest = format!(
+            "sha256:{}",
+            hex::encode(sha2::Digest::finalize(sha2::Sha256::new_with_prefix(body)))
+        );
+        // 4 tags all pointing at the same manifest
+        for tag in ["latest", "stable", "v1.0", "v0.9"] {
+            storage
+                .put(&format!("docker/lib/manifests/{}.json", tag), body)
+                .await
+                .unwrap();
+        }
+        // 1 shared digest file
+        storage
+            .put(&format!("docker/lib/manifests/{}.json", digest), body)
+            .await
+            .unwrap();
+
+        let groups = super::collect_docker_versions(&storage).await;
+        let lib = groups
+            .iter()
+            .find(|(g, _)| g == "docker:lib")
+            .expect("group exists");
+        assert_eq!(lib.1.len(), 4, "4 tags, 0 digests");
+
+        let rules = vec![RetentionRule {
+            registry: "docker".to_string(),
+            name_glob: None,
+            keep_last: Some(3),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+        let result =
+            super::run_retention(&storage, &test_publish_locks(), None, &rules, true).await;
+        assert_eq!(result.planned, 1, "1 of 4 tags deleted with keep_last=3");
     }
 
     // -- Integration tests with storage --

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -78,6 +78,14 @@ pub fn create_test_context_with_config(customize: impl FnOnce(&mut Config)) -> T
     build_context(false, &[], false, customize)
 }
 
+/// Build a test context with auth + anonymous_read + custom config tweaks.
+pub fn create_test_context_with_anonymous_read_and_config(
+    users: &[(&str, &str)],
+    customize: impl FnOnce(&mut Config),
+) -> TestContext {
+    build_context(true, users, true, customize)
+}
+
 fn build_context(
     auth_enabled: bool,
     users: &[(&str, &str)],

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -4,6 +4,7 @@
 use super::components::{format_size, format_timestamp, html_escape, sanitize_href};
 use super::templates::encode_uri_component;
 use crate::activity_log::ActivityEntry;
+use crate::auth::AuthenticatedUser;
 use crate::registry_type::RegistryType;
 use crate::repo_index::RepoInfo;
 use crate::validation::ends_with_ci;
@@ -12,6 +13,7 @@ use crate::Storage;
 use axum::{
     extract::{Path, Query, State},
     response::Json,
+    Extension,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -179,7 +181,19 @@ pub async fn api_stats(State(state): State<AppState>) -> Json<RegistryStats> {
     })
 }
 
-pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardResponse> {
+pub async fn api_dashboard(
+    State(state): State<AppState>,
+    user: Option<Extension<AuthenticatedUser>>,
+) -> Json<DashboardResponse> {
+    let authenticated = user.map(|Extension(u)| u.0 != "anonymous").unwrap_or(false);
+    Json(build_dashboard_response(&state, authenticated).await)
+}
+
+/// Build the dashboard JSON payload.
+///
+/// When `authenticated` is false, `proxy_upstreams` is redacted (empty vec)
+/// to avoid leaking upstream registry topology to anonymous callers.
+pub async fn build_dashboard_response(state: &AppState, authenticated: bool) -> DashboardResponse {
     let mut total_storage: u64 = 0;
     let mut total_artifacts: usize = 0;
     let mut registry_card_stats = Vec::new();
@@ -206,40 +220,46 @@ pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardRespo
             size_bytes: size,
         });
 
-        let proxy_upstreams: Vec<String> = match reg {
-            RegistryType::Docker => state
-                .config
-                .docker
-                .upstreams
-                .iter()
-                .map(|u| u.url.clone())
-                .collect(),
-            RegistryType::Maven => state
-                .config
-                .maven
-                .proxies
-                .iter()
-                .map(|p| p.url().to_string())
-                .collect(),
-            RegistryType::Npm => state.config.npm.proxy.clone().into_iter().collect(),
-            RegistryType::Cargo => state.config.cargo.proxy.clone().into_iter().collect(),
-            RegistryType::PyPI => state
-                .config
-                .pypi
-                .upstreams()
-                .iter()
-                .map(|u| u.url().to_string())
-                .collect(),
-            RegistryType::Go => state.config.go.proxy.clone().into_iter().collect(),
-            RegistryType::Raw => vec![],
-            RegistryType::Gems => state.config.gems.proxy.clone().into_iter().collect(),
-            RegistryType::Terraform => state.config.terraform.proxy.clone().into_iter().collect(),
-            RegistryType::Ansible => state.config.ansible.proxy.clone().into_iter().collect(),
-            RegistryType::Nuget => state.config.nuget.proxy.clone().into_iter().collect(),
-            RegistryType::PubDart => state.config.pub_dart.proxy.clone().into_iter().collect(),
-            RegistryType::Conan => state.config.conan.proxy.clone().into_iter().collect(),
-            RegistryType::Rpm => vec![],
-            RegistryType::Deb => vec![],
+        let proxy_upstreams: Vec<String> = if authenticated {
+            match reg {
+                RegistryType::Docker => state
+                    .config
+                    .docker
+                    .upstreams
+                    .iter()
+                    .map(|u| u.url.clone())
+                    .collect(),
+                RegistryType::Maven => state
+                    .config
+                    .maven
+                    .proxies
+                    .iter()
+                    .map(|p| p.url().to_string())
+                    .collect(),
+                RegistryType::Npm => state.config.npm.proxy.clone().into_iter().collect(),
+                RegistryType::Cargo => state.config.cargo.proxy.clone().into_iter().collect(),
+                RegistryType::PyPI => state
+                    .config
+                    .pypi
+                    .upstreams()
+                    .iter()
+                    .map(|u| u.url().to_string())
+                    .collect(),
+                RegistryType::Go => state.config.go.proxy.clone().into_iter().collect(),
+                RegistryType::Raw => vec![],
+                RegistryType::Gems => state.config.gems.proxy.clone().into_iter().collect(),
+                RegistryType::Terraform => {
+                    state.config.terraform.proxy.clone().into_iter().collect()
+                }
+                RegistryType::Ansible => state.config.ansible.proxy.clone().into_iter().collect(),
+                RegistryType::Nuget => state.config.nuget.proxy.clone().into_iter().collect(),
+                RegistryType::PubDart => state.config.pub_dart.proxy.clone().into_iter().collect(),
+                RegistryType::Conan => state.config.conan.proxy.clone().into_iter().collect(),
+                RegistryType::Rpm => vec![],
+                RegistryType::Deb => vec![],
+            }
+        } else {
+            vec![]
         };
 
         mount_points.push(MountPoint {
@@ -260,14 +280,14 @@ pub async fn api_dashboard(State(state): State<AppState>) -> Json<DashboardRespo
     let activity = state.activity.recent(20);
     let uptime_seconds = state.start_time.elapsed().as_secs();
 
-    Json(DashboardResponse {
+    DashboardResponse {
         global_stats,
         registry_stats: registry_card_stats,
         mount_points,
         activity,
         uptime_seconds,
         startup_duration_ms: state.startup_duration_ms,
-    })
+    }
 }
 
 pub async fn api_list(

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -251,13 +251,15 @@ async fn dashboard(
     State(state): State<AppState>,
     Query(query): Query<LangQuery>,
     headers: axum::http::HeaderMap,
+    user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
     let lang = extract_lang(
         &Query(query),
         headers.get("cookie").and_then(|v| v.to_str().ok()),
     );
     let auth_enabled = state.auth.is_some();
-    let response = api_dashboard(State(state)).await.0;
+    let authenticated = user.map(|Extension(u)| u.0 != "anonymous").unwrap_or(false);
+    let response = build_dashboard_response(&state, authenticated).await;
     Html(render_dashboard(&response, lang, auth_enabled))
 }
 


### PR DESCRIPTION
## Summary

- **Tag-rooted Docker GC (#655 part 2):** `detect_docker_orphans` now only considers tag manifests when building the referenced blob set. Digest-only manifests (`sha256:*.json`) not reachable from any tag become orphans, making their exclusive blobs reclaimable. Manifest list sub-manifests are transitively resolved (2-pass). Combined with #932 this fully solves "re-pushed tags never reclaim space".
- **Proxy-cache LRU eviction (#866):** size-based eviction for proxy-cached rpm/deb files via `NORA_GC_PROXY_CACHE_MAX_BYTES`.
- **Docker retention tags-only (#932):** `collect_docker_versions` and `list_tags` skip `sha256:`/`sha512:` digest references so they don't consume `keep_last` budget.
- **npm proxy stale-entry skip + 304 body-miss heal (#925, #867):** GC skips stale-entry cleanup in proxy mode; stale `.meta` validators are deleted on 304 body-miss to self-heal.
- **Dashboard proxy_upstreams redaction (#934):** anonymous callers see empty `proxy_upstreams` to prevent topology disclosure.
- **Opportunistic auth test coverage (#934):** tests for open web surfaces with optional auth.
- **llms.txt claims fix:** correct binary size and format count.

## Contracts

`docker-gc-tag-rooted` added to governance contracts (7/7 GREEN).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test -p nora-registry` — 1774 passed, 0 failed
- [x] Governance gate — GREEN (7/7)
- [x] `coherence-check.sh` — PASSED (0 errors)
- [x] Polygon step 2e: disk↔web reconcile PASS (pypi 12/12, docker count/size)
- [x] Polygon GC black-box: push v1 → re-push v2 → GC → v1 blobs+digest manifest reclaimed, v2 survived
- [x] OPSEC + Semgrep pre-push checks PASSED