### PR TITLE
refactor(registry): type registry dispatch via RegistryType

### DIFF
--- a/nora-registry/src/config/mod.rs
+++ b/nora-registry/src/config/mod.rs
@@ -543,23 +543,43 @@ impl Config {
 
         // NuGet extra search/autocomplete URLs
         if let Some(host) = extract_host(&self.nuget.search_service) {
-            result.push(("nuget".to_string(), host));
+            result.push((
+                crate::registry_type::RegistryType::Nuget
+                    .as_str()
+                    .to_string(),
+                host,
+            ));
         }
         if let Some(host) = extract_host(&self.nuget.autocomplete) {
-            result.push(("nuget".to_string(), host));
+            result.push((
+                crate::registry_type::RegistryType::Nuget
+                    .as_str()
+                    .to_string(),
+                host,
+            ));
         }
 
         // Docker upstreams: Vec<DockerUpstream>
         for upstream in &self.docker.upstreams {
             if let Some(host) = extract_host(&upstream.url) {
-                result.push(("docker".to_string(), host));
+                result.push((
+                    crate::registry_type::RegistryType::Docker
+                        .as_str()
+                        .to_string(),
+                    host,
+                ));
             }
         }
 
         // Maven proxies: Vec<MavenProxyEntry>
         for proxy in &self.maven.proxies {
             if let Some(host) = extract_host(proxy.url()) {
-                result.push(("maven".to_string(), host));
+                result.push((
+                    crate::registry_type::RegistryType::Maven
+                        .as_str()
+                        .to_string(),
+                    host,
+                ));
             }
         }
 
@@ -578,7 +598,12 @@ impl Config {
         // mirror with embedded credentials) would be invisible to leak scanning.
         for up in self.pypi.upstreams() {
             if let Some(host) = extract_host(up.url()) {
-                result.push(("pypi".to_string(), host));
+                result.push((
+                    crate::registry_type::RegistryType::PyPI
+                        .as_str()
+                        .to_string(),
+                    host,
+                ));
             }
         }
 

--- a/nora-registry/src/metrics.rs
+++ b/nora-registry/src/metrics.rs
@@ -731,39 +731,23 @@ fn is_own_surface(path: &str) -> bool {
         || path == "/metrics"
 }
 
-/// Detect registry type from path
+/// Detect registry type from path, using [`RegistryType::mount_point`] as the single
+/// source of truth: matching the registry whose mount point prefixes the path (adding a
+/// format extends this automatically via `all()`, no new arm here). PyPI has a second
+/// prefix (`/packages`) beyond its mount point; `/ui` and anything else are non-registry.
 fn detect_registry(path: &str) -> String {
-    if path.starts_with("/v2") {
-        "docker".to_string()
-    } else if path.starts_with("/maven2") {
-        "maven".to_string()
-    } else if path.starts_with("/npm") {
-        "npm".to_string()
-    } else if path.starts_with("/cargo") {
-        "cargo".to_string()
-    } else if path.starts_with("/simple") || path.starts_with("/packages") {
-        "pypi".to_string()
-    } else if path.starts_with("/go/") {
-        "go".to_string()
-    } else if path.starts_with("/raw/") {
-        "raw".to_string()
-    } else if path.starts_with("/gems/") {
-        "gems".to_string()
-    } else if path.starts_with("/terraform/") {
-        "terraform".to_string()
-    } else if path.starts_with("/ansible/") {
-        "ansible".to_string()
-    } else if path.starts_with("/nuget/") {
-        "nuget".to_string()
-    } else if path.starts_with("/pub/") {
-        "pub".to_string()
-    } else if path.starts_with("/conan/") {
-        "conan".to_string()
-    } else if path.starts_with("/rpm/") {
-        "rpm".to_string()
-    } else if path.starts_with("/deb/") {
-        "deb".to_string()
-    } else if path.starts_with("/ui") {
+    use crate::registry_type::RegistryType;
+    if path.starts_with("/packages") {
+        return RegistryType::PyPI.as_str().to_string();
+    }
+    for rt in RegistryType::all() {
+        // Match on the full mount point (with trailing slash) so a bare or lookalike
+        // prefix (`/goblin`, `/rawdata`) does not match a registry — matching the original.
+        if path.starts_with(rt.mount_point()) {
+            return rt.as_str().to_string();
+        }
+    }
+    if path.starts_with("/ui") {
         "ui".to_string()
     } else {
         "other".to_string()

--- a/nora-registry/src/registry_type.rs
+++ b/nora-registry/src/registry_type.rs
@@ -6,103 +6,68 @@
 use serde::Serialize;
 use std::fmt;
 
-/// All supported registry formats.
-///
-/// This is the single source of truth for registry types. Other modules
-/// (curation, config, metrics, UI) reference this enum.
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize)]
-pub enum RegistryType {
-    Docker,
-    Maven,
-    Npm,
-    Cargo,
-    #[serde(rename = "pypi")]
-    PyPI,
-    Go,
-    Raw,
-    // New formats (v0.7):
-    #[serde(rename = "gems")]
-    Gems,
-    #[serde(rename = "terraform")]
-    Terraform,
-    #[serde(rename = "ansible")]
-    Ansible,
-    #[serde(rename = "nuget")]
-    Nuget,
-    #[serde(rename = "pub")]
-    PubDart,
-    #[serde(rename = "conan")]
-    Conan,
-    #[serde(rename = "rpm")]
-    Rpm,
-    #[serde(rename = "deb")]
-    Deb,
+/// Declares [`RegistryType`] and its intrinsic string forms from a SINGLE list, so that
+/// adding a format is one line and `all()` can never drift from the enum: the variant,
+/// its `as_str`, `mount_point` and `display_name` are generated together, and each
+/// per-variant method is an exhaustive `match` (a new variant is a compile error until
+/// handled). This is the single source of truth for registry formats (#369).
+macro_rules! registry_types {
+    ( $( $variant:ident => $as_str:literal, $mount:literal, $display:literal );+ $(;)? ) => {
+        /// All supported registry formats.
+        ///
+        /// This is the single source of truth for registry types. Other modules
+        /// (curation, config, metrics, UI) reference this enum. Declared via
+        /// [`registry_types!`], so the enum and [`RegistryType::all`] are generated
+        /// from one list and cannot desync.
+        #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize)]
+        pub enum RegistryType {
+            $( #[serde(rename = $as_str)] $variant ),+
+        }
+
+        impl RegistryType {
+            /// Lowercase string identifier used in storage keys, metrics, and config.
+            pub fn as_str(&self) -> &'static str {
+                match self { $( Self::$variant => $as_str ),+ }
+            }
+
+            /// URL mount point for this registry's routes.
+            pub fn mount_point(&self) -> &'static str {
+                match self { $( Self::$variant => $mount ),+ }
+            }
+
+            /// Display name for UI (capitalized).
+            pub fn display_name(&self) -> &'static str {
+                match self { $( Self::$variant => $display ),+ }
+            }
+
+            /// Every registry type, in declaration order. Generated from the same list
+            /// as the enum itself, so it can never silently omit a variant.
+            pub fn all() -> &'static [RegistryType] {
+                &[ $( Self::$variant ),+ ]
+            }
+        }
+    };
+}
+
+registry_types! {
+    Docker    => "docker",    "/v2/",        "Docker";
+    Maven     => "maven",     "/maven2/",    "Maven";
+    Npm       => "npm",       "/npm/",       "npm";
+    Cargo     => "cargo",     "/cargo/",     "Cargo";
+    PyPI      => "pypi",      "/simple/",    "PyPI";
+    Go        => "go",        "/go/",        "Go";
+    Raw       => "raw",       "/raw/",       "Raw";
+    Gems      => "gems",      "/gems/",      "RubyGems";
+    Terraform => "terraform", "/terraform/", "Terraform";
+    Ansible   => "ansible",   "/ansible/",   "Ansible";
+    Nuget     => "nuget",     "/nuget/",     "NuGet";
+    PubDart   => "pub",       "/pub/",       "Pub (Dart)";
+    Conan     => "conan",     "/conan/",     "Conan";
+    Rpm       => "rpm",       "/rpm/",       "RPM";
+    Deb       => "deb",       "/deb/",       "Debian";
 }
 
 impl RegistryType {
-    /// Lowercase string identifier used in storage keys, metrics, and config.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Self::Docker => "docker",
-            Self::Maven => "maven",
-            Self::Npm => "npm",
-            Self::Cargo => "cargo",
-            Self::PyPI => "pypi",
-            Self::Go => "go",
-            Self::Raw => "raw",
-            Self::Gems => "gems",
-            Self::Terraform => "terraform",
-            Self::Ansible => "ansible",
-            Self::Nuget => "nuget",
-            Self::PubDart => "pub",
-            Self::Conan => "conan",
-            Self::Rpm => "rpm",
-            Self::Deb => "deb",
-        }
-    }
-
-    /// URL mount point for this registry's routes.
-    pub fn mount_point(&self) -> &'static str {
-        match self {
-            Self::Docker => "/v2/",
-            Self::Maven => "/maven2/",
-            Self::Npm => "/npm/",
-            Self::Cargo => "/cargo/",
-            Self::PyPI => "/simple/",
-            Self::Go => "/go/",
-            Self::Raw => "/raw/",
-            Self::Gems => "/gems/",
-            Self::Terraform => "/terraform/",
-            Self::Ansible => "/ansible/",
-            Self::Nuget => "/nuget/",
-            Self::PubDart => "/pub/",
-            Self::Conan => "/conan/",
-            Self::Rpm => "/rpm/",
-            Self::Deb => "/deb/",
-        }
-    }
-
-    /// Display name for UI (capitalized).
-    pub fn display_name(&self) -> &'static str {
-        match self {
-            Self::Docker => "Docker",
-            Self::Maven => "Maven",
-            Self::Npm => "npm",
-            Self::Cargo => "Cargo",
-            Self::PyPI => "PyPI",
-            Self::Go => "Go",
-            Self::Raw => "Raw",
-            Self::Gems => "RubyGems",
-            Self::Terraform => "Terraform",
-            Self::Ansible => "Ansible",
-            Self::Nuget => "NuGet",
-            Self::PubDart => "Pub (Dart)",
-            Self::Conan => "Conan",
-            Self::Rpm => "RPM",
-            Self::Deb => "Debian",
-        }
-    }
-
     /// All registry types (original 7).
     pub fn all_v1() -> &'static [RegistryType] {
         &[
@@ -116,28 +81,9 @@ impl RegistryType {
         ]
     }
 
