### PR TITLE
chore: release 1.2.2

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,54 @@
+name: Link Check
+
+on:
+  push:
+    branches: [main]
+    paths: ["**.md", "llms.txt"]
+  pull_request:
+    branches: [main]
+    paths: ["**.md", "llms.txt"]
+  schedule:
+    # Weekly external-link rot check (Sunday 06:00 UTC)
+    - cron: "0 6 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  link-check:
+    name: Check Markdown Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Restore lychee cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+
+      - name: Run lychee link checker
+        uses: lycheeverse/lychee-action@f613a0156d062e3ecbf2dfa68ab1abcbcae85654 # v2.4.1
+        with:
+          args: >-
+            --cache
+            --max-cache-age 7d
+            --exclude-path CHANGELOG.md
+            --exclude-path mutants.out
+            --exclude 'localhost'
+            --exclude '127\.0\.0\.1'
+            --exclude '0\.0\.0\.0'
+            --exclude 'example\.com'
+            --exclude 'nora\.example\.com'
+            --exclude 'registry\.example\.com'
+            --exclude '10\.\d+'
+            --exclude '192\.168\.'
+            --timeout 30
+            --max-retries 3
+            --accept 200,206,429
+            '**/*.md'
+            'llms.txt'
+          fail: ${{ github.event_name != 'schedule' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/COMPAT.md
+++ b/COMPAT.md
@@ -381,7 +381,7 @@ Helm charts are stored as OCI artifacts via the Docker registry endpoints. `helm
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Authentication (Bearer/Basic) | Full | Per-request token validation |
+| Authentication (Bearer/Basic) | Full | Per-request token validation; see OIDC note below |
 | Anonymous read | Full | `NORA_AUTH_ANONYMOUS_READ=true` |
 | Rate limiting (429 + Retry-After) | Full | `tower_governor`, per-IP, documented in OpenAPI |
 | 405 Method Not Allowed + Allow | Full | RFC 9110 §15.5.6, multi-method routes return Allow header |
@@ -394,6 +394,17 @@ Helm charts are stored as OCI artifacts via the Docker registry endpoints. `helm
 | Activity log | Full | Recent push/pull in dashboard |
 | Backup/restore | Full | CLI commands |
 | Mirror CLI | Full | `nora mirror` for npm/pip/cargo/maven/docker/rpm/deb |
+
+### OIDC authentication transport
+
+OIDC JWT tokens are validated only on the **Bearer** authentication path.
+Docker, twine, and Maven clients transmit credentials via HTTP Basic, and the
+Basic-auth handler recognises htpasswd passwords and opaque API tokens (`nra_…`)
+but does **not** attempt OIDC JWT validation on the password field. To use OIDC
+workload identity from CI, send the JWT as a `Bearer` token (e.g.
+`Authorization: Bearer <jwt>`) rather than as a `docker login` password. For
+`docker login` specifically, use an opaque API token created via the UI or
+`/api/tokens`. (#853)
 
 ### Storage backend notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,7 +2322,7 @@ dependencies = [
 
 [[package]]
 name = "nora-registry"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "ar",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 rust-version = "1.88"
 license = "MIT"

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # NORA
 
-A lightweight, open-source artifact registry. 15 formats in a single binary (< 27 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++), RPM (yum/dnf, hosted), Debian/APT (hosted). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
+A lightweight, open-source artifact registry. 15 formats in a single binary (< 30 MB on disk): Docker (+ Helm OCI), Maven, npm, PyPI, Cargo, Go, Raw, RubyGems, Terraform, Ansible Galaxy, NuGet, Pub (Dart/Flutter), Conan (C/C++), RPM (yum/dnf, hosted), Debian/APT (hosted). Zero dependencies, zero config. Starts with `docker run`, scales to enterprise.
 
 > The artifact registry that grows with you. Zero-config to start, S3-ready when you need it. MIT licensed, air-gapped ready, FSTEC builds included.
 
@@ -187,13 +187,13 @@ cd nora && cargo build --release
 |--------|------|-------|-------------------|
 | Startup | < 3s | 30-60s | 30-60s |
 | Memory | < 50 MB idle | 2-4 GB | 2-4 GB |
-| Binary | < 27 MB | 600+ MB | 1+ GB |
+| Binary | < 30 MB | 600+ MB | 1+ GB |
 | Dependencies | None | Java 11+ | Java 11+ |
 | Database | None (filesystem) | Embedded/PostgreSQL | Embedded/PostgreSQL |
 
 ## How NORA compares to alternatives
 
-- vs Sonatype Nexus: NORA is over 20x smaller (< 27 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
+- vs Sonatype Nexus: NORA is over 20x smaller (< 30 MB vs 600+ MB), needs no Java, starts in 3s vs 30-60s. Nexus supports more formats (30+) and has LDAP/SAML
 - vs JFrog Artifactory: NORA is free and open-source with no feature gating. Artifactory has more enterprise features (replication, Xray scanning, RBAC)
 - vs Docker Distribution (registry:2): NORA adds 12 more formats, Web UI, upstream proxy, backup/restore, metrics. Distribution is Docker-only
 - vs Verdaccio: Verdaccio is npm-only. NORA handles npm plus 12 other formats

--- a/nora-registry/src/openapi.rs
+++ b/nora-registry/src/openapi.rs
@@ -21,7 +21,7 @@ use crate::AppState;
 #[openapi(
     info(
         title = "Nora",
-        version = "1.2.1",
+        version = "1.2.2",
         description = "Multi-protocol package registry supporting Docker, Maven, npm, Cargo, PyPI, Go, Raw, RubyGems, Terraform, Ansible, NuGet, pub.dev, Conan, RPM, and Debian",
         license(name = "MIT"),
         contact(name = "The NORA Authors", url = "https://getnora.dev")

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -2630,7 +2630,12 @@ async fn list_tags(State(state): State<AppState>, Path(name): Path<String>) -> R
                 .and_then(|t| t.strip_suffix(".json"))
                 .map(String::from)
         })
-        .filter(|t| !ends_with_ci(t, ".meta") && !t.contains(".meta."))
+        .filter(|t| {
+            !t.starts_with("sha256:")
+                && !t.starts_with("sha512:")
+                && !ends_with_ci(t, ".meta")
+                && !t.contains(".meta.")
+        })
         .collect();
     (StatusCode::OK, Json(json!({"name": name, "tags": tags}))).into_response()
 }
@@ -4134,6 +4139,59 @@ mod integration_tests {
         assert_eq!(json["name"], "alpine");
         let tags = json["tags"].as_array().unwrap();
         assert!(tags.contains(&serde_json::json!("latest")));
+    }
+
+    /// #932: tags/list must not include digest references (sha256:…).
+    /// put_manifest stores both {tag}.json and {digest}.json — only tags
+    /// belong in the OCI tags API response.
+    #[tokio::test]
+    async fn test_list_tags_excludes_digests() {
+        let ctx = create_test_context();
+        let manifest = serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+            "config": {
+                "mediaType": "application/vnd.docker.container.image.v1+json",
+                "size": 0,
+                "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "layers": []
+        });
+        seed_zero_config(&ctx.state, "nginx").await;
+        // Push two tags — each also stores a digest copy
+        for tag in ["stable", "mainline"] {
+            send(
+                &ctx.app,
+                Method::PUT,
+                &format!("/v2/nginx/manifests/{}", tag),
+                Body::from(serde_json::to_vec(&manifest).unwrap()),
+            )
+            .await;
+        }
+
+        let resp = send(&ctx.app, Method::GET, "/v2/nginx/tags/list", Body::empty()).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_bytes(resp).await;
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let tags = json["tags"].as_array().unwrap();
+        // Must contain the real tags
+        assert!(
+            tags.iter().any(|t| t.as_str() == Some("stable")),
+            "{tags:?}"
+        );
+        assert!(
+            tags.iter().any(|t| t.as_str() == Some("mainline")),
+            "{tags:?}"
+        );
+        // Must NOT contain any digest reference
+        for tag in tags {
+            let t = tag.as_str().unwrap_or("");
+            assert!(
+                !t.starts_with("sha256:") && !t.starts_with("sha512:"),
+                "digest leaked into tags list: {}",
+                t
+            );
+        }
     }
 
     #[tokio::test]

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -1113,10 +1113,15 @@ async fn merge_and_cache_proxy_metadata(
         Bytes::copy_from_slice(upstream)
     };
 
-    if let Err(error) = state.storage.put(&key, &data).await {
-        tracing::warn!(key = %key, error = %error, "maven: failed to cache metadata");
-    } else {
-        compute_and_store_checksums(&state.storage, &key, &data).await;
+    // Skip the write when the merged document is byte-identical to the cached
+    // version — avoids 5 no-op storage writes (1 doc + 4 checksums) on every
+    // revalidation under low/zero metadata_ttl (#888).
+    if cached.as_deref() != Some(data.as_ref()) {
+        if let Err(error) = state.storage.put(&key, &data).await {
+            tracing::warn!(key = %key, error = %error, "maven: failed to cache metadata");
+        } else {
+            compute_and_store_checksums(&state.storage, &key, &data).await;
+        }
     }
 
     data

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -456,7 +456,7 @@ async fn download_file(
         };
 
         // The file may live on a later upstream — keep walking the list.
-        let Some(file_url) = find_file_url(&html, &filename) else {
+        let Some(file_url) = find_file_url(&html, &filename, &page_url) else {
             continue;
         };
 
@@ -967,7 +967,10 @@ fn merge_file_lists(upstream: Vec<FileEntry>, local: &[FileEntry]) -> Vec<FileEn
 }
 
 /// Find the download URL for a specific file in the HTML.
-fn find_file_url(html: &str, target_filename: &str) -> Option<String> {
+///
+/// `page_url` is the simple-index page URL used to resolve relative hrefs
+/// returned by some mirrors (Tsinghua, USTC, Aliyun) (#877).
+fn find_file_url(html: &str, target_filename: &str, page_url: &str) -> Option<String> {
     let mut remaining = html;
 
     while let Some(href_start) = remaining.find("href=\"") {
@@ -983,7 +986,16 @@ fn find_file_url(html: &str, target_filename: &str) -> Option<String> {
                 // unchanged — it must stay encoded to fetch from the upstream (#664).
                 let decoded = percent_encoding::percent_decode_str(filename).decode_utf8_lossy();
                 if decoded.as_ref() == target_filename {
-                    return Some(url.split('#').next().unwrap_or(url).to_string());
+                    let raw = url.split('#').next().unwrap_or(url).to_string();
+                    // Resolve relative URLs against the page URL (#877).
+                    if raw.starts_with("http://") || raw.starts_with("https://") {
+                        return Some(raw);
+                    }
+                    return reqwest::Url::parse(page_url)
+                        .ok()
+                        .and_then(|base| base.join(&raw).ok())
+                        .map(|u| u.to_string())
+                        .or(Some(raw));
                 }
             }
 
@@ -1071,7 +1083,7 @@ mod tests {
             r#"torch-2.4.0+cu124-cp310-cp310-linux_x86_64.whl</a>"#,
         );
         assert_eq!(
-            find_file_url(html, "torch-2.4.0+cu124-cp310-cp310-linux_x86_64.whl").as_deref(),
+            find_file_url(html, "torch-2.4.0+cu124-cp310-cp310-linux_x86_64.whl", "https://pypi.org/simple/torch/").as_deref(),
             Some(
                 "https://download.pytorch.org/whl/cu124/torch-2.4.0%2Bcu124-cp310-cp310-linux_x86_64.whl"
             )
@@ -1079,7 +1091,12 @@ mod tests {
         // A plain filename (no encoding) still matches.
         let plain = r#"<a href="https://x/torch-0.1.10-cp36-cp36m-macosx.whl">x</a>"#;
         assert_eq!(
-            find_file_url(plain, "torch-0.1.10-cp36-cp36m-macosx.whl").as_deref(),
+            find_file_url(
+                plain,
+                "torch-0.1.10-cp36-cp36m-macosx.whl",
+                "https://pypi.org/simple/torch/"
+            )
+            .as_deref(),
             Some("https://x/torch-0.1.10-cp36-cp36m-macosx.whl")
         );
     }
@@ -1174,7 +1191,7 @@ mod tests {
     #[test]
     fn test_find_file_url_found() {
         let html = r#"<a href="https://files.pythonhosted.org/packages/aa/bb/flask-2.0.tar.gz#sha256=abc">flask-2.0.tar.gz</a>"#;
-        let result = find_file_url(html, "flask-2.0.tar.gz");
+        let result = find_file_url(html, "flask-2.0.tar.gz", "https://pypi.org/simple/flask/");
         assert_eq!(
             result,
             Some("https://files.pythonhosted.org/packages/aa/bb/flask-2.0.tar.gz".to_string())
@@ -1184,15 +1201,58 @@ mod tests {
     #[test]
     fn test_find_file_url_not_found() {
         let html = r#"<a href="https://example.com/other-1.0.tar.gz">other</a>"#;
-        let result = find_file_url(html, "flask-2.0.tar.gz");
+        let result = find_file_url(html, "flask-2.0.tar.gz", "https://pypi.org/simple/flask/");
         assert_eq!(result, None);
     }
 
     #[test]
     fn test_find_file_url_strips_hash() {
         let html = r#"<a href="https://example.com/pkg-1.0.whl#sha256=deadbeef">pkg</a>"#;
-        let result = find_file_url(html, "pkg-1.0.whl");
+        let result = find_file_url(html, "pkg-1.0.whl", "https://pypi.org/simple/pkg/");
         assert_eq!(result, Some("https://example.com/pkg-1.0.whl".to_string()));
+    }
+
+    // -- #877: relative URL resolution --
+
+    #[test]
+    fn test_find_file_url_relative() {
+        let html = r#"<a href="../../packages/torch-2.4.0.whl#sha256=abc">torch-2.4.0.whl</a>"#;
+        let result = find_file_url(
+            html,
+            "torch-2.4.0.whl",
+            "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/torch/",
+        );
+        assert_eq!(
+            result,
+            Some(
+                "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/packages/torch-2.4.0.whl"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_find_file_url_absolute_unchanged() {
+        let html = r#"<a href="https://files.pythonhosted.org/packages/ab/cd/pkg-1.0.whl">pkg-1.0.whl</a>"#;
+        let result = find_file_url(
+            html,
+            "pkg-1.0.whl",
+            "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple/pkg/",
+        );
+        assert_eq!(
+            result,
+            Some("https://files.pythonhosted.org/packages/ab/cd/pkg-1.0.whl".to_string())
+        );
+    }
+
+    #[test]
+    fn test_find_file_url_path_only() {
+        let html = r#"<a href="/packages/pkg-1.0.whl#sha256=ff">pkg-1.0.whl</a>"#;
+        let result = find_file_url(html, "pkg-1.0.whl", "https://pypi.example.com/simple/pkg/");
+        assert_eq!(
+            result,
+            Some("https://pypi.example.com/packages/pkg-1.0.whl".to_string())
+        );
     }
 
     #[test]

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -501,6 +501,12 @@ async fn collect_docker_versions(storage: &Storage) -> Vec<(String, Vec<VersionE
                 let tag_file = &rest[idx + "/manifests/".len()..];
                 if ends_with_ci(tag_file, ".json") && !ends_with_ci(tag_file, ".meta.json") {
                     let tag = tag_file.strip_suffix(".json").unwrap_or(tag_file);
+                    // Skip digest references (sha256:…, sha512:…) — they are
+                    // stored alongside the tag file by put_manifest and must not
+                    // consume keep_last budget (#932).
+                    if tag.starts_with("sha256:") || tag.starts_with("sha512:") {
+                        continue;
+                    }
                     repos
                         .entry(repo.to_string())
                         .or_default()
@@ -944,6 +950,7 @@ fn find_matching_rule<'a>(
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use sha2::Digest as _;
     use std::sync::Arc;
 
     fn test_publish_locks() -> PublishLocks {
@@ -1579,6 +1586,133 @@ mod tests {
         assert_eq!(plans.len(), 1);
         assert!(plans[0].reason.contains("keep_last"));
         assert!(plans[0].reason.contains("older than"));
+    }
+
+    // -- #932: Docker retention must count tags only, not digest references --
+
+    /// collect_docker_versions must skip sha256:/sha512: digest files so that
+    /// keep_last counts real OCI tags, not tag+digest pairs.
+    #[tokio::test]
+    async fn test_collect_docker_versions_skips_digests() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        // 4 tags + 4 digest copies (as put_manifest stores them)
+        for tag in ["v1", "v2", "v3", "v4"] {
+            let manifest = serde_json::json!({"tag": tag});
+            let body = serde_json::to_vec(&manifest).unwrap();
+            let digest = format!(
+                "sha256:{}",
+                hex::encode(sha2::Digest::finalize(sha2::Sha256::new_with_prefix(&body)))
+            );
+            storage
+                .put(&format!("docker/myapp/manifests/{}.json", tag), &body)
+                .await
+                .unwrap();
+            storage
+                .put(&format!("docker/myapp/manifests/{}.json", digest), &body)
+                .await
+                .unwrap();
+        }
+
+        let groups = super::collect_docker_versions(&storage).await;
+        let myapp = groups
+            .iter()
+            .find(|(g, _)| g == "docker:myapp")
+            .expect("group exists");
+        assert_eq!(myapp.1.len(), 4, "exactly 4 tag entries, no digests");
+        for entry in &myapp.1 {
+            assert!(
+                !entry.name.starts_with("sha256:"),
+                "digest leaked: {}",
+                entry.name
+            );
+        }
+    }
+
+    /// With digests filtered, keep_last=3 on 4 tags correctly deletes 1 tag.
+    /// Before fix: 4 tags + 4 digests = 8 entries, keep_last=3 → 5 deleted
+    /// (only ceil(3/2) = 2 tags survived).
+    #[tokio::test]
+    async fn test_docker_keep_last_correct_with_digests() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        for (i, tag) in ["v1", "v2", "v3", "v4"].iter().enumerate() {
+            let manifest = serde_json::json!({"tag": tag, "i": i});
+            let body = serde_json::to_vec(&manifest).unwrap();
+            let digest = format!(
+                "sha256:{}",
+                hex::encode(sha2::Digest::finalize(sha2::Sha256::new_with_prefix(&body)))
+            );
+            storage
+                .put(&format!("docker/img/manifests/{}.json", tag), &body)
+                .await
+                .unwrap();
+            storage
+                .put(&format!("docker/img/manifests/{}.json", digest), &body)
+                .await
+                .unwrap();
+        }
+
+        let rules = vec![RetentionRule {
+            registry: "docker".to_string(),
+            name_glob: None,
+            keep_last: Some(3),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+
+        let result =
+            super::run_retention(&storage, &test_publish_locks(), None, &rules, true).await;
+        assert_eq!(
+            result.planned, 1,
+            "exactly 1 tag should be planned for deletion"
+        );
+    }
+
+    /// 4 tags pointing at the same manifest (1 shared digest) — keep_last=3
+    /// must still count 4 tags and delete 1, not be confused by the shared digest.
+    #[tokio::test]
+    async fn test_docker_tag_aliasing_keep_last() {
+        let dir = tempfile::tempdir().unwrap();
+        let storage = Storage::new_local(dir.path().join("data").to_str().unwrap());
+
+        let body = b"{\"shared\": true}";
+        let digest = format!(
+            "sha256:{}",
+            hex::encode(sha2::Digest::finalize(sha2::Sha256::new_with_prefix(body)))
+        );
+        // 4 tags all pointing at the same manifest
+        for tag in ["latest", "stable", "v1.0", "v0.9"] {
+            storage
+                .put(&format!("docker/lib/manifests/{}.json", tag), body)
+                .await
+                .unwrap();
+        }
+        // 1 shared digest file
+        storage
+            .put(&format!("docker/lib/manifests/{}.json", digest), body)
+            .await
+            .unwrap();
+
+        let groups = super::collect_docker_versions(&storage).await;
+        let lib = groups
+            .iter()
+            .find(|(g, _)| g == "docker:lib")
+            .expect("group exists");
+        assert_eq!(lib.1.len(), 4, "4 tags, 0 digests");
+
+        let rules = vec![RetentionRule {
+            registry: "docker".to_string(),
+            name_glob: None,
+            keep_last: Some(3),
+            older_than_days: None,
+            exclude_tags: vec![],
+        }];
+        let result =
+            super::run_retention(&storage, &test_publish_locks(), None, &rules, true).await;
+        assert_eq!(result.planned, 1, "1 of 4 tags deleted with keep_last=3");
     }
 
     // -- Integration tests with storage --


### PR DESCRIPTION
## Summary
Patch release assembling changes since v1.2.1:

- **fix(retention)**: exclude digest references from Docker `keep_last` budget (#932)
- **fix(pypi)**: resolve relative URLs from upstream mirror indexes (#877)
- **perf(maven)**: skip metadata rewrite when merged document is unchanged (#888)
- **docs(compat)**: clarify OIDC JWT is Bearer-only, not Basic password (#853)
- **ci**: add docs link-checker to catch dead links (#727)
- **docs(llms)**: correct binary size claim from < 27 MB to < 30 MB

Also closed #754 (already fixed — `!already_cached` guards in place).

## Polygon Verdict: PENDING (re-run needed after new fixes)

Previous polygon (before #932, #877) was GREEN 8/8.

## Test plan
- [x] `cargo fmt --check` PASS
- [x] `cargo clippy -- -D warnings` PASS
- [x] `cargo test` 1768/1768 PASS (was 1761, +7 new tests)
- [ ] Full 8-step polygon (re-run pending)
- [x] claims-verify PASS
- [x] coherence-check 0 errors