### PR TITLE
docs(readme): point stars badge at the repo, not /stargazers

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Created and maintained by [Pavel Volkov](https://github.com/devitway)
 
 [![Docs](https://img.shields.io/badge/docs-getnora.dev-green?logo=gitbook)](https://getnora.dev)
 [![Telegram](https://img.shields.io/badge/Telegram-Community-blue?logo=telegram)](https://t.me/getnora)
-[![GitHub Stars](https://img.shields.io/github/stars/getnora-io/nora?style=flat&logo=github)](https://github.com/getnora-io/nora/stargazers)
+[![GitHub Stars](https://img.shields.io/github/stars/getnora-io/nora?style=flat&logo=github)](https://github.com/getnora-io/nora)
 
 ## Contributing
 


### PR DESCRIPTION
## What

One-line README fix: the GitHub-stars badge linked to `/stargazers`, which GitHub now serves as 404 to logged-out clients (try any repository's `/stargazers` while signed out — `rust-lang/rust` included). Point the badge at the repository instead.

## Why

The link is dead for anonymous visitors, and the docs link-checker added in #941 correctly rejects it — currently failing the `Check Markdown Links` job on every PR (e.g. #947).

## Checklist

- [x] Tests pass (`cargo test`) — docs-only change
- [x] No new clippy warnings — docs-only change
- [x] Updated CHANGELOG.md (if user-facing change) — not user-facing
- [ ] New registry? See CONTRIBUTING.md checklist