-    /// All registry types including new formats.
-    pub fn all() -> &'static [RegistryType] {
-        &[
-            Self::Docker,
-            Self::Maven,
-            Self::Npm,
-            Self::Cargo,
-            Self::PyPI,
-            Self::Go,
-            Self::Raw,
-            Self::Gems,
-            Self::Terraform,
-            Self::Ansible,
-            Self::Nuget,
-            Self::PubDart,
-            Self::Conan,
-            Self::Rpm,
-            Self::Deb,
-        ]
-    }
-
-    /// Parse from string (case-insensitive).
+    /// Parse from string (case-insensitive), accepting common aliases. Kept hand-written
+    /// because of the aliases; `test_as_str_roundtrip` guards that every variant's
+    /// canonical `as_str` parses back.
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "docker" => Some(Self::Docker),

--- a/nora-registry/src/retention.rs
+++ b/nora-registry/src/retention.rs
@@ -929,15 +929,21 @@ pub async fn run_retention(
     // repo: a failed rebuild logs loudly and the next publish/reindex heals
     // it; the deletions themselves are already durable.
     for (fmt, repo) in &regen {
-        let lock_key = match *fmt {
-            "rpm" => format!("rpm/{repo}/repodata/repomd.xml"),
-            _ => format!("deb/{repo}/Release"),
+        let is_rpm = matches!(
+            crate::registry_type::RegistryType::from_str_opt(fmt),
+            Some(crate::registry_type::RegistryType::Rpm)
+        );
+        let lock_key = if is_rpm {
+            format!("rpm/{repo}/repodata/repomd.xml")
+        } else {
+            format!("deb/{repo}/Release")
         };
         let lock = crate::acquire_publish_lock(publish_locks, &lock_key);
         let _guard = lock.lock().await;
-        let result = match *fmt {
-            "rpm" => crate::registry::rpm::regenerate_repodata(storage, signer, repo).await,
-            _ => crate::registry::deb::regenerate_indexes(storage, signer, repo).await,
+        let result = if is_rpm {
+            crate::registry::rpm::regenerate_repodata(storage, signer, repo).await
+        } else {
+            crate::registry::deb::regenerate_indexes(storage, signer, repo).await
         };
         if let Err(e) = result {
             tracing::error!(registry = %fmt, repo = %repo, error = %e, "retention: index regeneration failed — run -/reindex to heal");

--- a/nora-registry/src/ui/api.rs
+++ b/nora-registry/src/ui/api.rs
@@ -302,16 +302,16 @@ pub async fn api_detail(
     State(state): State<AppState>,
     Path((registry_type, name)): Path<(String, String)>,
 ) -> Json<serde_json::Value> {
-    match registry_type.as_str() {
-        "docker" => {
+    match RegistryType::from_str_opt(&registry_type) {
+        Some(RegistryType::Docker) => {
             let detail = get_docker_detail(&state, &name).await;
             Json(serde_json::to_value(detail).unwrap_or_default())
         }
-        "npm" => {
+        Some(RegistryType::Npm) => {
             let detail = get_npm_detail(&state.storage, &name, true, true).await;
             Json(serde_json::to_value(detail).unwrap_or_default())
         }
-        "cargo" => {
+        Some(RegistryType::Cargo) => {
             let detail = get_cargo_detail(&state.storage, &name, true, true).await;
             Json(serde_json::to_value(detail).unwrap_or_default())
         }
@@ -1089,14 +1089,24 @@ pub async fn get_generic_detail(
 ) -> PackageDetail {
     let name_lower = name.to_lowercase();
 
-    match registry {
-        "nuget" => get_nuget_detail(storage, &name_lower, show_prerelease, show_all).await,
-        "conan" => get_conan_detail(storage, &name_lower, show_prerelease, show_all).await,
-        "rpm" => get_rpm_detail(storage, name, show_all).await,
-        "deb" => get_deb_detail(storage, name, show_all).await,
-        "gems" => get_gems_detail(storage, &name_lower, show_prerelease, show_all).await,
-        "pub" => get_pub_detail(storage, &name_lower, show_prerelease, show_all).await,
-        "ansible" => get_ansible_detail(storage, &name_lower, show_prerelease, show_all).await,
+    match RegistryType::from_str_opt(registry) {
+        Some(RegistryType::Nuget) => {
+            get_nuget_detail(storage, &name_lower, show_prerelease, show_all).await
+        }
+        Some(RegistryType::Conan) => {
+            get_conan_detail(storage, &name_lower, show_prerelease, show_all).await
+        }
+        Some(RegistryType::Rpm) => get_rpm_detail(storage, name, show_all).await,
+        Some(RegistryType::Deb) => get_deb_detail(storage, name, show_all).await,
+        Some(RegistryType::Gems) => {
+            get_gems_detail(storage, &name_lower, show_prerelease, show_all).await
+        }
+        Some(RegistryType::PubDart) => {
+            get_pub_detail(storage, &name_lower, show_prerelease, show_all).await
+        }
+        Some(RegistryType::Ansible) => {
+            get_ansible_detail(storage, &name_lower, show_prerelease, show_all).await
+        }
         _ => {
             get_storage_scan_detail(storage, registry, &name_lower, show_prerelease, show_all).await
         }

--- a/nora-registry/src/ui/mod.rs
+++ b/nora-registry/src/ui/mod.rs
@@ -682,15 +682,15 @@ async fn generic_registry_list(
 
     // Extract registry type from URI path: /ui/{type}
     let registry_key = uri.path().strip_prefix("/ui/").unwrap_or("raw");
-    let title = match registry_key {
-        "gems" => "RubyGems",
-        "terraform" => "Terraform Registry",
-        "ansible" => "Ansible Galaxy",
-        "nuget" => "NuGet Gallery",
-        "pub" => "Pub (Dart/Flutter)",
-        "conan" => "Conan (C/C++)",
-        "rpm" => "RPM (yum/dnf)",
-        "deb" => "Debian (APT)",
+    let title = match crate::registry_type::RegistryType::from_str_opt(registry_key) {
+        Some(crate::registry_type::RegistryType::Gems) => "RubyGems",
+        Some(crate::registry_type::RegistryType::Terraform) => "Terraform Registry",
+        Some(crate::registry_type::RegistryType::Ansible) => "Ansible Galaxy",
+        Some(crate::registry_type::RegistryType::Nuget) => "NuGet Gallery",
+        Some(crate::registry_type::RegistryType::PubDart) => "Pub (Dart/Flutter)",
+        Some(crate::registry_type::RegistryType::Conan) => "Conan (C/C++)",
+        Some(crate::registry_type::RegistryType::Rpm) => "RPM (yum/dnf)",
+        Some(crate::registry_type::RegistryType::Deb) => "Debian (APT)",
         _ => registry_key,
     };
 


### PR DESCRIPTION
Registry format dispatch was scattered across config, retention, metrics, and the UI as string comparisons. This centralizes it on the `RegistryType` enum.

- `RegistryType` and its `as_str` / `mount_point` / `display_name` / `all()` are generated from a single list via a `registry_types!` macro: adding a format is one line, and `all()` can no longer drift from the enum. Each per-variant method is an exhaustive `match`, so a new variant is a compile error until every site handles it.
- String dispatch is replaced by `match RegistryType` / `RegistryType::X.as_str()` across config, retention, metrics, and the UI.

The `ui/templates` string sites are deferred to a follow-up PR.

No behavioral change: mount points, metric labels, and display names are unchanged.

Closes #369
