### PR TITLE
test: count storage round-trips on index endpoints

### DIFF
--- a/nora-registry/src/registry/cargo_registry.rs
+++ b/nora-registry/src/registry/cargo_registry.rs
@@ -2168,3 +2168,48 @@ mod integration_tests {
         assert_eq!(&body_bytes(resp).await[..], krate);
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod index_cost_tests {
+    //! Serving a sparse index file must cost the same storage round-trips for 1 and 100 versions.
+    use crate::test_helpers::{create_test_context_with_storage, op_counting_storage, send};
+    use axum::http::{Method, StatusCode};
+
+    async fn sparse_index_ops(n: usize) -> (usize, String) {
+        let (storage, ops) = op_counting_storage();
+        let ctx = create_test_context_with_storage(storage);
+        let mut lines = String::new();
+        for i in 0..n {
+            let version = format!("1.0.{i}");
+            let crate_key = format!("cargo/costcrate/{version}/costcrate-{version}.crate");
+            ctx.state.storage.put(&crate_key, b"CRATE").await.unwrap();
+            lines.push_str(&format!(
+                "{{\"name\":\"costcrate\",\"vers\":\"{version}\",\"deps\":[],\"cksum\":\"abc\",\"features\":{{}},\"yanked\":false}}\n"
+            ));
+        }
+        ctx.state
+            .storage
+            .put("cargo/index/co/st/costcrate", lines.as_bytes())
+            .await
+            .unwrap();
+        ops.reset();
+        let resp = send(&ctx.app, Method::GET, "/cargo/index/co/st/costcrate", "").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "sparse index with {n} versions"
+        );
+        (ops.total(), format!("{:?}", ops.snapshot()))
+    }
+
+    #[tokio::test]
+    async fn cargo_sparse_index_cost_is_independent_of_version_count() {
+        let (small, small_ops) = sparse_index_ops(1).await;
+        let (large, large_ops) = sparse_index_ops(100).await;
+        assert_eq!(
+            small, large,
+            "a hosted sparse index file must cost the same storage round-trips for 1 and 100 versions: {small_ops} vs {large_ops}"
+        );
+    }
+}

--- a/nora-registry/src/registry/docker.rs
+++ b/nora-registry/src/registry/docker.rs
@@ -5929,3 +5929,68 @@ mod integration_tests {
         assert_eq!(body.as_ref(), b"{\"legacy\":true}");
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod index_cost_tests {
+    //! Tag and catalog listings must cost the same storage round-trips for 1 and 100 entries.
+    use crate::test_helpers::{create_test_context_with_storage, op_counting_storage, send};
+    use axum::body::Body;
+    use axum::http::{Method, StatusCode};
+
+    async fn tags_list_ops(n: usize) -> (usize, String) {
+        let (storage, ops) = op_counting_storage();
+        let ctx = create_test_context_with_storage(storage);
+        for i in 0..n {
+            let key = format!("docker/costimg/manifests/tag-{i}.json");
+            ctx.state.storage.put(&key, b"{}").await.unwrap();
+        }
+        ops.reset();
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/v2/costimg/tags/list",
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::OK, "tags/list with {n} tags");
+        (ops.total(), format!("{:?}", ops.snapshot()))
+    }
+
+    async fn catalog_ops(n: usize) -> (usize, String) {
+        let (storage, ops) = op_counting_storage();
+        let ctx = create_test_context_with_storage(storage);
+        for i in 0..n {
+            let key = format!("docker/costrepo-{i}/manifests/latest.json");
+            ctx.state.storage.put(&key, b"{}").await.unwrap();
+        }
+        ops.reset();
+        let resp = send(&ctx.app, Method::GET, "/v2/_catalog", Body::empty()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "_catalog with {n} repositories"
+        );
+        (ops.total(), format!("{:?}", ops.snapshot()))
+    }
+
+    #[tokio::test]
+    async fn docker_tags_list_cost_is_independent_of_tag_count() {
+        let (small, small_ops) = tags_list_ops(1).await;
+        let (large, large_ops) = tags_list_ops(100).await;
+        assert_eq!(
+            small, large,
+            "tags/list must cost the same storage round-trips for 1 and 100 tags: {small_ops} vs {large_ops}"
+        );
+    }
+
+    #[tokio::test]
+    async fn docker_catalog_cost_is_independent_of_repository_count() {
+        let (small, small_ops) = catalog_ops(1).await;
+        let (large, large_ops) = catalog_ops(100).await;
+        assert_eq!(
+            small, large,
+            "_catalog must cost the same storage round-trips for 1 and 100 repositories: {small_ops} vs {large_ops}"
+        );
+    }
+}

