### PR TITLE
chore: release 1.3.0-rc

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,54 @@
+name: Link Check
+
+on:
+  push:
+    branches: [main]
+    paths: ["**.md", "llms.txt"]
+  pull_request:
+    branches: [main]
+    paths: ["**.md", "llms.txt"]
+  schedule:
+    # Weekly external-link rot check (Sunday 06:00 UTC)
+    - cron: "0 6 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Restore lychee cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+
+      - name: Run lychee link checker
+        uses: lycheeverse/lychee-action@f613a0156d062e3ecbf2dfa68ab1abcbcae85654 # v2.4.1
+        with:
+          args: >-
+            --cache
+            --max-cache-age 7d
+            --exclude-path CHANGELOG.md
+            --exclude-path mutants.out
+            --exclude 'localhost'
+            --exclude '127\.0\.0\.1'
+            --exclude '0\.0\.0\.0'
+            --exclude 'example\.com'
+            --exclude 'nora\.example\.com'
+            --exclude 'registry\.example\.com'
+            --exclude '10\.\d+'
+            --exclude '192\.168\.'
+            --timeout 30
+            --max-retries 3
+            --accept 200,206,429
+            '**/*.md'
+            'llms.txt'
+          fail: ${{ github.event_name != 'schedule' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -381,7 +381,7 @@ Helm charts are stored as OCI artifacts via the Docker registry endpoints. `helm
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Authentication (Bearer/Basic) | Full | Per-request token validation |
+| Authentication (Bearer/Basic) | Full | Per-request token validation; see OIDC note below |
 | Anonymous read | Full | `NORA_AUTH_ANONYMOUS_READ=true` |
 | Rate limiting (429 + Retry-After) | Full | `tower_governor`, per-IP, documented in OpenAPI |
 | 405 Method Not Allowed + Allow | Full | RFC 9110 §15.5.6, multi-method routes return Allow header |
@@ -394,6 +394,17 @@ Helm charts are stored as OCI artifacts via the Docker registry endpoints. `helm
 | Activity log | Full | Recent push/pull in dashboard |
 | Backup/restore | Full | CLI commands |
 | Mirror CLI | Full | `nora mirror` for npm/pip/cargo/maven/docker/rpm/deb |
+
+### OIDC authentication transport
+
+OIDC JWT tokens are validated only on the **Bearer** authentication path.
+Docker, twine, and Maven clients transmit credentials via HTTP Basic, and the
+Basic-auth handler recognises htpasswd passwords and opaque API tokens (`nra_…`)
+but does **not** attempt OIDC JWT validation on the password field. To use OIDC
+workload identity from CI, send the JWT as a `Bearer` token (e.g.
+`Authorization: Bearer <jwt>`) rather than as a `docker login` password. For
+`docker login` specifically, use an opaque API token created via the UI or
+`/api/tokens`. (#853)
 
 ### Storage backend notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "1.2.1"
+version = "1.3.0-rc"
 dependencies = [
  "ar",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.1"
+version = "1.3.0-rc"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # NORA
 
-A lightweight, open-source artifact registry. 15 formats in a single binary (< 27 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++), RPM (yum/dnf, hosted), Debian/APT (hosted). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
+A lightweight, open-source artifact registry. 15 formats in a single binary (< 30 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++), RPM (yum/dnf, hosted), Debian/APT (hosted). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
 
 > The artifact registry that grows with you. Zero-config to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
 
@@ -187,13 +187,13 @@ cd nora && cargo build --release
 |--------|------|-------|-------------------|
 | Startup | < 3s | 30-60s | 30-60s |
 | Memory | < 50 MB idle | 2-4 GB | 2-4 GB |
-| Binary | < 27 MB | 600+ MB | 1+ GB |
+| Binary | < 30 MB | 600+ MB | 1+ GB |
 | Dependencies | None | Java 11+ | Java 11+ |
 | Database | None (filesystem) | Embedded/PostgreSQL | Embedded/PostgreSQL |
 
 ## How NORA compares to alternatives
 
-- vs Sonatype Nexus: NORA is over 20x smaller (< 27 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
+- vs Sonatype Nexus: NORA is over 20x smaller (< 30 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
 - vs JFrog Artifactory: NORA is free and open-source with no feature gating. Artifactory has more enterprise features (replication, Xray scanning, RBAC)
 - vs Docker Distribution (registry:2): NORA adds 12 more formats, Web UI, upstream proxy, backup/restore, metrics. Distribution is Docker-only
 - vs Verdaccio: Verdaccio is npm-only. NORA handles npm plus 12 other formats

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "1.2.1",
+        version = "1.3.0-rc",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, Conan, RPM, and Debian",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -1113,10 +1113,15 @@ async fn merge_and_cache_proxy_metadata(
         Bytes::copy_from_slice(upstream)
     };
 
-    if let Err(error) = state.storage.put(&key, &data).await {
-        tracing::warn!(key = %key, error = %error, "maven: failed to cache metadata");
-    } else {
-        compute_and_store_checksums(&state.storage, &key, &data).await;
+    // Skip the write when the merged document is byte-identical to the cached
+    // version — avoids 5 no-op storage writes (1 doc + 4 checksums) on every
+    // revalidation under low/zero metadata_ttl (#888).
+    if cached.as_deref() != Some(data.as_ref()) {
+        if let Err(error) = state.storage.put(&key, &data).await {
+            tracing::warn!(key = %key, error = %error, "maven: failed to cache metadata");
+        } else {
+            compute_and_store_checksums(&state.storage, &key, &data).await;
+        }
     }
 
     data


### PR DESCRIPTION
## Summary
Release candidate for NORA v1.3.0 assembling all changes since v1.2.1:

- **perf(maven)**: skip metadata rewrite when merged document is unchanged (#888)
- **docs(compat)**: clarify OIDC JWT is Bearer-only, not Basic password (#853)
- **ci**: add docs link-checker to catch dead links (#727)
- **chore**: bump version 1.2.1 → 1.3.0-rc (Cargo.toml, openapi.rs, Cargo.lock)
- **docs(llms)**: correct binary size claim from < 27 MB to < 30 MB

## Polygon Verdict: GREEN (8/8 PASS)

| Step | Name | Verdict |
|------|------|---------|
| 1 | Config Matrix (256 combos) | PASS |
| 2 | Functional (push-pull, disk-web reconcile) | PASS |
| 3 | Non-functional (concurrency) | PASS |
| 4 | Security (path traversal, auth, air-gap) | PASS |
| 5 | API Contract (OpenAPI, OCI) | PASS |
| 6 | E2E Real Clients (raw, maven, pypi) | PASS |
| 7 | Observability (metrics, audit) | PASS |
| 8 | Coherence (0 errors, 6 pre-existing warnings) | PASS |

- Binary: 29.6 MB (`nora 1.3.0-rc`)
- Tests: 1761 pass, 0 fail
- Contract gate: 6 pre-existing reds (same as main HEAD, no new regressions)

## Test plan
- [x] `cargo fmt --check` PASS
- [x] `cargo clippy -- -D warnings` PASS
- [x] `cargo test` 1761/1761 PASS
- [x] Full 8-step polygon GREEN
- [x] claims-verify PASS (binary size claim fixed)
- [x] coherence-check 0 errors