### PR TITLE
perf(maven): skip metadata rewrite when merged document is unchanged

### DIFF
--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -1113,10 +1113,15 @@ async fn merge_and_cache_proxy_metadata(
         Bytes::copy_from_slice(upstream)
     };
 
-    if let Err(error) = state.storage.put(&key, &data).await {
-        tracing::warn!(key = %key, error = %error, "maven: failed to cache metadata");
-    } else {
-        compute_and_store_checksums(&state.storage, &key, &data).await;
+    // Skip the write when the merged document is byte-identical to the cached
+    // version — avoids 5 no-op storage writes (1 doc + 4 checksums) on every
+    // revalidation under low/zero metadata_ttl (#888).
+    if cached.as_deref() != Some(data.as_ref()) {
+        if let Err(error) = state.storage.put(&key, &data).await {
+            tracing::warn!(key = %key, error = %error, "maven: failed to cache metadata");
+        } else {
+            compute_and_store_checksums(&state.storage, &key, &data).await;
+        }
     }
 
     data


### PR DESCRIPTION
## Summary
- Skip 5 storage writes (1 document + 4 checksums) when merged Maven metadata is byte-identical to the cached version
- Guards the hot path in `merge_and_cache_proxy_metadata` with `cached.as_deref() != Some(data.as_ref())`
- Significant I/O reduction under low/zero `metadata_ttl` configurations

Closes #888

## Test plan
- [x] `cargo fmt --check` PASS
- [x] `cargo clippy -- -D warnings` PASS  
- [x] `cargo test` 1761/1761 PASS
- [x] Polygon step 2 (functional): Maven push-pull byte-exact PASS
- [x] Polygon step 2: disk-web reconcile maven PASS