### PR TITLE
fix(retention): regenerate the npm packument after deleting versions

### DIFF
--- a/nora-registry/src/registry/mod.rs
+++ b/nora-registry/src/registry/mod.rs
@@ -10,7 +10,7 @@ pub mod docker_auth;
 pub(crate) mod gems;
 mod go;
 mod maven;
-mod npm;
+pub(crate) mod npm;
 pub(crate) mod nuget;
 pub(crate) mod pub_dart;
 mod pypi;

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -580,7 +580,7 @@ async fn handle_request(
             // A concurrent request may have rebuilt it while this one waited.
             let data = match state.storage.get(&key).await {
                 Ok(data) => Some(data),
-                Err(_) => match regenerate_packument(&state, &package_name).await {
+                Err(_) => match regenerate_packument(&state.storage, &package_name).await {
                     Ok(()) => state.storage.get(&key).await.ok(),
                     Err(()) => {
                         tracing::warn!(
@@ -1075,7 +1075,10 @@ async fn handle_publish(
     }
 
     // Regenerate the packument (metadata.json) by listing the immutable per-version keys.
-    if regenerate_packument(&state, &package_name).await.is_err() {
+    if regenerate_packument(&state.storage, &package_name)
+        .await
+        .is_err()
+    {
         tracing::error!(package = %package_name, "npm publish: failed to regenerate packument");
         return StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
@@ -1132,18 +1135,17 @@ async fn handle_publish(
 /// them all, so no version is permanently lost (the maven scan-regenerate guarantee, #39). Old
 /// embedded-packument packages are migrated to per-version keys by `migrate_embedded_packument`
 /// in the publish handler BEFORE the new version is written, so this stays a pure list-derive.
-async fn regenerate_packument(state: &AppState, package_name: &str) -> Result<(), ()> {
+pub(crate) async fn regenerate_packument(
+    storage: &crate::storage::Storage,
+    package_name: &str,
+) -> Result<(), ()> {
     let versions_prefix = format!("npm/{}/versions/", package_name);
-    let version_keys = state
-        .storage
-        .list(&versions_prefix)
-        .await
-        .unwrap_or_default();
+    let version_keys = storage.list(&versions_prefix).await.unwrap_or_default();
 
     // versions map, keyed by the filename (version) without the .json suffix.
     let mut versions = serde_json::Map::new();
     for key in &version_keys {
-        let Ok(data) = state.storage.get(key).await else {
+        let Ok(data) = storage.get(key).await else {
             continue;
         };
         let Ok(vd) = serde_json::from_slice::<serde_json::Value>(&data) else {
@@ -1157,8 +1159,8 @@ async fn regenerate_packument(state: &AppState, package_name: &str) -> Result<()
     // dist-tags from the pointer keys (+ derive `latest` if publish left it unset).
     let dt_prefix = format!("npm/{}/dist-tags/", package_name);
     let mut dist_tags = serde_json::Map::new();
-    for key in state.storage.list(&dt_prefix).await.unwrap_or_default() {
-        if let Ok(data) = state.storage.get(&key).await {
+    for key in storage.list(&dt_prefix).await.unwrap_or_default() {
+        if let Ok(data) = storage.get(&key).await {
             if let (Some(tag), Ok(ver)) = (key.rsplit('/').next(), String::from_utf8(data.to_vec()))
             {
                 dist_tags.insert(tag.to_string(), serde_json::Value::String(ver));
@@ -1172,11 +1174,7 @@ async fn regenerate_packument(state: &AppState, package_name: &str) -> Result<()
     }
 
     // Package-level fields + the assembled maps -> the packument.
-    let mut packument = match state
-        .storage
-        .get(&format!("npm/{}/pkg.json", package_name))
-        .await
-    {
+    let mut packument = match storage.get(&format!("npm/{}/pkg.json", package_name)).await {
         Ok(d) => serde_json::from_slice(&d).unwrap_or_else(|_| serde_json::json!({})),
         Err(_) => serde_json::json!({}),
     };
@@ -1192,8 +1190,7 @@ async fn regenerate_packument(state: &AppState, package_name: &str) -> Result<()
     obj.insert("versions".to_string(), serde_json::Value::Object(versions));
 
     let bytes = serde_json::to_vec(&packument).map_err(|_| ())?;
-    state
-        .storage
+    storage
         .put(&format!("npm/{}/metadata.json", package_name), &bytes)
         .await
         .map_err(|_| ())

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -571,11 +571,20 @@ async fn collect_npm_versions(storage: &Storage) -> Vec<(String, Vec<VersionEntr
         for key in tarball_keys {
             let filename = key.rsplit('/').next().unwrap_or("");
             let (modified, size) = aggregate_meta(storage, std::slice::from_ref(key)).await;
-            // Include associated .sha256
+            // A version is its whole key set, not just the payload: the
+            // `.sha256` sidecar and the per-version document describe the same
+            // artifact, and leaving either behind makes the registry advertise
+            // a version it can no longer serve (#961).
             let mut keys = vec![key.clone()];
             let hash_key = format!("{}.sha256", key);
             if storage.stat(&hash_key).await.is_some() {
                 keys.push(hash_key);
+            }
+            if let Some(version) = crate::curation::parse_npm_tarball_version(pkg, filename) {
+                let version_key = format!("npm/{}/versions/{}.json", pkg, version);
+                if storage.stat(&version_key).await.is_some() {
+                    keys.push(version_key);
+                }
             }
             entries.push(VersionEntry {
                 name: filename.to_string(),
@@ -803,6 +812,7 @@ pub async fn run_retention(
     let mut total_bytes = 0u64;
     // rpm/deb repos whose packages were deleted — their indexes must be
     // rebuilt (and re-signed) afterwards or they keep advertising ghosts.
+    let mut npm_regen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
     let mut regen: std::collections::BTreeSet<(&'static str, String)> =
         std::collections::BTreeSet::new();
 
@@ -822,6 +832,9 @@ pub async fn run_retention(
         total_planned += plans.len();
 
         if !dry_run {
+            if let Some(package) = group_name.strip_prefix("npm:") {
+                npm_regen.insert(package.to_string());
+            }
             if let Some(repo) = group_name
                 .strip_prefix("rpm:")
                 .map(|n| ("rpm", n))
@@ -869,6 +882,46 @@ pub async fn run_retention(
         }
 
         all_plans.push((group_name, plans));
+    }
+
+    // Regenerate the packument of every npm package retention touched, for the
+    // same reason the rpm/deb rebuild below exists: the index is derived, and
+    // leaving it describing deleted artifacts makes the registry promise
+    // versions it can no longer serve (#961). A dangling dist-tag pointer is
+    // dropped first, so the regenerated `latest` is derived from what survives
+    // rather than pointing at a retired version.
+    //
+    // Fail-open per package: a failed regeneration logs and the next publish or
+    // read heals it (a read rebuilds a *missing* packument, #956); the
+    // deletions themselves are already durable.
+    for package in &npm_regen {
+        let lock_key = format!("npm/{package}/metadata.json");
+        let lock = crate::acquire_publish_lock(publish_locks, &lock_key);
+        let _guard = lock.lock().await;
+
+        let dist_tags_prefix = format!("npm/{package}/dist-tags/");
+        for tag_key in storage.list(&dist_tags_prefix).await.unwrap_or_default() {
+            let Ok(data) = storage.get(&tag_key).await else {
+                continue;
+            };
+            let Ok(version) = String::from_utf8(data.to_vec()) else {
+                continue;
+            };
+            let version_key = format!("npm/{package}/versions/{}.json", version.trim());
+            if storage.stat(&version_key).await.is_none() && storage.delete(&tag_key).await.is_ok()
+            {
+                info!(package = %package, tag = %tag_key, version = %version.trim(),
+                    "retention: dropped dist-tag pointing at a retired version");
+            }
+        }
+
+        match crate::registry::npm::regenerate_packument(storage, package).await {
+            Ok(()) => {
+                info!(registry = "npm", package = %package, "retention: packument regenerated")
+            }
+            Err(()) => tracing::error!(registry = "npm", package = %package,
+                "retention: packument regeneration failed — the next publish or read heals it"),
+        }
     }
 
     // Rebuild + re-sign the indexes of every rpm/deb repo retention touched,
@@ -2104,6 +2157,204 @@ mod format_retention_tests {
     }
 
     /// `keep_last` counts per architecture: each `binary-{arch}/Packages` is
+    async fn publish_npm(ctx: &crate::test_helpers::TestContext, package: &str, version: &str) {
+        use base64::Engine;
+        let payload = serde_json::json!({
+            "name": package,
+            "versions": { version: { "name": package, "version": version, "dist": {} } },
+            "_attachments": {
+                format!("{package}-{version}.tgz"): {
+                    "data": base64::engine::general_purpose::STANDARD.encode(b"fake-tarball"),
+                }
+            }
+        });
+        let response = send(
+            &ctx.app,
+            Method::PUT,
+            &format!("/npm/{package}"),
+            axum::body::Body::from(serde_json::to_vec(&payload).unwrap()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CREATED, "publish {version}");
+    }
+
+    /// Versions present in the packument, from the registry's own answer.
+    async fn packument_versions(
+        ctx: &crate::test_helpers::TestContext,
+        package: &str,
+    ) -> Vec<String> {
+        let response = send(&ctx.app, Method::GET, &format!("/npm/{package}"), "").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&body_bytes(response).await).unwrap();
+        let mut versions: Vec<String> = json["versions"]
+            .as_object()
+            .map(|o| o.keys().cloned().collect())
+            .unwrap_or_default();
+        versions.sort();
+        versions
+    }
+
+    /// Versions whose tarball still exists in storage.
+    async fn stored_versions(storage: &Storage, package: &str) -> Vec<String> {
+        let mut versions: Vec<String> = storage
+            .list(&format!("npm/{package}/tarballs/"))
+            .await
+            .unwrap_or_default()
+            .iter()
+            .filter(|key| !key.ends_with(".sha256"))
+            .filter_map(|key| {
+                let filename = key.rsplit('/').next()?;
+                crate::curation::parse_npm_tarball_version(package, filename)
+            })
+            .collect();
+        versions.sort();
+        versions
+    }
+
+    /// #961: retention deleted the tarball and left the packument advertising
+    /// the version. The invariant is stated without naming which versions
+    /// survive, because that depends on mtime ordering — what must hold is that
+    /// the registry never promises an artifact it does not have.
+    #[tokio::test]
+    async fn test_npm_retention_packument_matches_storage() {
+        let ctx = create_test_context();
+        for version in ["1.0.1", "1.0.2", "1.0.3", "1.0.4"] {
+            publish_npm(&ctx, "rettest", version).await;
+        }
+        assert_eq!(packument_versions(&ctx, "rettest").await.len(), 4);
+
+        let rules = vec![rule("npm", None, Some(2), None)];
+        let result = run_retention(
+            &ctx.state.storage,
+            &ctx.state.publish_locks,
+            ctx.state.signer.as_deref(),
+            &rules,
+            false,
+        )
+        .await;
+        assert_eq!(result.planned, 2, "keep_last=2 of four versions");
+
+        let advertised = packument_versions(&ctx, "rettest").await;
+        let stored = stored_versions(&ctx.state.storage, "rettest").await;
+        assert_eq!(
+            advertised, stored,
+            "the packument must advertise exactly what storage can serve"
+        );
+        assert_eq!(advertised.len(), 2);
+
+        // The per-version documents go with their tarballs.
+        for version in &advertised {
+            assert!(
+                ctx.state
+                    .storage
+                    .get(&format!("npm/rettest/versions/{version}.json"))
+                    .await
+                    .is_ok(),
+                "surviving version {version} lost its document"
+            );
+        }
+        let retired: Vec<String> = ["1.0.1", "1.0.2", "1.0.3", "1.0.4"]
+            .iter()
+            .map(|v| v.to_string())
+            .filter(|v| !advertised.contains(v))
+            .collect();
+        for version in &retired {
+            assert!(
+                ctx.state
+                    .storage
+                    .get(&format!("npm/rettest/versions/{version}.json"))
+                    .await
+                    .is_err(),
+                "retired version {version} kept its document"
+            );
+        }
+    }
+
+    /// A dist-tag must never point at a version that retention removed.
+    #[tokio::test]
+    async fn test_npm_retention_drops_dangling_dist_tag() {
+        let ctx = create_test_context();
+        for version in ["1.0.1", "1.0.2", "1.0.3"] {
+            publish_npm(&ctx, "tagtest", version).await;
+        }
+        // Pin `latest` at the oldest version, which keep_last=1 will retire.
+        ctx.state
+            .storage
+            .put("npm/tagtest/dist-tags/latest", b"1.0.1")
+            .await
+            .unwrap();
+
+        let rules = vec![rule("npm", None, Some(1), None)];
+        run_retention(
+            &ctx.state.storage,
+            &ctx.state.publish_locks,
+            ctx.state.signer.as_deref(),
+            &rules,
+            false,
+        )
+        .await;
+
+        let advertised = packument_versions(&ctx, "tagtest").await;
+
+        // Compare the pointer against storage, not against the advertised list:
+        // on a stale packument the advertised list still contains the retired
+        // version, so that comparison would pass without the fix.
+        let stored = stored_versions(&ctx.state.storage, "tagtest").await;
+        if let Ok(pointer) = ctx.state.storage.get("npm/tagtest/dist-tags/latest").await {
+            let pointer = String::from_utf8(pointer.to_vec()).unwrap_or_default();
+            assert!(
+                stored.iter().any(|v| *v == pointer.trim()),
+                "dist-tags/latest points at {pointer:?}, whose artifact is gone; storage has {stored:?}"
+            );
+        }
+
+        let response = send(&ctx.app, Method::GET, "/npm/tagtest", "").await;
+        let json: serde_json::Value = serde_json::from_slice(&body_bytes(response).await).unwrap();
+        let latest = json["dist-tags"]["latest"].as_str().unwrap_or_default();
+        assert!(
+            advertised.iter().any(|v| v == latest),
+            "dist-tags.latest={latest} is not among the surviving versions {advertised:?}"
+        );
+    }
+
+    /// A package retention did not touch keeps its packument exactly as it was.
+    /// A guard against over-reach rather than a witness for the fix: it passes
+    /// with or without the regeneration, and would fail if it regenerated too
+    /// much.
+    #[tokio::test]
+    async fn test_npm_retention_leaves_untouched_package_alone() {
+        let ctx = create_test_context();
+        for version in ["1.0.1", "1.0.2", "1.0.3"] {
+            publish_npm(&ctx, "busy", version).await;
+        }
+        publish_npm(&ctx, "quiet", "2.0.0").await;
+        let before = ctx
+            .state
+            .storage
+            .get("npm/quiet/metadata.json")
+            .await
+            .unwrap();
+
+        let rules = vec![rule("npm", Some("busy"), Some(1), None)];
+        run_retention(
+            &ctx.state.storage,
+            &ctx.state.publish_locks,
+            ctx.state.signer.as_deref(),
+            &rules,
+            false,
+        )
+        .await;
+
+        let after = ctx
+            .state
+            .storage
+            .get("npm/quiet/metadata.json")
+            .await
+            .unwrap();
+        assert_eq!(before, after, "an untouched package must not be rewritten");
+        assert_eq!(packument_versions(&ctx, "quiet").await, vec!["2.0.0"]);
+    }
+
     /// an independent APT index, so two architectures of the same
     /// package/version/distribution must not share one `keep_last` budget —
     /// pooling them always evicts an arch once `keep_last < arch count`.


### PR DESCRIPTION
Closes #961.

## What

npm retention deleted a version's tarball and its `.sha256` sidecar and nothing else. The per-version document survived, and so did the packument entry — so the registry kept advertising versions it could no longer deliver.

`run_retention` already rebuilds derived indexes after deleting, but only for rpm and deb. npm never entered that set.

Two changes, both following what is already in that function:

- **A version is its whole key set.** `collect_npm_versions` now includes `npm/<pkg>/versions/<v>.json` alongside the tarball, the same way it already includes the `.sha256` sidecar.
- **The derived index is regenerated afterwards**, through the existing `regenerate_packument`, under the same publish lock, fail-open per package — the rationale the rpm/deb block already states in its comment. A dist-tag pointing at a retired version is dropped first, so the regenerated `latest` comes from what survives.

`regenerate_packument` now takes `&Storage` instead of `&AppState` — it only ever used storage, and retention has no `AppState`.

## On crash-safety, and what this deliberately does not add

A crash between the delete and the regenerate leaves the packument **stale, not torn**, and the next publish or read heals it — a read rebuilds a missing packument since #956.

No transaction log, no in-flight markers, no resume state machine. The packument is derived, so regenerating it *is* the transaction boundary. That is the cheaper answer available to a registry whose index is a projection of its objects rather than an authority of its own.

## Verified on a polygon

Five versions published through the real npm client, `keep_last = 2`, local storage:

| | `main` | this branch |
|---|---|---|
| keys deleted | 6 | **9** (the version documents go too) |
| packument | **5 versions** | **1.0.4, 1.0.5** — exactly what storage holds |
| `dist-tags.latest` | stale | 1.0.5 |
| `GET` retired tarball | 404 | 404 |
| `npm install pkg@1.0.1` | fails fetching an artifact the registry just advertised | `ETARGET — No matching version found` |

The last row is the point: the error a developer meets stops being a 404 on something the registry promised and becomes a plain "no such version".

## Tests

Three in `format_retention_tests`, flip-verified — with the regeneration disabled the first two go red, the third stays green because it is the over-reach guard, not a witness:

- `test_npm_retention_packument_matches_storage` — the packument advertises exactly the versions whose tarballs exist, and retired version documents are gone. Stated without naming which versions survive, since that depends on mtime ordering; the invariant is the agreement between index and storage.
- `test_npm_retention_drops_dangling_dist_tag` — a `latest` pinned at a version retention removes must not survive pointing there. Asserted against **storage**, not against the advertised list: on a stale packument the retired version is still advertised, so that comparison would pass without the fix.
- `test_npm_retention_leaves_untouched_package_alone` — a package retention did not touch keeps its packument byte-identical.

Full suite: 63 lib + 1795 bin + 6 doc, zero failures. `cargo fmt --check` and `cargo clippy -p nora-registry --all-targets -- -D warnings` clean.

## Provenance

Surfaced while validating #889 — his durable maintenance markers circle the same class of problem from the other side, in an architecture where the packument is authoritative. The defect and this fix are ours.