### PR TITLE
fix(lock-audit): keep the awk programs POSIX so the check cannot pass vacuously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 ## [Unreleased]
 
+### Fixed
+- **`lock-audit` no longer depends on gawk (#971 follow-up)** — Checks 1 and 3 used gawk's three-argument `match()`, which mawk rejects. mawk is the default `awk` on Debian, Ubuntu and the CI images, and an aborted awk prints nothing — so on any machine without gawk the audit reported no findings and looked clean. The awk programs are now POSIX, and `scripts/test-lock-audit.sh` runs the audit under every implementation it finds, asserting they agree *and* that each run still produced the known finding, so "both silent because both aborted" cannot pass.
+
 ### Changed
 - **Every storage round-trip is counted (#969 follow-up)** — `stat`, `pin`, `list` and `list_with_meta` reached the backend without touching `nora_storage_operations_total`, which is why a handler issuing one `stat()` per file (tens of thousands of HEAD requests on a single PyPI index response) moved no metric and could only be found by reading code. All four now increment it; on `stat`/`pin` an absent object or an unpinned one is `status="miss"`, so ordinary misses do not inflate error-rate alerting. Counters only — no behavioural change.
 

--- a/scripts/lock-audit.sh
+++ b/scripts/lock-audit.sh
@@ -9,6 +9,13 @@
 # 3. Known RMW patterns: index append, metadata merge
 set -uo pipefail
 
+# The awk programs below stay within POSIX awk. They used to rely on gawk's
+# three-argument `match()`, which mawk — the default `awk` on Debian, Ubuntu and the CI
+# images — rejects; an aborted awk prints nothing, and "no output" reads exactly like
+# "no findings", so the check would have passed vacuously wherever gawk was absent.
+# Verified against both gawk and mawk by scripts/test-lock-audit.sh.
+AWK="${AWK:-awk}"
+
 REGISTRY_DIR="${1:-nora-registry/src/registry}"
 FAIL_FILE=$(mktemp)
 echo 0 > "$FAIL_FILE"
@@ -29,10 +36,12 @@ for file in "$REGISTRY_DIR"/*.rs; do
     [ -f "$file" ] || continue
     base=$(basename "$file")
 
-    awk -v base="$base" '
+    "$AWK" -v base="$base" '
     /^async fn (update_|generate_|rebuild_).*/ {
         fname=$0; has_put=0; has_lock=0; has_doc=0; start=NR; depth=0
-        match(fname, /fn ([a-zA-Z_]+)/, m); fn_name=m[1]
+        fn_name = ""
+        if (match(fname, /fn [a-zA-Z_]+/))
+            fn_name = substr(fname, RSTART + 3, RLENGTH - 3)
     }
     fname!="" && /{/ { depth++ }
     fname!="" && /}/ { depth--
@@ -82,7 +91,7 @@ for file in "$REGISTRY_DIR"/*.rs; do
     [ -f "$file" ] || continue
     base=$(basename "$file")
 
-    awk -v base="$base" '
+    "$AWK" -v base="$base" '
     # Normalized condition of an `if` / `} else if` block opener; "" for anything else.
     function norm_cond(line,   c) {
         c = line
@@ -209,16 +218,24 @@ for file in "$REGISTRY_DIR"/*.rs; do
     base=$(basename "$file")
 
     # Find get+put pairs where data is modified between them
-    awk -v base="$base" '
+    "$AWK" -v base="$base" '
     /storage\.(get|list)\(&/ {
         read_line=NR
-        match($0, /storage\.(get|list)\(&([a-zA-Z_]+)/, m)
-        read_key=m[2]
+        read_key = ""
+        if (match($0, /storage\.(get|list)\(&[a-zA-Z_]+/)) {
+            frag = substr($0, RSTART, RLENGTH)
+            sub(/^.*\(&/, "", frag)
+            read_key = frag
+        }
     }
     read_key && /(extend_from_slice|push|insert|entry\(|\.put\()/ && NR > read_line && (NR - read_line < 30) {
         if (/storage\.put/) {
-            match($0, /storage\.put\(&([a-zA-Z_]+)/, m)
-            put_key=m[1]
+            put_key = ""
+            if (match($0, /storage\.put\(&[a-zA-Z_]+/)) {
+                frag = substr($0, RSTART, RLENGTH)
+                sub(/^.*\(&/, "", frag)
+                put_key = frag
+            }
             if (put_key == read_key || (read_key && put_key)) {
                 # Check if publish_lock exists between read and write
                 has_lock=0

--- a/scripts/test-lock-audit.sh
+++ b/scripts/test-lock-audit.sh
@@ -127,6 +127,35 @@ expect_silent   "annotated.rs" "a write with a LOCK-SAFE reason in its block is 
 expect_reported "annotated_no_reason.rs" "a bare LOCK-SAFE marker with no reason does not silence"
 expect_silent   "annotated_outer.rs" "a LOCK-SAFE reason one block out still covers the write"
 
+# The audit must behave the same on whatever awk the machine has: gawk here, mawk on
+# Debian, Ubuntu and the CI images. A gawk-only construct aborts under mawk, and an
+# aborted awk prints nothing — which reads exactly like a clean tree, so this compares
+# the findings AND checks each run actually produced one.
+IMPLS=""
+for impl in gawk mawk; do
+    command -v "$impl" >/dev/null 2>&1 || continue
+    AWK="$impl" bash "$AUDIT" "$TMP" > "$TMP/out.$impl" 2>&1
+    IMPLS="$IMPLS $impl"
+    if grep -q "positive.rs" "$TMP/out.$impl"; then
+        echo "  OK: $impl reports the known finding (the run was not a silent abort)"
+    else
+        echo "FAIL: $impl produced no finding for positive.rs — likely an aborted awk"
+        sed 's/^/      /' "$TMP/out.$impl" | head -5
+        FAILURES=$((FAILURES + 1))
+    fi
+done
+if [ -f "$TMP/out.gawk" ] && [ -f "$TMP/out.mawk" ]; then
+    if diff -q "$TMP/out.gawk" "$TMP/out.mawk" >/dev/null 2>&1; then
+        echo "  OK: gawk and mawk produce identical output"
+    else
+        echo "FAIL: gawk and mawk disagree"
+        diff "$TMP/out.gawk" "$TMP/out.mawk" | sed 's/^/      /' | head -10
+        FAILURES=$((FAILURES + 1))
+    fi
+else
+    echo "  OK: only[$IMPLS ] available, cross-implementation comparison skipped"
+fi
+
 echo ""
 if [ "$FAILURES" -eq 0 ]; then
     echo "lock-audit self-test PASSED"


### PR DESCRIPTION
Refs #971. Prerequisite for running the audit in CI, and a defect on its own.

## The problem

Checks 1 and 3 used gawk's three-argument `match()`:

```awk
match(fname, /fn ([a-zA-Z_]+)/, m); fn_name=m[1]
```

mawk rejects that form, and mawk is the default `awk` on Debian, Ubuntu and the GitHub
runner images — `gawk` is not in the documented tool list for `ubuntu-24.04`. An awk
that aborts prints nothing, and no output from this script reads exactly like "no
findings". So on any machine without gawk, `lock-audit` reported a clean tree without
having looked at it.

That is the same shape as the finding it exists to catch: something that looks green
because it never ran.

## The change

The three call sites use POSIX `match()` + `substr()`. Behaviour is unchanged — `gawk`
and `mawk` produce byte-identical output on this repository:

```
$ AWK=gawk bash scripts/lock-audit.sh > /tmp/g; AWK=mawk bash scripts/lock-audit.sh > /tmp/m
$ diff /tmp/g /tmp/m && echo identical
identical
```

Check 3 keeps producing nothing, exactly as before: its awk block computes and never
prints, which is why its gawk-ism never surfaced — its stderr also goes to `/dev/null`.
Making it report is a separate question, not this PR.

## The test

`scripts/test-lock-audit.sh` now runs the audit under every awk implementation present
and asserts two things:

```
  OK: gawk reports the known finding (the run was not a silent abort)
  OK: mawk reports the known finding (the run was not a silent abort)
  OK: gawk and mawk produce identical output
```

The per-implementation assertion is the load-bearing one. Comparing outputs alone would
pass happily if both aborted and both printed nothing.

## Follow-up

Adding the audit as a CI step. With this merged it is two lines and no `apt-get`;
without it, a CI step would have to install gawk or gate on a check that never looks.
