### PR TITLE
ci: fix lychee-action pin to v2.9.0

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,7 +29,7 @@ jobs:
           restore-keys: lychee-
 
       - name: Run lychee link checker
-        uses: lycheeverse/lychee-action@f613a0156d062e3ecbf2dfa68ab1abcbcae85654 # v2.4.1
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >-
             --cache


### PR DESCRIPTION
## Summary
- The SHA `f613a015` pinned as `v2.4.1` does not exist in `lycheeverse/lychee-action`
- Every CI run of the link-checker fails at action resolution
- Pin to `v2.9.0` (`e7477775`) which resolves correctly