### PR TITLE
docs: point at Dozor for advisory-driven curation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -476,6 +476,9 @@ external tools (Grafana dashboards, git-based rule management).
   deploy them.
 - **Not a vulnerability scanner.** Curation blocks known-bad packages.
   For CVE scanning of your own artifacts, use Trivy, Grype, or similar.
+  NORA keeps no advisory database (ADR-2); to drive the blocklist from
+  advisory data, [Dozor](https://github.com/getnora-io/dozor) compiles the OSV
+  feed and a registry inventory into a blocklist file NORA reads as-is.
 - **Not a package builder.** NORA does not compile source code into
   packages. Use `cargo publish`, `npm publish`, `mvn deploy` to create
   artifacts, then push them to NORA.

--- a/README.md
+++ b/README.md
@@ -186,6 +186,14 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting.
 
 Full documentation: **https://getnora.dev**
 
+## Companion
+
+[**Dozor**](https://github.com/getnora-io/dozor) writes NORA's curation
+blocklist. It compiles the OSV advisory feed together with an inventory of what
+your registry actually holds into a `blocklist.json`, and NORA enforces it — no
+NORA configuration beyond `curation.blocklist_path`, and no changes to NORA
+itself. Separate binary, separate repository, MIT.
+
 ## Author
 
 Created and maintained by [Pavel Volkov](https://github.com/devitway)


### PR DESCRIPTION
Adds a pointer from NORA's docs to the companion that answers #923 without putting a vulnerability database inside the registry.

- `ARCHITECTURE.md` — the "Not a vulnerability scanner" non-goal now says where advisory-driven curation actually lives, and why NORA keeps no advisory DB (ADR-2).
- `README.md` — a short Companion section.

Deliberately claims only what exists today: Dozor covers npm. The parity claim it rests on is machine-checked on every push in that repo — the published NORA image is started against a generated blocklist, and a blocked tarball must return 403 carrying the advisory id.

Related: #923 (closed, not planned), #953 (O(1) blocklist lookup — the one change that does belong in NORA).

*(Supersedes #954, which I closed by accident while rebuilding the branch.)*