--- a/nora-registry/src/registry/go.rs
+++ b/nora-registry/src/registry/go.rs
@@ -1082,3 +1082,57 @@ mod integration_tests {
         assert!(resp.headers().get("accept-ranges").is_none());
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod index_cost_tests {
+    //! Serving a cached @v/list must cost the same storage round-trips for 1 and 100 versions.
+    use crate::test_helpers::{create_test_context_with_storage, op_counting_storage, send};
+    use axum::http::{Method, StatusCode};
+
+    async fn version_list_ops(n: usize) -> (usize, String) {
+        let (storage, ops) = op_counting_storage();
+        let ctx = create_test_context_with_storage(storage);
+        let mut list = String::new();
+        for i in 0..n {
+            let version = format!("v1.0.{i}");
+            let base = format!("go/example.com/costmod/@v/{version}");
+            let info = format!("{{\"Version\":\"{version}\",\"Time\":\"2026-01-01T00:00:00Z\"}}");
+            ctx.state
+                .storage
+                .put(&format!("{base}.info"), info.as_bytes())
+                .await
+                .unwrap();
+            ctx.state
+                .storage
+                .put(&format!("{base}.mod"), b"module example.com/costmod\n")
+                .await
+                .unwrap();
+            ctx.state
+                .storage
+                .put(&format!("{base}.zip"), b"ZIP")
+                .await
+                .unwrap();
+            list.push_str(&format!("{version}\n"));
+        }
+        ctx.state
+            .storage
+            .put("go/example.com/costmod/@v/list", list.as_bytes())
+            .await
+            .unwrap();
+        ops.reset();
+        let resp = send(&ctx.app, Method::GET, "/go/example.com/costmod/@v/list", "").await;
+        assert_eq!(resp.status(), StatusCode::OK, "@v/list with {n} versions");
+        (ops.total(), format!("{:?}", ops.snapshot()))
+    }
+
+    #[tokio::test]
+    async fn go_version_list_cost_is_independent_of_version_count() {
+        let (small, small_ops) = version_list_ops(1).await;
+        let (large, large_ops) = version_list_ops(100).await;
+        assert_eq!(
+            small, large,
+            "a cached @v/list must cost the same storage round-trips for 1 and 100 versions: {small_ops} vs {large_ops}"
+        );
+    }
+}

--- a/nora-registry/src/registry/maven.rs
+++ b/nora-registry/src/registry/maven.rs
@@ -2510,3 +2510,61 @@ mod integration_tests {
         assert_eq!(body_bytes(resp).await.as_ref(), &xml[..]);
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod index_cost_tests {
+    //! Serving hosted maven-metadata.xml must cost the same storage round-trips for 1 and 100 versions.
+    use crate::test_helpers::{create_test_context_with_storage, op_counting_storage, send};
+    use axum::http::{Method, StatusCode};
+
+    async fn metadata_ops(n: usize) -> (usize, String) {
+        let (storage, ops) = op_counting_storage();
+        let ctx = create_test_context_with_storage(storage);
+        let mut versions = String::new();
+        for i in 0..n {
+            let version = format!("1.0.{i}");
+            let jar_key = format!("maven/com/example/costlib/{version}/costlib-{version}.jar");
+            ctx.state.storage.put(&jar_key, b"JAR").await.unwrap();
+            versions.push_str(&format!("<version>{version}</version>"));
+        }
+        let last = format!("1.0.{}", n - 1);
+        let xml = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?><metadata><groupId>com.example</groupId>\
+             <artifactId>costlib</artifactId><versioning><latest>{last}</latest>\
+             <release>{last}</release><versions>{versions}</versions></versioning></metadata>"
+        );
+        ctx.state
+            .storage
+            .put(
+                "maven/com/example/costlib/maven-metadata.xml",
+                xml.as_bytes(),
+            )
+            .await
+            .unwrap();
+        ops.reset();
+        let resp = send(
+            &ctx.app,
+            Method::GET,
+            "/maven2/com/example/costlib/maven-metadata.xml",
+            "",
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "maven-metadata.xml with {n} versions"
+        );
+        (ops.total(), format!("{:?}", ops.snapshot()))
+    }
+
+    #[tokio::test]
+    async fn maven_hosted_metadata_cost_is_independent_of_version_count() {
+        let (small, small_ops) = metadata_ops(1).await;
+        let (large, large_ops) = metadata_ops(100).await;
+        assert_eq!(
+            small, large,
+            "hosted maven-metadata.xml must cost the same storage round-trips for 1 and 100 versions: {small_ops} vs {large_ops}"
+        );
+    }
+}

--- a/nora-registry/src/registry/npm.rs
+++ b/nora-registry/src/registry/npm.rs
@@ -4083,3 +4083,57 @@ mod spec_conformance_tests {
         assert!(json["versions"]["1.0.0"].get("scripts").is_none());
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod index_cost_tests {
+    //! Serving a stored packument must cost the same storage round-trips for 1 and 100 versions.
+    use crate::test_helpers::{create_test_context_with_storage, op_counting_storage, send};
+    use axum::http::{Method, StatusCode};
+
+    async fn packument_ops(n: usize) -> (usize, String) {
+        let (storage, ops) = op_counting_storage();
+        let ctx = create_test_context_with_storage(storage);
+        let mut versions = serde_json::Map::new();
+        for i in 0..n {
+            let version = format!("1.0.{i}");
+            let tarball = format!("costpkg-{version}.tgz");
+            let tarball_key = format!("npm/costpkg/tarballs/{tarball}");
+            ctx.state.storage.put(&tarball_key, b"TGZ").await.unwrap();
+            let doc = serde_json::json!({
+                "name": "costpkg",
+                "version": version,
+                "dist": { "tarball": format!("http://localhost/npm/costpkg/-/{tarball}") }
+            });
+            let doc_key = format!("npm/costpkg/versions/{version}.json");
+            let doc_bytes = serde_json::to_vec(&doc).unwrap();
+            ctx.state.storage.put(&doc_key, &doc_bytes).await.unwrap();
+            versions.insert(version, doc);
+        }
+        let packument = serde_json::json!({
+            "name": "costpkg",
+            "dist-tags": { "latest": format!("1.0.{}", n - 1) },
+            "versions": versions
+        });
+        let packument_bytes = serde_json::to_vec(&packument).unwrap();
+        ctx.state
+            .storage
+            .put("npm/costpkg/metadata.json", &packument_bytes)
+            .await
+            .unwrap();
+        ops.reset();
+        let resp = send(&ctx.app, Method::GET, "/npm/costpkg", "").await;
+        assert_eq!(resp.status(), StatusCode::OK, "packument with {n} versions");
+        (ops.total(), format!("{:?}", ops.snapshot()))
+    }
+
+    #[tokio::test]
+    async fn npm_packument_cost_is_independent_of_version_count() {
+        let (small, small_ops) = packument_ops(1).await;
+        let (large, large_ops) = packument_ops(100).await;
+        assert_eq!(
+            small, large,
+            "a stored packument must cost the same storage round-trips for 1 and 100 versions: {small_ops} vs {large_ops}"
+        );
+    }
+}

--- a/nora-registry/src/registry/pypi.rs
+++ b/nora-registry/src/registry/pypi.rs
@@ -2392,99 +2392,11 @@ mod integration_tests {
     #[tokio::test]
     async fn pypi_simple_json_cost_is_independent_of_index_size() {
         use super::PEP691_JSON;
-        use crate::storage::{FileMeta, ObjectStorage, Storage, StorageBackend};
-        use crate::test_helpers::create_test_context_with_storage_and_config;
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        use std::sync::Arc;
+        use crate::test_helpers::{
+            create_test_context_with_storage_and_config, op_counting_storage,
+        };
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
-
-        /// Counts every backend round-trip, delegating to a real in-memory store.
-        struct OpCounting {
-            inner: ObjectStorage,
-            ops: Arc<AtomicUsize>,
-        }
-        macro_rules! count {
-            ($self:ident) => {
-                $self.ops.fetch_add(1, Ordering::SeqCst)
-            };
-        }
-
-        #[async_trait::async_trait]
-        impl StorageBackend for OpCounting {
-            async fn stat(&self, key: &str) -> Option<FileMeta> {
-                count!(self);
-                self.inner.stat(key).await
-            }
-            async fn put(&self, k: &str, d: &[u8], sha256: &str) -> crate::storage::Result<()> {
-                count!(self);
-                self.inner.put(k, d, sha256).await
-            }
-            async fn get(
-                &self,
-                k: &str,
-            ) -> crate::storage::Result<(axum::body::Bytes, Option<String>)> {
-                count!(self);
-                self.inner.get(k).await
-            }
-            async fn pin(&self, k: &str) -> Option<String> {
-                count!(self);
-                self.inner.pin(k).await
-            }
-            async fn delete(&self, k: &str) -> crate::storage::Result<()> {
-                count!(self);
-                self.inner.delete(k).await
-            }
-            async fn list(&self, prefix: &str) -> crate::storage::Result<Vec<String>> {
-                count!(self);
-                self.inner.list(prefix).await
-            }
-            async fn list_with_meta(
-                &self,
-                prefix: &str,
-            ) -> crate::storage::Result<Vec<(String, FileMeta)>> {
-                count!(self);
-                self.inner.list_with_meta(prefix).await
-            }
-            async fn health_check(&self) -> bool {
-                self.inner.health_check().await
-            }
-            async fn total_size(&self) -> u64 {
-                self.inner.total_size().await
-            }
-            fn backend_name(&self) -> &'static str {
-                "op-counting-test"
-            }
-            async fn put_from_path(
-                &self,
-                k: &str,
-                src: &std::path::Path,
-                sha256: Option<&str>,
-            ) -> crate::storage::Result<()> {
-                count!(self);
-                self.inner.put_from_path(k, src, sha256).await
-            }
-            async fn copy(
-                &self,
-                src: &str,
-                dst: &str,
-                sha256: Option<&str>,
-            ) -> crate::storage::Result<()> {
-                count!(self);
-                self.inner.copy(src, dst, sha256).await
-            }
-            async fn get_reader(
-                &self,
-                k: &str,
-            ) -> crate::storage::Result<(
-                u64,
-                Option<String>,
-                std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
-            )> {
-                count!(self);
-                self.inner.get_reader(k).await
-            }
-        }
 
         /// Serve an upstream index of `n` files and return the storage ops one JSON
         /// index request costs.
@@ -2502,15 +2414,11 @@ mod integration_tests {
                 .mount(&upstream)
                 .await;
 
-            let ops = Arc::new(AtomicUsize::new(0));
-            let storage = Storage::from_backend(Arc::new(OpCounting {
-                inner: ObjectStorage::in_memory(),
-                ops: Arc::clone(&ops),
-            }));
+            let (storage, ops) = op_counting_storage();
             let ctx = create_test_context_with_storage_and_config(storage, |cfg| {
                 cfg.pypi.proxy = Some(upstream.uri());
             });
-            ops.store(0, Ordering::SeqCst);
+            ops.reset();
             let response = send_with_headers(
                 &ctx.app,
                 Method::GET,
@@ -2524,7 +2432,7 @@ mod integration_tests {
                 StatusCode::OK,
                 "index of {n} files served"
             );
-            ops.load(Ordering::SeqCst)
+            ops.total()
         }
 
         let small = ops_for_index(1).await;

--- a/nora-registry/src/test_helpers.rs
+++ b/nora-registry/src/test_helpers.rs
@@ -17,6 +17,7 @@ use axum::{
 use http_body_util::BodyExt;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 use tempfile::TempDir;
@@ -479,4 +480,189 @@ pub async fn body_bytes(response: axum::http::Response<Body>) -> axum::body::Byt
         .await
         .expect("failed to read body")
         .to_bytes()
+}
+
+// ── Storage round-trip counting ─────────────────────────────────────────────
+
+/// Backend methods an [`OpCountingBackend`] counts, in reporting order.
+const COUNTED_METHODS: [&str; 11] = [
+    "put",
+    "get",
+    "pin",
+    "delete",
+    "list",
+    "stat",
+    "list_with_meta",
+    "put_from_path",
+    "copy",
+    "get_reader",
+    "get_range",
+];
+
+/// Per-method count of backend round-trips observed by an [`OpCountingBackend`].
+///
+/// The counters are atomics: backend methods run in async code, where a blocking
+/// lock does not belong.
+#[derive(Default)]
+pub struct OpCounts {
+    counts: [AtomicUsize; COUNTED_METHODS.len()],
+}
+
+impl OpCounts {
+    fn hit(&self, method: &'static str) {
+        let slot = COUNTED_METHODS
+            .iter()
+            .position(|counted| *counted == method)
+            .expect("every counted backend method is listed in COUNTED_METHODS");
+        self.counts[slot].fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Forget everything counted so far. Call it after seeding, right before the
+    /// request under test.
+    pub fn reset(&self) {
+        for count in &self.counts {
+            count.store(0, Ordering::Relaxed);
+        }
+    }
+
+    /// Round-trips counted since the last [`reset`](Self::reset).
+    pub fn total(&self) -> usize {
+        self.counts
+            .iter()
+            .map(|count| count.load(Ordering::Relaxed))
+            .sum()
+    }
+
+    /// Per-method counts since the last reset, leaving out methods that were not
+    /// called, for assertion messages.
+    pub fn snapshot(&self) -> std::collections::BTreeMap<&'static str, usize> {
+        COUNTED_METHODS
+            .iter()
+            .zip(&self.counts)
+            .map(|(method, count)| (*method, count.load(Ordering::Relaxed)))
+            .filter(|(_, calls)| *calls > 0)
+            .collect()
+    }
+}
+
+/// Storage backend that counts every round-trip and delegates to an in-memory
+/// object store.
+///
+/// Each counted call is one request on S3/GCS, so the count is what a handler
+/// costs against a real object store. `list_with_meta` and `get_range` forward to
+/// the object store's own implementations (one LIST, one ranged GET) rather than
+/// the trait defaults, so the counts match production.
+pub struct OpCountingBackend {
+    inner: crate::storage::ObjectStorage,
+    counts: Arc<OpCounts>,
+}
+
+/// An in-memory object-store [`Storage`] whose backend round-trips are counted.
+///
+/// Used by the index-cost tests: an index or metadata response must cost the same
+/// number of round-trips whether it lists 1 item or 100.
+pub fn op_counting_storage() -> (Storage, Arc<OpCounts>) {
+    let counts = Arc::new(OpCounts::default());
+    let backend = OpCountingBackend {
+        inner: crate::storage::ObjectStorage::in_memory(),
+        counts: Arc::clone(&counts),
+    };
+    (Storage::from_backend(Arc::new(backend)), counts)
+}
+
+#[async_trait::async_trait]
+impl crate::storage::StorageBackend for OpCountingBackend {
+    async fn put(&self, key: &str, data: &[u8], sha256: &str) -> crate::storage::Result<()> {
+        self.counts.hit("put");
+        self.inner.put(key, data, sha256).await
+    }
+
+    async fn get(&self, key: &str) -> crate::storage::Result<(axum::body::Bytes, Option<String>)> {
+        self.counts.hit("get");
+        self.inner.get(key).await
+    }
+
+    async fn pin(&self, key: &str) -> Option<String> {
+        self.counts.hit("pin");
+        self.inner.pin(key).await
+    }
+
+    async fn delete(&self, key: &str) -> crate::storage::Result<()> {
+        self.counts.hit("delete");
+        self.inner.delete(key).await
+    }
+
+    async fn list(&self, prefix: &str) -> crate::storage::Result<Vec<String>> {
+        self.counts.hit("list");
+        self.inner.list(prefix).await
+    }
+
+    async fn stat(&self, key: &str) -> Option<crate::storage::FileMeta> {
+        self.counts.hit("stat");
+        self.inner.stat(key).await
+    }
+
+    async fn list_with_meta(
+        &self,
+        prefix: &str,
+    ) -> crate::storage::Result<Vec<(String, crate::storage::FileMeta)>> {
+        self.counts.hit("list_with_meta");
+        self.inner.list_with_meta(prefix).await
+    }
+
+    async fn health_check(&self) -> bool {
+        self.inner.health_check().await
+    }
+
+    async fn total_size(&self) -> u64 {
+        self.inner.total_size().await
+    }
+
+    fn backend_name(&self) -> &'static str {
+        self.inner.backend_name()
+    }
+
+    async fn refresh_total_size(&self) {
+        self.inner.refresh_total_size().await
+    }
+
+    async fn put_from_path(
+        &self,
+        key: &str,
+        src: &std::path::Path,
+        sha256: Option<&str>,
+    ) -> crate::storage::Result<()> {
+        self.counts.hit("put_from_path");
+        self.inner.put_from_path(key, src, sha256).await
+    }
+
+    async fn copy(&self, src: &str, dst: &str, sha256: Option<&str>) -> crate::storage::Result<()> {
+        self.counts.hit("copy");
+        self.inner.copy(src, dst, sha256).await
+    }
+
+    async fn get_reader(
+        &self,
+        key: &str,
+    ) -> crate::storage::Result<(
+        u64,
+        Option<String>,
+        std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
+    )> {
+        self.counts.hit("get_reader");
+        self.inner.get_reader(key).await
+    }
+
+    async fn get_range(
+        &self,
+        key: &str,
+        start: u64,
+        end: u64,
+    ) -> crate::storage::Result<(
+        u64,
+        std::pin::Pin<Box<dyn tokio::io::AsyncRead + Send + Unpin>>,
+    )> {
+        self.counts.hit("get_range");
+        self.inner.get_range(key, start, end).await
+    }
 }


### PR DESCRIPTION
## What

Index and metadata responses should cost the same number of storage round-trips whether a package or repository has 1 entry or 100. On an object store every round-trip is a network request, and #969 was exactly this class of regression.

- `test_helpers`: `op_counting_storage()` — an in-memory object store whose backend calls are counted per method (`reset`, `total`, `snapshot`). `list_with_meta` and `get_range` forward to the object store's own implementations, so the counts match production. The counters are atomics, so counting adds no lock to async backend calls.
- The PyPI simple JSON test from #969 now uses this helper instead of its own counting backend.
- New cost tests, each seeding 1 and 100 entries with the artifacts themselves in storage and requiring equal round-trips: Docker `tags/list` and `_catalog`, the stored npm packument, hosted Maven `maven-metadata.xml`, the Cargo sparse index and Go `@v/list`.

## How it was checked

- The seven cost tests pass against the current handlers.
- `make check`: fmt, clippy with `-D warnings`, the full test suite.

Test-only change; no production code is touched.
